### PR TITLE
feat(ai-claude-review): switch to code-review plugin

### DIFF
--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -13,17 +13,23 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
 
       - uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
+          plugins: "code-review@claude-code-plugins"
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           prompt: |
-            Review this PR. Check code quality, bugs, performance, security.
-            Use CLAUDE.md for conventions. Post review via `gh pr comment`.
-          claude_args: '--allowed-tools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"'
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+            Run /code-review --comment


### PR DESCRIPTION
## Summary
- Migrate Claude Code review workflow to use the official `code-review` plugin from the claude-code marketplace
- Enable `pull-requests: write` permission for inline review comments
- Use `/code-review --comment` for structured, inline PR reviews

## Test plan
- [ ] Trigger workflow on a test PR to verify plugin loads correctly
- [ ] Verify inline comments are posted on changed lines
- [ ] Confirm permissions are sufficient for comment creation