### PR TITLE
fix(claude): enable inline comments by removing use_sticky_comment

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>sbaerlocher/.github:renovate-base#2026-03-21"],
+  "extends": ["github>sbaerlocher/.github:renovate-base#main"],
   "packageRules": [
     {
       "description": "Group GitHub Actions updates",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>sbaerlocher/.github:renovate-base"],
+  "extends": ["github>sbaerlocher/.github:renovate-base#2026-03-21"],
   "packageRules": [
     {
       "description": "Group GitHub Actions updates",

--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
-          use_sticky_comment: true
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           claude_args: |


### PR DESCRIPTION
## Problem

PR #26 introduced `use_sticky_comment: true` for cleaner UX. However, this option consolidates **all** Claude output into a single top-level PR comment — including what should be posted as inline code comments on specific lines.

As observed in PR #27, Claude posted a detailed review as one block comment instead of inline annotations on the affected lines.

## Fix

Remove `use_sticky_comment: true`. The code-review plugin will now post inline comments directly on the relevant lines when issues are found, and a summary comment for the overall review.

`track_progress: true` is kept for the progress tracking indicator.

## Test plan

- [ ] Open a PR with a real issue (e.g. unsupported action tag) → Claude posts an inline comment on that line