### PR TITLE
fix(ci): allow compound BSD-3-Clause + Google patent license

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -479,4 +479,4 @@ jobs:
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: moderate
-          allow-licenses: Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MIT, LicenseRef-scancode-google-patent-license-golang
+          allow-licenses: Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MIT, LicenseRef-scancode-google-patent-license-golang, BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang


### PR DESCRIPTION
## Summary

- `golang.org/x/*` packages report compound SPDX expression `BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang`
- The individual licenses were already allowed but the compound `AND` expression was not matched
- Add the compound expression to `allow-licenses` in `ci-go.yml`

## Test plan

- [ ] Savvy PR #18 dependency review passes after tag update