### PR TITLE
refactor(renovate): migrate deprecated options and simplify presets

### DIFF
--- a/renovate-base.json
+++ b/renovate-base.json
@@ -4,16 +4,17 @@
   "extends": [
     "config:best-practices",
     ":dependencyDashboard",
-    ":semanticCommitTypeAll(chore)",
-    "group:allNonMajor",
-    "schedule:weekdays"
+    ":semanticCommitTypeAll(chore)"
   ],
-  "schedule": ["before 6am on Monday"],
+  "schedule": [
+    "before 6am on Monday"
+  ],
   "timezone": "Europe/Zurich",
-  "labels": ["dependencies"],
-  "assignees": ["sbaerlocher"],
-  "reviewersFromCodeOwners": true,
+  "labels": [
+    "dependencies"
+  ],
   "assigneesFromCodeOwners": true,
+  "reviewersFromCodeOwners": true,
   "prConcurrentLimit": 5,
   "prHourlyLimit": 0,
   "prCreation": "not-pending",
@@ -26,44 +27,60 @@
   "separateMajorMinor": true,
   "separateMultipleMajor": true,
   "rangeStrategy": "bump",
-  "stabilityDays": 3,
+  "minimumReleaseAge": "3 days",
+  "configMigration": true,
   "internalChecksFilter": "strict",
-  "postUpdateOptions": ["gomodTidy", "npmDedupe", "pnpmDedupe"],
+  "postUpdateOptions": [
+    "gomodTidy",
+    "npmDedupe",
+    "pnpmDedupe"
+  ],
   "commitMessageAction": "Update",
   "commitMessagePrefix": "chore(deps): ",
   "commitMessageTopic": "{{depName}}",
   "commitMessageExtra": "to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
-  "dependencyDashboard": true,
   "dependencyDashboardTitle": "Dependency Dashboard",
-  "dependencyDashboardLabels": ["dependencies", "renovate"],
+  "dependencyDashboardLabels": [
+    "dependencies",
+    "renovate"
+  ],
   "dependencyDashboardFooter": "Managed by Renovate Bot - [Documentation](https://docs.renovatebot.com/)",
   "packageRules": [
     {
-      "description": "Automerge non-major updates",
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "description": "Automerge all non-major updates",
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-non-major",
       "automerge": true
     },
     {
-      "description": "Group all patch updates",
-      "matchUpdateTypes": ["patch"],
-      "groupName": "all patch dependencies",
-      "groupSlug": "all-patch"
+      "description": "Major updates require manual review",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false,
+      "labels": [
+        "dependencies",
+        "major-update"
+      ],
+      "prPriority": 10,
+      "minimumReleaseAge": "7 days"
     },
     {
-      "description": "Group all minor updates",
-      "matchUpdateTypes": ["minor"],
-      "groupName": "all minor dependencies",
-      "groupSlug": "all-minor"
-    },
-    {
-      "description": "Automerge devDependencies",
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
+      "description": "Pre-release versions require manual review",
+      "matchCurrentVersion": "/^0\\./",
+      "automerge": false
     },
     {
       "description": "GitHub Actions - pin digests & automerge",
-      "matchManagers": ["github-actions"],
+      "matchManagers": [
+        "github-actions"
+      ],
       "groupName": "GitHub Actions",
       "pinDigests": true,
       "automerge": true,
@@ -71,36 +88,18 @@
       "semanticCommitScope": "actions"
     },
     {
-      "description": "Reusable workflows & Renovate presets - use date tags, no digest pinning",
-      "matchManagers": ["github-actions"],
-      "matchPackageNames": ["sbaerlocher/.github"],
+      "description": "sbaerlocher/.github - date tags, no digest pinning, immediate merge",
+      "matchPackageNames": [
+        "sbaerlocher/.github"
+      ],
+      "matchDepNames": [
+        "sbaerlocher/.github"
+      ],
       "pinDigests": false,
       "versioning": "regex:^(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})$",
       "allowedVersions": "/^\\d{4}-\\d{2}-\\d{2}$/",
       "minimumReleaseAge": "0 days",
-      "automerge": true,
-      "stabilityDays": 0
-    },
-    {
-      "description": "Major updates require manual approval",
-      "matchUpdateTypes": ["major"],
-      "automerge": false,
-      "dependencyDashboardApproval": true,
-      "labels": ["dependencies", "major-update"],
-      "prPriority": 10,
-      "stabilityDays": 7
-    },
-    {
-      "description": "Pre-release versions manual approval",
-      "matchCurrentVersion": "/^0\\./",
-      "automerge": false,
-      "dependencyDashboardApproval": true
-    },
-    {
-      "description": "Automerge sbaerlocher/.github Renovate preset updates",
-      "matchDepNames": ["sbaerlocher/.github"],
-      "automerge": true,
-      "stabilityDays": 0
+      "automerge": true
     }
   ],
   "lockFileMaintenance": {
@@ -108,9 +107,15 @@
   },
   "vulnerabilityAlerts": {
     "enabled": true,
-    "labels": ["dependencies", "security", "priority-high"],
+    "labels": [
+      "dependencies",
+      "security",
+      "priority-high"
+    ],
     "automerge": true,
-    "schedule": ["at any time"],
+    "schedule": [
+      "at any time"
+    ],
     "minimumReleaseAge": null,
     "semanticCommitType": "fix",
     "semanticCommitScope": "security"
@@ -119,7 +124,14 @@
     {
       "customType": "regex",
       "description": "Update versions in comments (renovate: datasource=... depName=...)",
-      "fileMatch": ["\\.ya?ml$", "\\.json$", "\\.toml$", "Makefile$", "\\.mk$", "Dockerfile$"],
+      "managerFilePatterns": [
+        "/\\.ya?ml$/",
+        "/\\.json$/",
+        "/\\.toml$/",
+        "/Makefile$/",
+        "/\\.mk$/",
+        "/Dockerfile$/"
+      ],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)(\\s+versioning=(?<versioning>[^\\s]+))?(\\s+extractVersion=(?<extractVersion>[^\\s]+))?\\s*\\n[^:]*:\\s*['\"]?(?<currentValue>[^'\"\\s]+)['\"]?"
       ],
@@ -128,7 +140,10 @@
     {
       "customType": "regex",
       "description": "Update _VERSION variables in Makefiles",
-      "fileMatch": ["^Makefile$", "\\.mk$"],
+      "managerFilePatterns": [
+        "/^Makefile$/",
+        "/\\.mk$/"
+      ],
       "matchStrings": [
         "(?<depName>[A-Z_]+)_VERSION\\s*[:?]?=\\s*(?<currentValue>[^\\s]+)"
       ],
@@ -138,7 +153,11 @@
     {
       "customType": "regex",
       "description": "Update pinned Renovate preset versions from sbaerlocher/.github",
-      "fileMatch": ["(^|/)renovate[^/]*\\.json$", "(^|/)\\.renovaterc\\.json$", "(^|/)\\.renovaterc$"],
+      "managerFilePatterns": [
+        "/(^|/)renovate[^/]*\\.json$/",
+        "/(^|/)\\.renovaterc\\.json$/",
+        "/(^|/)\\.renovaterc$/"
+      ],
       "matchStrings": [
         "github>sbaerlocher/\\.github[^\"]*#(?<currentValue>\\d{4}-\\d{2}-\\d{2})"
       ],

--- a/renovate-docker.json
+++ b/renovate-docker.json
@@ -9,75 +9,95 @@
   "packageRules": [
     {
       "description": "Docker base images in Dockerfiles",
-      "matchDatasources": ["docker"],
-      "matchFileNames": ["**/Dockerfile*"],
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchFileNames": [
+        "**/Dockerfile*"
+      ],
       "groupName": "Docker base images",
-      "pinDigests": true,
-      "separateMajorMinor": true,
       "semanticCommitType": "build",
       "semanticCommitScope": "docker"
     },
     {
       "description": "Docker Compose service images",
-      "matchDatasources": ["docker"],
-      "matchFileNames": ["**/docker-compose*.yml", "**/docker-compose*.yaml"],
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchFileNames": [
+        "**/docker-compose*.yml",
+        "**/docker-compose*.yaml"
+      ],
       "groupName": "Docker Compose images",
-      "pinDigests": true,
-      "automerge": true,
-      "matchUpdateTypes": ["minor", "patch"],
       "semanticCommitType": "build",
       "semanticCommitScope": "compose"
     },
     {
-      "description": "Base OS images - automerge minor/patch",
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["alpine", "debian", "ubuntu"],
-      "groupName": "Base OS images",
-      "automerge": true,
-      "matchUpdateTypes": ["minor", "patch"]
+      "description": "Base OS images",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "alpine",
+        "debian",
+        "ubuntu"
+      ],
+      "groupName": "Base OS images"
     },
     {
       "description": "Language runtime images - group by language",
-      "matchDatasources": ["docker"],
-      "matchPackagePatterns": ["^golang", "^node", "^python", "^ruby", "^php", "^openjdk", "^rust"],
+      "matchDatasources": [
+        "docker"
+      ],
       "groupName": "{{packageName}} runtime",
-      "automerge": true,
-      "matchUpdateTypes": ["minor", "patch"],
-      "stabilityDays": 3
+      "matchPackageNames": [
+        "/^golang/",
+        "/^node/",
+        "/^python/",
+        "/^ruby/",
+        "/^php/",
+        "/^openjdk/",
+        "/^rust/"
+      ]
     },
     {
-      "description": "Database images - group by database",
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["postgres", "postgresql", "mysql", "mariadb", "mongo", "redis", "elasticsearch"],
+      "description": "Database images - higher stability days",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "postgres",
+        "postgresql",
+        "mysql",
+        "mariadb",
+        "mongo",
+        "redis",
+        "elasticsearch"
+      ],
       "groupName": "{{packageName}} database",
-      "automerge": true,
-      "matchUpdateTypes": ["minor", "patch"],
-      "stabilityDays": 5
+      "minimumReleaseAge": "5 days"
     },
     {
       "description": "Web servers - group by server",
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["nginx", "httpd", "caddy", "traefik"],
-      "groupName": "{{packageName}} web server",
-      "automerge": true,
-      "matchUpdateTypes": ["minor", "patch"]
-    },
-    {
-      "description": "Major updates for all Docker images - require approval",
-      "matchDatasources": ["docker"],
-      "matchUpdateTypes": ["major"],
-      "schedule": ["before 6am on monday"],
-      "automerge": false,
-      "dependencyDashboardApproval": true,
-      "stabilityDays": 7,
-      "labels": ["dependencies", "major-update"]
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "nginx",
+        "httpd",
+        "caddy",
+        "traefik"
+      ],
+      "groupName": "{{packageName}} web server"
     }
   ],
   "customManagers": [
     {
       "customType": "regex",
       "description": "Update Docker images in GitHub Actions workflows",
-      "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
+      "managerFilePatterns": [
+        "/\\.github/workflows/.*\\.ya?ml$/"
+      ],
       "matchStrings": [
         "image:\\s*(?<depName>[^:@\\s]+)(?::(?<currentValue>[^@\\s]+))?(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
       ],

--- a/renovate-go.json
+++ b/renovate-go.json
@@ -2,145 +2,199 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Go Renovate configuration for Go modules, tools, and dependencies",
   "extends": [
-    "github>sbaerlocher/.github:renovate-base#main",
-    ":semanticCommitTypeAll(chore)"
+    "github>sbaerlocher/.github:renovate-base#main"
   ],
-  "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodUpdateImportPaths"
+  ],
   "packageRules": [
     {
-      "description": "Go version updates - manual review",
-      "matchManagers": ["gomod"],
-      "matchDepTypes": ["golang"],
+      "description": "Go version updates - higher stability",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepTypes": [
+        "golang"
+      ],
       "groupName": "Go version",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "go",
-      "stabilityDays": 14,
+      "minimumReleaseAge": "14 days",
       "automerge": false,
-      "dependencyDashboardApproval": true,
-      "labels": ["go", "golang-version"],
+      "labels": [
+        "go",
+        "golang-version"
+      ],
       "prPriority": 20
     },
     {
       "description": "Group golang.org/x packages",
-      "matchManagers": ["gomod"],
-      "matchPackagePrefixes": ["golang.org/x/"],
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "golang.org/x/**"
+      ],
       "groupName": "golang.org/x packages",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "stabilityDays": 3
+      "semanticCommitScope": "deps"
     },
     {
       "description": "Group google.golang.org packages",
-      "matchManagers": ["gomod"],
-      "matchPackagePrefixes": ["google.golang.org/"],
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "google.golang.org/**"
+      ],
       "groupName": "google.golang.org packages",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "stabilityDays": 3
+      "semanticCommitScope": "deps"
     },
     {
       "description": "Group go.uber.org packages",
-      "matchManagers": ["gomod"],
-      "matchPackagePrefixes": ["go.uber.org/"],
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "go.uber.org/**"
+      ],
       "groupName": "go.uber.org packages",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "deps"
     },
     {
       "description": "Group gRPC related packages",
-      "matchManagers": ["gomod"],
-      "matchPackagePrefixes": ["google.golang.org/grpc", "github.com/grpc-ecosystem/"],
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "google.golang.org/grpc**",
+        "github.com/grpc-ecosystem/**"
+      ],
       "groupName": "gRPC packages",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "grpc",
-      "stabilityDays": 5
+      "minimumReleaseAge": "5 days"
     },
     {
       "description": "Group Kubernetes packages",
-      "matchManagers": ["gomod"],
-      "matchPackagePrefixes": ["k8s.io/", "sigs.k8s.io/"],
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "k8s.io/**",
+        "sigs.k8s.io/**"
+      ],
       "groupName": "Kubernetes packages",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "k8s",
-      "stabilityDays": 7,
-      "labels": ["kubernetes"]
+      "minimumReleaseAge": "7 days",
+      "labels": [
+        "kubernetes"
+      ]
     },
     {
       "description": "Group Prometheus packages",
-      "matchManagers": ["gomod"],
-      "matchPackagePrefixes": ["github.com/prometheus/"],
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "github.com/prometheus/**"
+      ],
       "groupName": "Prometheus packages",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "prometheus"
     },
     {
       "description": "Group testing packages",
-      "matchManagers": ["gomod"],
-      "matchPackagePatterns": ["testify", "gomock", "mockery", "ginkgo", "gomega"],
+      "matchManagers": [
+        "gomod"
+      ],
       "groupName": "Go testing packages",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "test",
-      "automerge": true
+      "matchPackageNames": [
+        "/testify/",
+        "/gomock/",
+        "/mockery/",
+        "/ginkgo/",
+        "/gomega/"
+      ]
     },
     {
       "description": "Group linting and formatting tools",
-      "matchManagers": ["gomod"],
-      "matchPackagePatterns": ["golangci-lint", "gofumpt", "goimports", "staticcheck"],
+      "matchManagers": [
+        "gomod"
+      ],
       "groupName": "Go linting tools",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "lint",
-      "automerge": true
+      "matchPackageNames": [
+        "/golangci-lint/",
+        "/gofumpt/",
+        "/goimports/",
+        "/staticcheck/"
+      ]
     },
     {
       "description": "Development tools",
-      "matchManagers": ["gomod"],
-      "matchPackagePatterns": ["air", "wire", "mockgen", "protoc-gen", "buf", "goreleaser"],
+      "matchManagers": [
+        "gomod"
+      ],
       "groupName": "Go development tools",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "tools",
-      "automerge": true,
-      "labels": ["dev-tools"]
+      "labels": [
+        "dev-tools"
+      ],
+      "matchPackageNames": [
+        "/air/",
+        "/wire/",
+        "/mockgen/",
+        "/protoc-gen/",
+        "/buf/",
+        "/goreleaser/"
+      ]
     },
     {
       "description": "Indirect dependencies - lower priority",
-      "matchManagers": ["gomod"],
-      "matchDepTypes": ["indirect"],
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepTypes": [
+        "indirect"
+      ],
       "groupName": "Go indirect dependencies",
       "prPriority": -5,
-      "stabilityDays": 5
-    },
-    {
-      "description": "Major Go module updates - manual review",
-      "matchManagers": ["gomod"],
-      "matchUpdateTypes": ["major"],
-      "excludePackagePrefixes": ["golang.org/x/"],
-      "dependencyDashboardApproval": true,
-      "automerge": false,
-      "stabilityDays": 14,
-      "labels": ["go", "major-update"]
+      "minimumReleaseAge": "5 days"
     },
     {
       "description": "Major golang.org/x updates - auto-approve (pseudo-versioned)",
-      "matchManagers": ["gomod"],
-      "matchPackagePrefixes": ["golang.org/x/"],
-      "matchUpdateTypes": ["major"],
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "golang.org/x/**"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
       "automerge": true,
-      "stabilityDays": 5
+      "minimumReleaseAge": "5 days"
     }
   ],
   "customManagers": [
     {
       "customType": "regex",
       "description": "Go version in .go-version files",
-      "fileMatch": ["(^|/)\\.go-version$"],
-      "matchStrings": ["^(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)$"],
+      "managerFilePatterns": [
+        "/(^|/)\\.go-version$/"
+      ],
+      "matchStrings": [
+        "^(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)$"
+      ],
       "datasourceTemplate": "golang-version",
       "depNameTemplate": "go"
     },
     {
       "customType": "regex",
       "description": "Go version in Makefiles",
-      "fileMatch": ["^Makefile$", "\\.mk$"],
+      "managerFilePatterns": [
+        "/^Makefile$/",
+        "/\\.mk$/"
+      ],
       "matchStrings": [
         "GO_VERSION\\s*[:?]?=\\s*(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)"
       ],
@@ -150,7 +204,10 @@
     {
       "customType": "regex",
       "description": "Go tools in Makefiles",
-      "fileMatch": ["^Makefile$", "\\.mk$"],
+      "managerFilePatterns": [
+        "/^Makefile$/",
+        "/\\.mk$/"
+      ],
       "matchStrings": [
         "GOLANGCI_LINT_VERSION\\s*[:?]?=\\s*v?(?<currentValue>[^\\s]+)"
       ],
@@ -161,7 +218,10 @@
     {
       "customType": "regex",
       "description": "Go tools versions in comments",
-      "fileMatch": ["\\.ya?ml$", "Dockerfile$"],
+      "managerFilePatterns": [
+        "/\\.ya?ml$/",
+        "/Dockerfile$/"
+      ],
       "matchStrings": [
         "#\\s*renovate:\\s*go-tool\\s+(?<depName>[^\\s]+)\\s+(?<currentValue>[^\\s]+)"
       ],

--- a/renovate-js.json
+++ b/renovate-js.json
@@ -3,113 +3,148 @@
   "description": "JavaScript/TypeScript Renovate configuration for Node.js, pnpm, Astro, Vue, Cloudflare Workers",
   "extends": [
     "github>sbaerlocher/.github:renovate-base#main",
-    ":enableVulnerabilityAlertsWithLabel(security)",
     ":preserveSemverRanges"
   ],
-  "enabledManagers": ["npm", "nvm", "github-actions"],
-  "rangeStrategy": "bump",
+  "enabledManagers": [
+    "npm",
+    "nvm",
+    "github-actions"
+  ],
   "packageRules": [
     {
-      "description": "Node.js version updates",
-      "matchManagers": ["nvm"],
-      "matchPackageNames": ["node"],
+      "description": "Node.js version updates - higher stability",
+      "matchManagers": [
+        "nvm"
+      ],
+      "matchPackageNames": [
+        "node"
+      ],
       "groupName": "Node.js",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "node",
-      "stabilityDays": 14,
+      "minimumReleaseAge": "14 days",
       "automerge": false,
-      "dependencyDashboardApproval": true,
-      "labels": ["nodejs"]
+      "labels": [
+        "nodejs"
+      ]
     },
     {
       "description": "TypeScript - manual review for breaking changes",
-      "matchPackageNames": ["typescript"],
+      "matchPackageNames": [
+        "typescript"
+      ],
       "groupName": "TypeScript",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "typescript",
       "automerge": false,
-      "dependencyDashboardApproval": true,
-      "labels": ["typescript"],
-      "stabilityDays": 7
+      "minimumReleaseAge": "7 days",
+      "labels": [
+        "typescript"
+      ]
     },
     {
       "description": "Group ESLint packages",
-      "matchPackagePatterns": ["^eslint", "^@eslint/", "^eslint-"],
       "groupName": "ESLint packages",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "lint"
+      "semanticCommitScope": "lint",
+      "matchPackageNames": [
+        "/^eslint/",
+        "/^@eslint//",
+        "/^eslint-/"
+      ]
     },
     {
       "description": "Group Prettier packages",
-      "matchPackagePatterns": ["^prettier", "^@prettier/"],
       "groupName": "Prettier packages",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "format"
+      "semanticCommitScope": "format",
+      "matchPackageNames": [
+        "/^prettier/",
+        "/^@prettier//"
+      ]
     },
     {
       "description": "Group Vitest packages",
-      "matchPackagePatterns": ["^vitest", "^@vitest/"],
       "groupName": "Vitest packages",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "test"
+      "semanticCommitScope": "test",
+      "matchPackageNames": [
+        "/^vitest/",
+        "/^@vitest//"
+      ]
     },
     {
       "description": "Group Jest packages",
-      "matchPackagePatterns": ["^jest", "^@jest/", "^@types/jest"],
       "groupName": "Jest packages",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "test"
+      "semanticCommitScope": "test",
+      "matchPackageNames": [
+        "/^jest/",
+        "/^@jest//",
+        "/^@types/jest/"
+      ]
     },
     {
       "description": "Group Vite packages",
-      "matchPackagePatterns": ["^vite", "^@vitejs/"],
       "groupName": "Vite packages",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "build"
+      "semanticCommitScope": "build",
+      "matchPackageNames": [
+        "/^vite/",
+        "/^@vitejs//"
+      ]
     },
     {
       "description": "Group Astro packages",
-      "matchPackagePatterns": ["^astro", "^@astrojs/"],
       "groupName": "Astro packages",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "astro",
-      "stabilityDays": 5,
-      "labels": ["astro"]
+      "minimumReleaseAge": "5 days",
+      "labels": [
+        "astro"
+      ],
+      "matchPackageNames": [
+        "/^astro/",
+        "/^@astrojs//"
+      ]
     },
     {
       "description": "Group Vue packages",
-      "matchPackagePatterns": ["^vue", "^@vue/"],
       "groupName": "Vue packages",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "vue",
-      "stabilityDays": 5,
-      "labels": ["vue"]
+      "minimumReleaseAge": "5 days",
+      "labels": [
+        "vue"
+      ],
+      "matchPackageNames": [
+        "/^vue/",
+        "/^@vue//"
+      ]
     },
     {
       "description": "Group Cloudflare Workers packages",
-      "matchPackagePatterns": ["^@cloudflare/", "^wrangler"],
       "groupName": "Cloudflare Workers packages",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "workers",
-      "labels": ["cloudflare"]
+      "labels": [
+        "cloudflare"
+      ],
+      "matchPackageNames": [
+        "/^@cloudflare//",
+        "/^wrangler/"
+      ]
     },
     {
       "description": "Group pnpm package manager",
-      "matchManagers": ["npm"],
-      "matchPackageNames": ["pnpm"],
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "pnpm"
+      ],
       "groupName": "pnpm",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "pnpm",
       "automerge": false,
-      "stabilityDays": 7
+      "minimumReleaseAge": "7 days"
     },
     {
-      "description": "Group @types packages with their corresponding packages",
-      "matchPackagePatterns": ["^@types/"],
+      "description": "Group @types packages",
       "groupName": "TypeScript definitions",
-      "automerge": true,
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "types"
+      "semanticCommitScope": "types",
+      "matchPackageNames": [
+        "/^@types//"
+      ]
     },
     {
       "description": "Workspace protocol - internal dependencies",
@@ -117,35 +152,44 @@
       "enabled": false
     },
     {
-      "description": "Major framework updates - extra caution",
-      "matchPackagePatterns": ["^astro", "^vue", "^@astrojs/", "^@vue/"],
-      "matchUpdateTypes": ["major"],
-      "dependencyDashboardApproval": true,
-      "automerge": false,
-      "stabilityDays": 14,
-      "labels": ["framework", "major-update"]
+      "description": "Major framework updates - extra stability",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "minimumReleaseAge": "14 days",
+      "labels": [
+        "framework",
+        "major-update"
+      ],
+      "matchPackageNames": [
+        "/^astro/",
+        "/^vue/",
+        "/^@astrojs//",
+        "/^@vue//"
+      ]
     },
     {
-      "description": "Build tooling major updates - manual review",
-      "matchPackagePatterns": ["^vite", "^@vitejs/", "^webpack", "^rollup"],
-      "matchUpdateTypes": ["major"],
-      "dependencyDashboardApproval": true,
-      "automerge": false,
-      "stabilityDays": 10
-    },
-    {
-      "description": "Auto-merge devDependencies patches and minors",
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "excludePackageNames": ["typescript", "astro", "vue"],
-      "automerge": true
+      "description": "Major build tooling updates - extra stability",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "minimumReleaseAge": "10 days",
+      "matchPackageNames": [
+        "/^vite/",
+        "/^@vitejs//",
+        "/^webpack/",
+        "/^rollup/"
+      ]
     },
     {
       "description": "Production dependencies - extra stability",
-      "matchDepTypes": ["dependencies"],
-      "stabilityDays": 5,
-      "labels": ["production"]
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "minimumReleaseAge": "5 days",
+      "labels": [
+        "production"
+      ]
     }
-  ],
-  "postUpdateOptions": ["npmDedupe", "pnpmDedupe"]
+  ]
 }

--- a/renovate-kubernetes.json
+++ b/renovate-kubernetes.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "GitOps Renovate configuration for Fleet, Helm, Kubernetes and Kustomize",
-  "extends": ["github>sbaerlocher/.github:renovate-base#main"],
+  "extends": [
+    "github>sbaerlocher/.github:renovate-base#main"
+  ],
   "enabledManagers": [
     "kubernetes",
     "helm-values",
@@ -11,58 +13,58 @@
     "github-actions"
   ],
   "kubernetes": {
-    "fileMatch": [
-      "\\.ya?ml$",
-      "^kustomization\\.ya?ml$"
+    "managerFilePatterns": [
+      "/\\.ya?ml$/",
+      "/^kustomization\\.ya?ml$/"
     ]
   },
   "helm-values": {
-    "fileMatch": [
-      "values\\.ya?ml$",
-      "values-.+\\.ya?ml$"
+    "managerFilePatterns": [
+      "/values\\.ya?ml$/",
+      "/values-.+\\.ya?ml$/"
     ]
   },
   "packageRules": [
     {
       "description": "Group Helm chart updates",
-      "matchManagers": ["helm-values", "helmfile"],
-      "matchDatasources": ["helm"],
+      "matchManagers": [
+        "helm-values",
+        "helmfile"
+      ],
+      "matchDatasources": [
+        "helm"
+      ],
       "groupName": "Helm charts",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "helm",
-      "stabilityDays": 5,
+      "minimumReleaseAge": "5 days",
       "prPriority": 5
     },
     {
       "description": "Container images - pin digests for production",
-      "matchManagers": ["kubernetes"],
-      "matchDatasources": ["docker"],
+      "matchManagers": [
+        "kubernetes"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
       "pinDigests": true,
-      "semanticCommitType": "chore",
       "semanticCommitScope": "images",
-      "versioning": "docker",
-      "stabilityDays": 3
+      "versioning": "docker"
     },
     {
       "description": "Kustomize base updates",
-      "matchManagers": ["kustomize"],
+      "matchManagers": [
+        "kustomize"
+      ],
       "groupName": "Kustomize bases",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "kustomize"
     },
     {
-      "description": "Major Helm chart updates - manual approval",
-      "matchManagers": ["helm-values", "helmfile"],
-      "matchDatasources": ["helm"],
-      "matchUpdateTypes": ["major"],
-      "dependencyDashboardApproval": true,
-      "automerge": false,
-      "stabilityDays": 7,
-      "labels": ["helm", "major-update"]
-    },
-    {
       "description": "Critical platform charts - extra stability",
-      "matchManagers": ["helm-values", "helmfile"],
+      "matchManagers": [
+        "helm-values",
+        "helmfile"
+      ],
       "matchPackageNames": [
         "cert-manager",
         "external-secrets",
@@ -74,24 +76,21 @@
         "grafana",
         "vault"
       ],
-      "stabilityDays": 7,
+      "minimumReleaseAge": "7 days",
       "automerge": false,
-      "dependencyDashboardApproval": true,
-      "labels": ["platform", "critical"]
-    },
-    {
-      "description": "Container image major versions - manual review",
-      "matchManagers": ["kubernetes"],
-      "matchDatasources": ["docker"],
-      "matchUpdateTypes": ["major"],
-      "dependencyDashboardApproval": true,
-      "automerge": false,
-      "labels": ["docker", "major-update"]
+      "labels": [
+        "platform",
+        "critical"
+      ]
     },
     {
       "description": "Disable digest pinning for custom regex manager (Fleet/Helm values)",
-      "matchManagers": ["custom.regex"],
-      "matchDatasources": ["docker"],
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
       "pinDigests": false
     }
   ],
@@ -99,7 +98,9 @@
     {
       "customType": "regex",
       "description": "Fleet Helm Charts in fleet.yaml (standard HTTP repos)",
-      "fileMatch": ["(^|/)fleet\\.ya?ml$"],
+      "managerFilePatterns": [
+        "/(^|/)fleet\\.ya?ml$/"
+      ],
       "matchStrings": [
         "repo:\\s+['\"]?(?<registryUrl>https?://[^\\s'\"]+)['\"]?[\\s\\S]*?chart:\\s+['\"]?(?<depName>[^\\s'\"]+)['\"]?[\\s\\S]*?version:\\s+['\"]?(?<currentValue>[^'\"\\s]+)['\"]?"
       ],
@@ -108,7 +109,9 @@
     {
       "customType": "regex",
       "description": "Fleet Helm Charts in fleet.yaml (OCI registries)",
-      "fileMatch": ["(^|/)fleet\\.ya?ml$"],
+      "managerFilePatterns": [
+        "/(^|/)fleet\\.ya?ml$/"
+      ],
       "matchStrings": [
         "chart:\\s+['\"]?oci://(?<registryUrl>[^/\\s'\"]+)/(?<depName>[^\\s'\"]+)['\"]?[\\s\\S]*?version:\\s+['\"]?(?<currentValue>[^'\"\\s]+)['\"]?"
       ],
@@ -118,7 +121,9 @@
     {
       "customType": "regex",
       "description": "Container image tags in YAML (image: repo:tag format)",
-      "fileMatch": ["\\.ya?ml$"],
+      "managerFilePatterns": [
+        "/\\.ya?ml$/"
+      ],
       "matchStrings": [
         "image:\\s+['\"]?(?<depName>[^:\"'\\s]+):(?<currentValue>[^\"'\\s]+)['\"]?"
       ],
@@ -128,7 +133,9 @@
     {
       "customType": "regex",
       "description": "Docker images in comments (for GitOps references)",
-      "fileMatch": ["\\.ya?ml$"],
+      "managerFilePatterns": [
+        "/\\.ya?ml$/"
+      ],
       "matchStrings": [
         "#\\s*renovate:\\s*image=(?<depName>[^:]+):(?<currentValue>[^\\s]+)"
       ],
@@ -138,18 +145,23 @@
     {
       "customType": "regex",
       "description": "Kubernetes tool versions in comments",
-      "fileMatch": ["\\.ya?ml$", "Makefile$"],
+      "managerFilePatterns": [
+        "/\\.ya?ml$/",
+        "/Makefile$/"
+      ],
       "matchStrings": [
         "#\\s*renovate:\\s*k8s-(?<depName>kubectl|helm|kustomize)\\s+(?<currentValue>[^\\s]+)"
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "kubernetes/{{depName}}",
       "versioningTemplate": "semver"
-    }
-  ],
-  "regexManagers": [
+    },
     {
-      "fileMatch": ["(^|/)fleet\\.ya?ml$"],
+      "customType": "regex",
+      "description": "Fleet datasource comment annotations",
+      "managerFilePatterns": [
+        "/(^|/)fleet\\.ya?ml$/"
+      ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?(\\s+registryUrl=(?<registryUrl>\\S+))?\\s+.+?:\\s*['\"]?(?<currentValue>[^'\"\\s]+)['\"]?"
       ]

--- a/renovate-terraform.json
+++ b/renovate-terraform.json
@@ -2,8 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Terraform/IaC Renovate configuration for providers, modules, and tools",
   "extends": [
-    "github>sbaerlocher/.github:renovate-base#main",
-    ":semanticCommitTypeAll(chore)"
+    "github>sbaerlocher/.github:renovate-base#main"
   ],
   "enabledManagers": [
     "terraform",
@@ -15,53 +14,78 @@
     "custom.regex"
   ],
   "terraform": {
-    "fileMatch": [
-      "\\.tf$",
-      "(^|/)\\.terraform\\.lock\\.hcl$"
+    "managerFilePatterns": [
+      "/\\.tf$/",
+      "/(^|/)\\.terraform\\.lock\\.hcl$/"
     ]
   },
   "packageRules": [
     {
-      "description": "Terraform Core version updates - manual review",
-      "matchManagers": ["terraform-version"],
-      "matchPackageNames": ["hashicorp/terraform"],
+      "description": "Terraform Core version updates - higher stability",
+      "matchManagers": [
+        "terraform-version"
+      ],
+      "matchPackageNames": [
+        "hashicorp/terraform"
+      ],
       "groupName": "Terraform Core",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "terraform",
-      "stabilityDays": 14,
+      "minimumReleaseAge": "14 days",
       "automerge": false,
-      "dependencyDashboardApproval": true,
-      "labels": ["terraform-core", "manual-review"],
+      "labels": [
+        "terraform-core"
+      ],
       "prPriority": 20
     },
     {
       "description": "Group Terraform Providers by patch/minor",
-      "matchManagers": ["terraform"],
-      "matchDatasources": ["terraform-provider"],
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchManagers": [
+        "terraform"
+      ],
+      "matchDatasources": [
+        "terraform-provider"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
       "groupName": "Terraform Providers (non-major)",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "providers",
-      "stabilityDays": 5,
-      "labels": ["terraform", "providers"]
+      "minimumReleaseAge": "5 days",
+      "labels": [
+        "terraform",
+        "providers"
+      ]
     },
     {
       "description": "Terraform Provider major updates - individual PRs",
-      "matchManagers": ["terraform"],
-      "matchDatasources": ["terraform-provider"],
-      "matchUpdateTypes": ["major"],
+      "matchManagers": [
+        "terraform"
+      ],
+      "matchDatasources": [
+        "terraform-provider"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
       "groupName": null,
-      "dependencyDashboardApproval": true,
-      "automerge": false,
-      "stabilityDays": 14,
-      "labels": ["terraform", "providers", "major-update"],
+      "minimumReleaseAge": "14 days",
+      "labels": [
+        "terraform",
+        "providers",
+        "major-update"
+      ],
       "semanticCommitType": "feat",
       "semanticCommitScope": "providers"
     },
     {
       "description": "Critical providers - extra stability",
-      "matchManagers": ["terraform"],
-      "matchDatasources": ["terraform-provider"],
+      "matchManagers": [
+        "terraform"
+      ],
+      "matchDatasources": [
+        "terraform-provider"
+      ],
       "matchPackageNames": [
         "hashicorp/aws",
         "hashicorp/azurerm",
@@ -70,57 +94,91 @@
         "cloudflare/cloudflare",
         "integrations/github"
       ],
-      "stabilityDays": 7,
+      "minimumReleaseAge": "7 days",
       "automerge": false,
-      "labels": ["terraform", "critical-provider"]
+      "labels": [
+        "terraform",
+        "critical-provider"
+      ]
     },
     {
       "description": "Terraform Modules updates",
-      "matchManagers": ["terraform"],
-      "matchDatasources": ["terraform-module", "github-tags", "git-tags"],
+      "matchManagers": [
+        "terraform"
+      ],
+      "matchDatasources": [
+        "terraform-module",
+        "github-tags",
+        "git-tags"
+      ],
       "groupName": "Terraform Modules",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "modules",
-      "stabilityDays": 7,
-      "labels": ["terraform", "modules"]
+      "minimumReleaseAge": "7 days",
+      "labels": [
+        "terraform",
+        "modules"
+      ]
     },
     {
-      "description": "Terraform Module major updates - manual review",
-      "matchManagers": ["terraform"],
-      "matchDatasources": ["terraform-module", "github-tags", "git-tags"],
-      "matchUpdateTypes": ["major"],
-      "dependencyDashboardApproval": true,
-      "automerge": false,
-      "stabilityDays": 14,
-      "labels": ["terraform", "modules", "major-update"]
+      "description": "Terraform Module major updates - higher stability",
+      "matchManagers": [
+        "terraform"
+      ],
+      "matchDatasources": [
+        "terraform-module",
+        "github-tags",
+        "git-tags"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "minimumReleaseAge": "14 days",
+      "labels": [
+        "terraform",
+        "modules",
+        "major-update"
+      ]
     },
     {
       "description": "tflint and plugins",
-      "matchManagers": ["tflint-plugin"],
+      "matchManagers": [
+        "tflint-plugin"
+      ],
       "groupName": "tflint",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "lint",
-      "automerge": true,
-      "labels": ["terraform", "tflint"]
+      "labels": [
+        "terraform",
+        "tflint"
+      ]
     },
     {
       "description": "Terragrunt version updates",
-      "matchManagers": ["terragrunt", "terragrunt-version"],
-      "matchPackageNames": ["gruntwork-io/terragrunt"],
+      "matchManagers": [
+        "terragrunt",
+        "terragrunt-version"
+      ],
+      "matchPackageNames": [
+        "gruntwork-io/terragrunt"
+      ],
       "groupName": "Terragrunt",
-      "semanticCommitType": "chore",
       "semanticCommitScope": "terragrunt",
-      "stabilityDays": 7,
+      "minimumReleaseAge": "7 days",
       "automerge": false,
-      "labels": ["terragrunt"]
+      "labels": [
+        "terragrunt"
+      ]
     },
     {
       "description": "Lock file maintenance for Terraform",
-      "matchManagers": ["terraform"],
-      "matchUpdateTypes": ["lockFileMaintenance"],
-      "schedule": ["before 6am on the first day of the month"],
-      "automerge": true,
-      "semanticCommitType": "chore",
+      "matchManagers": [
+        "terraform"
+      ],
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ],
+      "schedule": [
+        "before 6am on the first day of the month"
+      ],
       "semanticCommitScope": "lock"
     },
     {
@@ -130,17 +188,19 @@
         "terraform-docs/terraform-docs"
       ],
       "groupName": "Terraform pre-commit tools",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "tools",
-      "automerge": true
+      "semanticCommitScope": "tools"
     }
   ],
   "customManagers": [
     {
       "customType": "regex",
       "description": "Terraform version in .terraform-version files",
-      "fileMatch": ["(^|/)\\.terraform-version$"],
-      "matchStrings": ["^(?<currentValue>\\S+)$"],
+      "managerFilePatterns": [
+        "/(^|/)\\.terraform-version$/"
+      ],
+      "matchStrings": [
+        "^(?<currentValue>\\S+)$"
+      ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "hashicorp/terraform",
       "versioningTemplate": "hashicorp"
@@ -148,8 +208,12 @@
     {
       "customType": "regex",
       "description": "Terragrunt version in .terragrunt-version files",
-      "fileMatch": ["(^|/)\\.terragrunt-version$"],
-      "matchStrings": ["^(?<currentValue>\\S+)$"],
+      "managerFilePatterns": [
+        "/(^|/)\\.terragrunt-version$/"
+      ],
+      "matchStrings": [
+        "^(?<currentValue>\\S+)$"
+      ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "gruntwork-io/terragrunt",
       "versioningTemplate": "semver"
@@ -157,7 +221,10 @@
     {
       "customType": "regex",
       "description": "Terraform/Terragrunt versions in Makefiles",
-      "fileMatch": ["^Makefile$", "\\.mk$"],
+      "managerFilePatterns": [
+        "/^Makefile$/",
+        "/\\.mk$/"
+      ],
       "matchStrings": [
         "TERRAFORM_VERSION\\s*[:?]?=\\s*(?<currentValue>[^\\s]+)",
         "TERRAGRUNT_VERSION\\s*[:?]?=\\s*(?<currentValue>[^\\s]+)"
@@ -169,7 +236,9 @@
     {
       "customType": "regex",
       "description": "Terraform provider versions in comments",
-      "fileMatch": ["\\.tf$"],
+      "managerFilePatterns": [
+        "/\\.tf$/"
+      ],
       "matchStrings": [
         "#\\s*renovate:\\s*terraform-provider\\s+(?<depName>[^\\s]+)\\s+(?<currentValue>[^\\s]+)"
       ],
@@ -179,7 +248,10 @@
     {
       "customType": "regex",
       "description": "Ansible versions in requirements files",
-      "fileMatch": ["^ansible/requirements\\.ya?ml$", "requirements\\.ya?ml$"],
+      "managerFilePatterns": [
+        "/^ansible/requirements\\.ya?ml$/",
+        "/requirements\\.ya?ml$/"
+      ],
       "matchStrings": [
         "version:\\s+['\"]?(?<currentValue>[^'\"\\s]+)['\"]?\\s+#\\s*renovate:\\s*(?<depName>[^\\s]+)"
       ],
@@ -189,8 +261,12 @@
     {
       "customType": "regex",
       "description": "Packer version in .packer-version files",
-      "fileMatch": ["(^|/)\\.packer-version$"],
-      "matchStrings": ["^(?<currentValue>\\S+)$"],
+      "managerFilePatterns": [
+        "/(^|/)\\.packer-version$/"
+      ],
+      "matchStrings": [
+        "^(?<currentValue>\\S+)$"
+      ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "hashicorp/packer",
       "versioningTemplate": "hashicorp"


### PR DESCRIPTION
## Summary

- Migrate all deprecated Renovate options across 6 preset files to current syntax
  - `stabilityDays` → `minimumReleaseAge`
  - `matchPackagePrefixes` → `matchPackageNames` (glob)
  - `matchPackagePatterns` → `matchPackageNames` (regex)
  - `fileMatch` → `managerFilePatterns`
  - `regexManagers` → `customManagers`
- Remove redundant rules already inherited from `renovate-base.json`
- Remove `dependencyDashboardApproval` so Renovate creates PRs automatically
- Add `configMigration: true` to base for automatic future migration PRs
- All configs validated with `renovate-config-validator` (0 warnings)

## Affected files

| File | Changes |
|------|---------|
| `renovate-base.json` | Migrate deprecated options, add `configMigration`, remove redundancies |
| `renovate-docker.json` | Migrate deprecated options, remove rules covered by base |
| `renovate-go.json` | Migrate `matchPackagePrefixes` to glob syntax, remove redundancies |
| `renovate-js.json` | Migrate `matchPackagePatterns` to regex syntax, remove redundancies |
| `renovate-terraform.json` | Migrate deprecated options, remove redundant overrides |
| `renovate-kubernetes.json` | Migrate `regexManagers` → `customManagers`, remove redundancies |

## Test plan

- [x] All 6 configs pass `npx renovate-config-validator` without warnings
- [ ] Verify Renovate creates PRs automatically (no more "Pending Approval")
- [ ] Confirm inherited base rules still apply correctly in child presets