### PR TITLE
docs(standards): add REVIEW.md standard, rewrite STANDARDS.md, add SETUP.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ uses: sbaerlocher/.github/.github/workflows/ci-js.yml@v1
 | Dependencies    | `security-deps.yml`         | Dependency vulnerabilities | govulncheck, npm audit  |
 | Secrets         | `security-secrets.yml`      | Secret detection           | Gitleaks, TruffleHog    |
 | Containers      | `security-containers.yml`   | Container scanning         | Trivy, Grype            |
-| Supply Chain    | `security-supply-chain.yml` | SBOM & signing             | Cosign, CycloneDX       |
+| Supply Chain    | `security-sbom.yml`         | SBOM & signing             | Cosign, CycloneDX       |
 
 **Strategy**:
 
@@ -179,6 +179,14 @@ uses: sbaerlocher/.github/.github/workflows/ci-js.yml@v1
 | ----------- | ---------------------- | ---------------------------------- |
 | Code Review | `ai-claude-review.yml` | Auto code review (reads REVIEW.md) |
 | On-demand   | `ai-claude.yml`        | On-demand @claude mentions         |
+
+### E2E - End-to-End Tests (1)
+
+**Purpose**: End-to-end testing with Docker Compose
+
+| Workflow   | File              | Description                     |
+| ---------- | ----------------- | ------------------------------- |
+| E2E Docker | `e2e-docker.yml` | E2E tests via Docker Compose    |
 
 ---
 
@@ -369,7 +377,7 @@ Ensure lock files are committed:
 ```text
 .github/
 ├── .github/
-│   ├── workflows/           # 27 reusable workflows
+│   ├── workflows/           # 21 reusable workflows
 │   │   ├── ci-*.yml        # CI workflows
 │   │   ├── security-*.yml  # Security workflows
 │   │   ├── deploy-*.yml    # Deploy workflows
@@ -385,7 +393,7 @@ Ensure lock files are committed:
 ├── README.md               # Human-readable documentation
 ├── CHANGELOG.md            # Version history
 ├── STANDARDS.md            # Repository standards
-├── SETUP.md         # GitHub repo setup commands & branch rulesets
+├── SETUP.md                # GitHub repo setup commands & branch rulesets
 ├── REVIEW.md               # Code review guidelines for this repo
 ├── LICENSE                 # MIT License
 ├── .editorconfig           # Editor consistency

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,9 @@
 
 ## Context for AI Agents
 
-This repository contains centralized, reusable GitHub Actions workflows that are used across all repositories in the sbaerlocher organization. When working on this repository, you are directly impacting the CI/CD pipelines of multiple projects.
+This repository contains centralized, reusable GitHub Actions workflows used across all
+repositories in the sbaerlocher organization. When working on this repository, you are
+directly impacting the CI/CD pipelines of multiple projects.
 
 ### What This Repository Does
 
@@ -22,9 +24,10 @@ This repository contains centralized, reusable GitHub Actions workflows that are
 
 **Current Statistics**:
 
-- **Total Workflows**: 27 reusable workflows (see [.github/workflows/](./.github/workflows/))
-- **Categories**: CI (3), Security (6), Deploy (2), Release (4), Operations (3), Other (9)
-- **Consumers**: applications, infrastructure, authentication, observability, functions, sbaerlocher.ch, tsmetrics, and more
+- **Total Workflows**: 21 reusable workflows (see [.github/workflows/](./.github/workflows/))
+- **Categories**: CI (5), Security (6), Deploy (2), Release (4), Operations (1), AI (2), E2E (1)
+- **Consumers**: applications, infrastructure, authentication, observability, functions,
+  sbaerlocher.ch, tsmetrics, and more
 
 ---
 
@@ -93,15 +96,17 @@ uses: sbaerlocher/.github/.github/workflows/ci-js.yml@v1
 
 ## Workflow Categories
 
-### CI - Continuous Integration (3)
+### CI - Continuous Integration (5)
 
 **Purpose**: Validate code quality, tests, and security before merge
 
-| Workflow       | File                                                     | Description                          | Languages/Tools                 |
-| -------------- | -------------------------------------------------------- | ------------------------------------ | ------------------------------- |
-| CI (Go)        | [ci-go.yml](./.github/workflows/ci-go.yml)               | Go build, test & security            | Go, golangci-lint, gosec        |
-| CI (JS/TS)     | [ci-js.yml](./.github/workflows/ci-js.yml)               | All-in-one: quality, tests, security | JS/TS, Prettier, ESLint, Vitest |
-| CI (Terraform) | [ci-terraform.yml](./.github/workflows/ci-terraform.yml) | Terraform validation                 | Terraform, tflint, yamllint     |
+| Workflow       | File               | Description               | Languages/Tools                 |
+| -------------- | ------------------ | ------------------------- | ------------------------------- |
+| CI (Ansible)   | `ci-ansible.yml`   | Ansible syntax & lint     | Ansible, ansible-lint           |
+| CI (GitOps)    | `ci-gitops.yml`    | Fleet & K8s validation    | Fleet, Helm, kubeconform        |
+| CI (Go)        | `ci-go.yml`        | Go build, test & security | Go, golangci-lint, gosec        |
+| CI (JS/TS)     | `ci-js.yml`        | Quality, tests & security | JS/TS, Prettier, ESLint, Vitest |
+| CI (Terraform) | `ci-terraform.yml` | Terraform validation      | Terraform, tflint               |
 
 **Key Features**:
 
@@ -114,14 +119,14 @@ uses: sbaerlocher/.github/.github/workflows/ci-js.yml@v1
 
 **Purpose**: Comprehensive security scanning (SAST, secrets, dependencies, containers)
 
-| Workflow        | File                                                                       | Description                | Tools                   |
-| --------------- | -------------------------------------------------------------------------- | -------------------------- | ----------------------- |
-| SAST            | [security-code.yml](./.github/workflows/security-code.yml)                 | Static code analysis       | CodeQL (multi-language) |
-| Config Security | [security-config.yml](./.github/workflows/security-config.yml)             | IaC security               | Checkov, Kubeconform    |
-| Dependencies    | [security-deps.yml](./.github/workflows/security-deps.yml)                 | Dependency vulnerabilities | govulncheck, npm audit  |
-| Secrets         | [security-secrets.yml](./.github/workflows/security-secrets.yml)           | Secret detection           | Gitleaks, TruffleHog    |
-| Containers      | [security-containers.yml](./.github/workflows/security-containers.yml)     | Container scanning         | Trivy, Grype            |
-| Supply Chain    | [security-supply-chain.yml](./.github/workflows/security-supply-chain.yml) | SBOM & signing             | Cosign, CycloneDX       |
+| Workflow        | File                        | Description                | Tools                   |
+| --------------- | --------------------------- | -------------------------- | ----------------------- |
+| SAST            | `security-code.yml`         | Static code analysis       | CodeQL (multi-language) |
+| Config Security | `security-config.yml`       | IaC security               | Checkov, Kubeconform    |
+| Dependencies    | `security-deps.yml`         | Dependency vulnerabilities | govulncheck, npm audit  |
+| Secrets         | `security-secrets.yml`      | Secret detection           | Gitleaks, TruffleHog    |
+| Containers      | `security-containers.yml`   | Container scanning         | Trivy, Grype            |
+| Supply Chain    | `security-supply-chain.yml` | SBOM & signing             | Cosign, CycloneDX       |
 
 **Strategy**:
 
@@ -134,10 +139,10 @@ uses: sbaerlocher/.github/.github/workflows/ci-js.yml@v1
 
 **Purpose**: Deploy infrastructure and applications
 
-| Workflow           | File                                                                               | Description            | Use Case             |
-| ------------------ | ---------------------------------------------------------------------------------- | ---------------------- | -------------------- |
-| Terraform Deploy   | [deploy-terraform.yml](./.github/workflows/deploy-terraform.yml)                   | Terraform plan & apply | IaC deployments      |
-| Cloudflare Workers | [deploy-cloudflare-workers.yml](./.github/workflows/deploy-cloudflare-workers.yml) | Wrangler deploy        | Serverless functions |
+| Workflow           | File                            | Description            | Use Case             |
+| ------------------ | ------------------------------- | ---------------------- | -------------------- |
+| Terraform Deploy   | `deploy-terraform.yml`          | Terraform plan & apply | IaC deployments      |
+| Cloudflare Workers | `deploy-cloudflare-workers.yml` | Wrangler deploy        | Serverless functions |
 
 **Features**:
 
@@ -149,24 +154,31 @@ uses: sbaerlocher/.github/.github/workflows/ci-js.yml@v1
 
 **Purpose**: Build and publish versioned artifacts
 
-| Workflow       | File                                                         | Description         | Output                    |
-| -------------- | ------------------------------------------------------------ | ------------------- | ------------------------- |
-| Go Release     | [release-go.yml](./.github/workflows/release-go.yml)         | GoReleaser          | Binaries (multi-platform) |
-| Docker Release | [release-docker.yml](./.github/workflows/release-docker.yml) | Docker build & push | Container images          |
-| Helm Release   | [release-helm.yml](./.github/workflows/release-helm.yml)     | Helm chart publish  | OCI charts                |
-| NPM Release    | [release-npm.yml](./.github/workflows/release-npm.yml)       | NPM publish         | Package with provenance   |
+| Workflow       | File                 | Description         | Output                    |
+| -------------- | -------------------- | ------------------- | ------------------------- |
+| Go Release     | `release-go.yml`     | GoReleaser          | Binaries (multi-platform) |
+| Docker Release | `release-docker.yml` | Docker build & push | Container images          |
+| Helm Release   | `release-helm.yml`   | Helm chart publish  | OCI charts                |
+| NPM Release    | `release-npm.yml`    | NPM publish         | Package with provenance   |
 
 **Trigger**: `push` events on tags (`v*`)
 
-### Operations - Operational Tasks (3)
+### Operations - Operational Tasks (1)
 
 **Purpose**: Scheduled maintenance and operational tasks
 
-| Workflow        | File                                                                                   | Description            | Schedule                |
-| --------------- | -------------------------------------------------------------------------------------- | ---------------------- | ----------------------- |
-| Drift Detection | [ops-drift-detection.yml](./.github/workflows/ops-drift-detection.yml)                 | Terraform drift        | Weekly Monday 06:00 UTC |
-| Secret Sync     | [ops-sync-secrets.yml](./.github/workflows/ops-sync-secrets.yml)                       | Bitwarden → CF Workers | On-demand               |
-| Orchestration   | [ops-terraform-orchestration.yml](./.github/workflows/ops-terraform-orchestration.yml) | Multi-environment TF   | On-demand               |
+| Workflow      | File                              | Description          | Schedule  |
+| ------------- | --------------------------------- | -------------------- | --------- |
+| Orchestration | `ops-terraform-orchestration.yml` | Multi-environment TF | On-demand |
+
+### AI - AI-Assisted Workflows (2)
+
+**Purpose**: AI-powered code review and on-demand assistance (private repos only)
+
+| Workflow    | File                   | Description                        |
+| ----------- | ---------------------- | ---------------------------------- |
+| Code Review | `ai-claude-review.yml` | Auto code review (reads REVIEW.md) |
+| On-demand   | `ai-claude.yml`        | On-demand @claude mentions         |
 
 ---
 
@@ -307,7 +319,7 @@ jobs:
 
 ### Workflow Not Found Error
 
-```
+```text
 Error: Unable to resolve action sbaerlocher/.github/.github/workflows/ci-js.yml@main
 ```
 
@@ -373,6 +385,8 @@ Ensure lock files are committed:
 ├── README.md               # Human-readable documentation
 ├── CHANGELOG.md            # Version history
 ├── STANDARDS.md            # Repository standards
+├── SETUP.md         # GitHub repo setup commands & branch rulesets
+├── REVIEW.md               # Code review guidelines for this repo
 ├── LICENSE                 # MIT License
 ├── .editorconfig           # Editor consistency
 ├── .gitignore              # Git ignore patterns
@@ -435,6 +449,7 @@ Ensure lock files are committed:
 - **[README.md](./README.md)** - User-facing workflow documentation
 - **[STANDARDS.md](./STANDARDS.md)** - Repository standards for all projects
 - **[CHANGELOG.md](./CHANGELOG.md)** - Version history and changes
+- **[REVIEW.md](./REVIEW.md)** - Code review guidelines for this repository
 - **Renovate Presets**: `renovate-*.json` files in repository root
 
 ---
@@ -478,7 +493,7 @@ Ensure lock files are committed:
 
 **Repository Owner**: Simon Bärlocher (@sbaerlocher)
 **Issues**: [GitHub Issues](https://github.com/sbaerlocher/.github/issues)
-**Website**: https://sbaerlocher.ch
+**Website**: [sbaerlocher.ch](https://sbaerlocher.ch)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,66 @@ This is a rolling release - changes are deployed continuously to `main`.
 
 ---
 
+## 2026-03-22
+
+### Added
+
+- **REVIEW.md**: Code review guidelines for this repository — required standard for all repos
+- **SETUP.md**: GitHub repository setup commands, branch ruleset JSON, and full setup script
+  (extracted from STANDARDS.md to keep standards focused on rules, not procedures)
+- **ci-gitops.yml**: New reusable workflow for GitOps/Fleet validation
+  - Validates YAML syntax, Fleet bundle configuration, and Kubernetes manifests
+  - Checks `fleet.yaml` presence, Helm chart structure, and HelmRelease CRD usage
+  - Consolidates all GitOps CI checks that were previously implemented locally per consumer repo
+
+### Removed
+
+- **drift-terraform.yml**: Deleted — was a pure wrapper around `deploy-terraform.yml` with `mode: drift`
+  - No functional difference; consumer repos call `deploy-terraform.yml` directly with `mode: drift`
+- **docs-terraform.yml**: Deleted — consumer repos implement `terraform-docs` locally
+- **helm-test.yml**: Deleted — covered by `ci-gitops.yml` and `e2e-docker.yml`
+- **notify-deployment.yml**: Deleted — non-generic Slack notification with hardcoded assumptions
+- **ops-drift-detection.yml**: Deleted — superseded by `deploy-terraform.yml` with `mode: drift`
+- **ops-sync-secrets.yml**: Deleted — Bitwarden → Cloudflare Workers secret sync was too repo-specific
+- **quality-benchmarks.yml**: Deleted — benchmark CI was not consumed by any active repo
+- **security-supply-chain.yml**: Deleted — SBOM generation and Cosign signing moved to `security-sbom.yml`
+
+### Changed
+
+- **ci-terraform.yml**: Remove `tfsec` job and `enable-tfsec` input
+  - Security scanning belongs in dedicated `security-config.yml`, not in CI
+  - Reduces CI scope to validation only (fmt, validate, tflint, docs check)
+- **ai-claude-review.yml**, **ai-claude.yml**: Add `id-token: write` permission
+  - Required for OIDC token fetching by `anthropics/claude-code-action`
+  - Without it, the action fails: "Could not fetch an OIDC token"
+- **Step summaries** (9 workflows): Refactor to runtime-result-only format
+  - Removed boilerplate sections ("Tools Used", "Best Practices", "Security Coverage")
+  - Each summary now contains: timestamp, repository context, status table, key config values
+  - Affected: `ci-js.yml`, `security-config.yml`, `security-containers.yml`, `security-code.yml`,
+    `security-deps.yml`, `security-secrets.yml`, `release-npm.yml`, `release-docker.yml`,
+    `deploy-cloudflare-workers.yml`
+- **STANDARDS.md**: Rewritten from 1549 → ~280 lines
+  - Removed long YAML/JSON examples, "Why?" explanations, Kubernetes/Monitoring details
+  - Removed `.claude/commands/` section — custom commands are no longer a standard requirement
+  - Added `REVIEW.md` as required file for all repositories
+  - Moved GitHub setup commands and branch ruleset JSON to new `SETUP.md`
+  - Kept: required files table, workflow matrix, SHA pinning rule, commit format, Renovate
+    preset mapping, secret rules, code quality table
+- **AGENTS.md**: Sync workflow categories with actual files
+  - Removed deleted workflows (`ops-drift-detection.yml`, `ops-sync-secrets.yml`)
+  - Added missing AI workflows section (`ai-claude-review.yml`, `ai-claude.yml`)
+  - Shortened workflow table file columns to filename-only
+  - Added `REVIEW.md` and `SETUP.md` to repo structure and related documentation
+- **renovate-docker.json**: Add `minimumReleaseAge: "5 days"` to additional image groups
+
+### Dependencies
+
+- **GitHub Actions** (PR #29): Update SHA digests
+  - `security-containers.yml`: `aquasecurity/trivy-action` SHA update
+  - `security-sbom.yml`: `anchore/sbom-action` and `sigstore/cosign-installer` SHA updates
+
+---
+
 ## 2026-03-21
 
 ### Changed

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,180 @@
+# GitHub Repository Setup
+
+Reference for configuring a new repository consistently. Run these commands once after creation.
+
+---
+
+## General Settings
+
+```bash
+gh repo edit {owner}/{repo} \
+  --delete-branch-on-merge \
+  --enable-squash-merge \
+  --enable-auto-merge
+
+gh api repos/{owner}/{repo} --method PATCH \
+  --field allow_merge_commit=false \
+  --field allow_rebase_merge=false
+```
+
+---
+
+## GITHUB_TOKEN Default Permissions
+
+Set to read-only. Workflows must declare write permissions explicitly.
+
+```bash
+gh api repos/{owner}/{repo} --method PATCH \
+  --field default_workflow_permissions=read \
+  --field can_approve_pull_request_reviews=false
+```
+
+Workflows that need write access declare it explicitly:
+
+```yaml
+permissions:
+  contents: write # only if needed (e.g. release)
+  pull-requests: write # only if needed (e.g. ai-claude-review)
+```
+
+---
+
+## Branch Ruleset (Personal Repo)
+
+```bash
+gh api repos/{owner}/{repo}/rulesets --method POST --input - <<'EOF'
+{
+  "name": "main-branch-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          { "context": "ci" }
+        ]
+      }
+    }
+  ]
+}
+EOF
+```
+
+**Note**: Omit `required_status_checks` for repos that have no `pull_request`-triggered workflow
+(e.g. this `.github` repo with `workflow_call`-only workflows). The check would never run and
+block every PR.
+
+### Team Repo Adjustments
+
+Change the `pull_request` rule parameters to:
+
+```json
+{
+  "required_approving_review_count": 1,
+  "dismiss_stale_reviews_on_push": true,
+  "require_code_owner_review": true,
+  "require_last_push_approval": false,
+  "required_review_thread_resolution": true
+}
+```
+
+---
+
+## Required Status Check Context Format
+
+The `context` value must exactly match the string GitHub shows in the Check Suite:
+
+| Workflow type     | Context format         | Example              |
+| ----------------- | ---------------------- | -------------------- |
+| Direct job        | `<job-id>`             | `ci`                 |
+| Reusable workflow | `<caller-job> / <job>` | `ci / terraform`     |
+| Matrix job        | `<job-id> (<matrix>)`  | `ci (ubuntu-latest)` |
+
+Verify the exact string by opening a PR and checking the "Checks" tab before adding it as a
+required check.
+
+**Never add as required checks**: `security` or `drift` — these run on schedule, not on PRs.
+
+---
+
+## Full Setup Script
+
+```bash
+#!/usr/bin/env bash
+# Usage: ./scripts/setup-repo.sh <owner/repo>
+set -euo pipefail
+
+REPO=$1
+
+gh repo edit "$REPO" \
+  --delete-branch-on-merge \
+  --enable-squash-merge \
+  --enable-auto-merge
+
+gh api "repos/$REPO" --method PATCH \
+  --field allow_merge_commit=false \
+  --field allow_rebase_merge=false
+
+gh api "repos/$REPO" --method PATCH \
+  --field default_workflow_permissions=read \
+  --field can_approve_pull_request_reviews=false
+
+gh api "repos/$REPO/rulesets" --method POST --input - <<'EOF'
+{
+  "name": "main-branch-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          { "context": "ci" }
+        ]
+      }
+    }
+  ]
+}
+EOF
+```

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -129,6 +129,7 @@ uses: sbaerlocher/.github/.github/workflows/ci-terraform.yml@2026-02-14
 | Ops      | `ops-terraform-orchestration.yml` | Multi-environment TF               |
 | AI       | `ai-claude-review.yml`            | Auto code review (reads REVIEW.md) |
 | AI       | `ai-claude.yml`                   | On-demand @claude mentions         |
+| E2E      | `e2e-docker.yml`                  | E2E tests via Docker Compose       |
 
 ### Action SHA Pinning
 

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -2,1545 +2,271 @@
 
 ## Principles
 
-**Public vs Private Repos:**
-
-| Aspect                  | Public          | Private                  |
-| ----------------------- | --------------- | ------------------------ |
-| LICENSE                 | MIT (Required)  | None (Rights with Owner) |
-| `security.yml` (CodeQL) | Required        | Optional                 |
-| Claude Workflows        | Not recommended | Recommended              |
-| Other structure         | Identical       | Identical                |
+| Aspect              | Public            | Private                  |
+| ------------------- | ----------------- | ------------------------ |
+| `LICENSE`           | MIT (Required)    | None (rights with owner) |
+| `security.yml`      | Required (CodeQL) | Optional                 |
+| Claude AI workflows | Not recommended   | Recommended              |
+| All other structure | Identical         | Identical                |
 
 ---
 
-## Recommended Minimal Structure
+## Required Files (Every Repo)
 
-Focus on essentials - no unnecessary files.
+| File                    | Notes                                  |
+| ----------------------- | -------------------------------------- |
+| `AGENTS.md`             | AI instructions (main file)            |
+| `CLAUDE.md`             | Only: `@AGENTS.md`                     |
+| `README.md`             | 1-2 sentences + quick start            |
+| `REVIEW.md`             | Code review guidelines                 |
+| `.editorconfig`         | See templates repo                     |
+| `.gitignore`            | Minimal — build outputs, deps, IDE, OS |
+| `.github/CODEOWNERS`    | `* @sbaerlocher`                       |
+| `.github/renovate.json` | Extend shared preset (see below)       |
+| `LICENSE`               | MIT — public repos only                |
 
-```text
-repository/
-├── .github/
-│   ├── workflows/
-│   │   └── [project-specific].yml
-│   ├── CODEOWNERS
-│   └── renovate.json
-├── AGENTS.md                      # AI instructions (main file)
-├── CLAUDE.md                      # Only: @AGENTS.md
-├── README.md                      # Main documentation
-├── LICENSE                        # MIT License (public only)
-├── .editorconfig                  # Editor consistency
-├── .gitignore                     # Project-specific
-└── [project files]
-```
+### README.md
 
----
+Minimal: name, 1-2 sentence description, quick start commands. No badges, no long feature lists.
 
-## Required Files
+### REVIEW.md
 
-### 1. README.md
+Documents review scope, required checks, severity levels, and which PRs to skip.
+See [REVIEW.md](./REVIEW.md) in this repository as a reference implementation.
 
-**Content (minimal):**
+Minimal template:
 
 ```markdown
-# Project Name
+# Code Review Guidelines
 
-Short description (1-2 sentences).
+## Scope
 
-## Quick Start
+[What is in / out of scope for reviews in this repo]
 
-[Commands to start]
+## Required checks
 
-## Structure
+[Repo-specific checks reviewers must verify]
 
-[Brief folder overview if needed]
+## Severity levels
 
-## License
+| Level        | Meaning                                             | Merge impact       |
+| ------------ | --------------------------------------------------- | ------------------ |
+| Bug          | Incorrect behavior or broken contract               | Blocks merge       |
+| Nit          | Minor issue — suboptimal but not incorrect          | Non-blocking       |
+| Pre-existing | Issue present before this PR; flagged for awareness | No action required |
 
-MIT License
+## Skip
+
+[PR types that do not require a full review]
 ```
 
-**Avoid:**
+### AGENTS.md
 
-- Badges (except npm/go packages)
-- Long feature lists
-- Code examples (belong in AGENTS.md or docs)
+Project context for AI agents: what the project does, code conventions, architecture, important
+patterns, what AI should not do. See workspace `AGENTS.md` for full guidance.
 
-### 2. LICENSE (Public Repos Only)
-
-MIT License for all public repos. Private repos don't need LICENSE (rights with owner).
-
-```
-MIT License
-
-Copyright (c) [YEAR] [YOUR NAME]
-
-Permission is hereby granted...
-```
-
-### 3. .editorconfig
-
-See [templates/.editorconfig](https://github.com/sbaerlocher/sbaerlocher/tree/main/templates/.editorconfig)
-
-### 4. .gitignore
-
-Project-specific, keep minimal:
-
-- Build outputs
-- Dependencies (node_modules, .terraform)
-- IDE files (.idea, .vscode)
-- OS files (.DS_Store)
-- **Secrets** (see Secret Management section)
-
-### 5. .github/CODEOWNERS
-
-```text
-# Default owner
-* @your-username
-```
-
-### 6. .github/renovate.json
-
-Required for all repos. See base configuration in [.github/renovate/renovate-base.json](./renovate/renovate-base.json).
+`CLAUDE.md` contains only: `@AGENTS.md`
 
 ---
 
-## Optional (Only When Useful)
+## Optional Files
 
-### CHANGELOG.md
+| File                 | When                                           |
+| -------------------- | ---------------------------------------------- |
+| `CHANGELOG.md`       | Packages / repos with versioned releases only  |
+| `ARCHITECTURE.md`    | Infrastructure, monorepos                      |
+| `OPERATIONS.md`      | Production services with runbooks              |
+| `DEPLOYMENT.md`      | Complex deploy processes (more than 1 command) |
+| `.github/SECRETS.md` | Any repo that uses secrets                     |
+| `CONTRIBUTING.md`    | Public repos only                              |
 
-Only for:
+Files that do NOT belong in every repo: `docs/`, `SECURITY.md`, issue/PR templates,
+`CODE_OF_CONDUCT.md` (only for public community projects).
 
-- npm/go packages with versions
-- Projects with releases
+---
 
-Format: Keep a Changelog
+## Workflows
 
-```markdown
-# Changelog
-
-## [1.0.0] - 2025-01-15
-
-### Added
-
-- Feature X
-
-### Fixed
-
-- Bug Y
-```
-
-### .github/workflows/
-
-**Naming Convention:**
-
-- Lowercase
-- Hyphens instead of underscores
-- Short and descriptive
-
-**Workflow Names (`name:` field):**
-
-- Always write out full names (no abbreviations)
-- Example: `name: Continuous Integration` (not `CI`)
-- Example: `name: Security Scanning` (not `Security`)
-- Match the workflow names in the table below
-
-**Action References (Security):**
-
-Actions MUST be pinned to full commit SHA with version comment:
+All reusable workflows live in `sbaerlocher/.github/.github/workflows/`. Reference with a
+date-based version tag for reproducibility:
 
 ```yaml
-# ✅ CORRECT - SHA pinned with version comment
+uses: sbaerlocher/.github/.github/workflows/ci-terraform.yml@2026-02-14
+```
+
+### Required Workflows by Repo Type
+
+| Repo Type             | Required                                  | Optional                |
+| --------------------- | ----------------------------------------- | ----------------------- |
+| Software / Packages   | `ci.yml`, `release.yml`                   | `security.yml`          |
+| Infrastructure (IaC)  | `ci.yml`, `deploy.yml`, `security.yml`    | `drift.yml`, `docs.yml` |
+| GitOps                | `ci.yml`, `deploy.yml`                    | —                       |
+| Serverless            | `ci.yml`, `deploy.yml`                    | —                       |
+| **All public repos**  | + `security.yml` (CodeQL)                 | —                       |
+| **All private repos** | + `ai-claude.yml`, `ai-claude-review.yml` | —                       |
+
+### Available Reusable Workflows
+
+| Category | File                              | Description                        |
+| -------- | --------------------------------- | ---------------------------------- |
+| CI       | `ci-go.yml`                       | Go tests, linting                  |
+| CI       | `ci-js.yml`                       | JS/TS quality, tests, security     |
+| CI       | `ci-terraform.yml`                | TF validate, fmt, tflint           |
+| CI       | `ci-gitops.yml`                   | Fleet & K8s validation             |
+| CI       | `ci-ansible.yml`                  | Ansible syntax & lint              |
+| Deploy   | `deploy-terraform.yml`            | Terraform plan & apply             |
+| Deploy   | `deploy-cloudflare-workers.yml`   | Wrangler deploy                    |
+| Release  | `release-go.yml`                  | GoReleaser (multi-platform)        |
+| Release  | `release-docker.yml`              | Docker build & push                |
+| Release  | `release-helm.yml`                | Helm chart publish (OCI)           |
+| Release  | `release-npm.yml`                 | NPM publish with provenance        |
+| Security | `security-code.yml`               | CodeQL SAST (multi-language)       |
+| Security | `security-config.yml`             | Terraform / K8s / Ansible          |
+| Security | `security-deps.yml`               | Go, JS/TS, Python dependencies     |
+| Security | `security-secrets.yml`            | Gitleaks, TruffleHog               |
+| Security | `security-containers.yml`         | Trivy, Grype                       |
+| Security | `security-sbom.yml`               | SBOM & Cosign signing              |
+| Ops      | `ops-terraform-orchestration.yml` | Multi-environment TF               |
+| AI       | `ai-claude-review.yml`            | Auto code review (reads REVIEW.md) |
+| AI       | `ai-claude.yml`                   | On-demand @claude mentions         |
+
+### Action SHA Pinning
+
+All `uses:` references must be pinned to a full 40-character commit SHA with the version tag
+as an inline comment:
+
+```yaml
+# Correct
 uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
 
-# ❌ WRONG - Tag only (mutable, security risk)
+# Wrong
 uses: actions/checkout@v4
-uses: actions/setup-node@v4.0.2
 ```
 
-**Why SHA pinning?**
+Renovate updates SHA references automatically when `pinDigests: true` is set.
 
-- **Immutable**: SHA cannot be changed after commit
-- **Supply-chain security**: Protects against tag hijacking attacks
-- **Audit trail**: Exact version is always traceable
-- **GitHub recommendation**: For security-critical workflows
-
-**Renovate handles updates**: With proper Renovate config, SHA references are automatically updated with new version comments.
-
-**Renovate Configuration** (add to `renovate-base.json`):
-
-```json
-{
-  "github-actions": {
-    "pinDigests": true
-  }
-}
-```
-
-**Reusable Workflow References:**
-
-Reusable workflows SHOULD use version tags (date-based) for reproducibility and control:
+### Workflow Trigger Pattern (No Duplicate Runs)
 
 ```yaml
-# ✅ CORRECT - Date tag (recommended)
-uses: sbaerlocher/.github/.github/workflows/ci-terraform.yml@2026-02-14
-
-# ⚠️ DISCOURAGED - Branch reference (automatic updates, less control)
-uses: sbaerlocher/.github/.github/workflows/ci-terraform.yml@2026-02-14
-```
-
-**Why version tags?**
-
-- **Reproducible builds**: Same workflow version produces same results
-- **Controlled updates**: Changes only when explicitly updated via tag
-- **Rollback capability**: Easy to revert to previous working version
-- **Clear versioning**: Date-based tags are human-readable
-
-**Standard Workflows:**
-
-All workflows are centralized as **Reusable Workflows** in `sbaerlocher/.github/.github/workflows/`:
-
-| Category       | Workflow                           | Local File               | Reusable Workflow                 | Description                          |
-| -------------- | ---------------------------------- | ------------------------ | --------------------------------- | ------------------------------------ |
-| **CI**         | Continuous Integration (Go)        | `ci.yml`                 | `ci-go.yml`                       | Go tests, linting, validation        |
-| **CI**         | Continuous Integration (JS/TS)     | `ci.yml`                 | `ci-js.yml`                       | All-in-one: quality, tests, security |
-| **CI**         | Continuous Integration (Terraform) | `ci.yml`                 | `ci-terraform.yml`                | TF validate, fmt, tflint             |
-| **Deploy**     | Deployment (Terraform)             | `deploy.yml`             | `deploy-terraform.yml`            | Terraform plan & apply               |
-| **Deploy**     | Deployment (Cloudflare Workers)    | `deploy.yml`             | `deploy-cloudflare-workers.yml`   | Wrangler deploy                      |
-| **Release**    | Release (Go)                       | `release.yml`            | `release-go.yml`                  | GoReleaser                           |
-| **Release**    | Release (Docker)                   | `release.yml`            | `release-docker.yml`              | Multi-platform build & push          |
-| **Release**    | Release (Helm)                     | `release.yml`            | `release-helm.yml`                | Helm chart publish                   |
-| **Release**    | Release (NPM)                      | `release.yml`            | `release-npm.yml`                 | NPM publish with provenance          |
-| **Security**   | SAST (Public)                      | `security.yml`           | `security-code.yml`               | CodeQL multi-language                |
-| **Security**   | Config Security                    | `security.yml`           | `security-config.yml`             | Terraform, Kubernetes, Ansible       |
-| **Security**   | Dependency Security                | `security.yml`           | `security-deps.yml`               | Go, JS/TS, Python + licenses         |
-| **Security**   | Secret Detection                   | `security.yml`           | `security-secrets.yml`            | Gitleaks, TruffleHog                 |
-| **Security**   | Container Security                 | `security.yml`           | `security-containers.yml`         | Trivy, Grype                         |
-| **Security**   | Supply Chain                       | `security.yml`           | `security-supply-chain.yml`       | SBOM, Cosign signing                 |
-| **Operations** | Drift Detection                    | `drift.yml`              | `ops-drift-detection.yml`         | Terraform drift detection            |
-| **Operations** | Orchestration                      | -                        | `ops-terraform-orchestration.yml` | Multi-environment                    |
-| **Operations** | Secret Sync                        | -                        | `ops-sync-secrets.yml`            | Bitwarden to CF Workers              |
-| **Docs**       | Terraform Docs                     | `docs.yml`               | `docs-terraform.yml`              | Auto-generate TF docs                |
-| **AI**         | Code Review (Private)              | `claude-code-review.yml` | `ai-claude-review.yml`            | AI code review                       |
-| **AI**         | Assistant (Private)                | `claude.yml`             | `ai-claude.yml`                   | On-demand @claude                    |
-
-**Workflow Consolidation Strategy:**
-
-All workflows are now centralized as reusable workflows in `sbaerlocher/.github/.github/workflows/`:
-
-- **Single Source of Truth**: One workflow definition, used by all projects
-- **Consistent Behavior**: All projects get the same CI/CD experience
-- **Easy Updates**: Fix once, benefits all repositories
-- **Reduced Maintenance**: No need to update workflows in each project individually
-
-**Key Benefits:**
-
-1. **JavaScript CI**: Consolidated 3 workflows (quality, test, security) into 1 all-in-one workflow
-2. **Security**: Multi-language support (Go + JS + Python in one workflow)
-3. **Defense-in-Depth**: Multiple scanners (Trivy + Grype, Gitleaks + TruffleHog)
-4. **Supply Chain Security**: SBOM generation and Cosign signing built-in
-
-**Usage Pattern** (call centralized workflows):
-
-```yaml
-# .github/workflows/ci.yml
-name: Continuous Integration
-on:
-  pull_request:
-  workflow_call:
-
-jobs:
-  terraform:
-    uses: sbaerlocher/.github/.github/workflows/ci-terraform.yml@2026-02-14
-    with:
-      terraform-version: '1.14.3'
-```
-
-**Complete Example** (Terraform Repository):
-
-```yaml
-# .github/workflows/ci.yml
-name: Continuous Integration
-on:
-  pull_request:
-  workflow_call:
-
-jobs:
-  terraform:
-    uses: sbaerlocher/.github/.github/workflows/ci-terraform.yml@2026-02-14
-    with:
-      terraform-version: '1.14.3'
-
-# .github/workflows/deploy.yml
-name: Deploy
-on:
-  push:
-    branches: [main]
-
-jobs:
-  ci:
-    uses: ./.github/workflows/ci.yml
-
-  deploy:
-    needs: ci
-    uses: sbaerlocher/.github/.github/workflows/deploy-terraform.yml@2026-02-14
-    with:
-      terraform-version: '1.14.3'
-      environment: 'production'
-    secrets:
-      BW_ACCESS_TOKEN: ${{ secrets.BW_ACCESS_TOKEN }}
-
-# .github/workflows/security.yml
-name: Security Scan
-on:
-  schedule:
-    - cron: '0 2 * * 1'  # Weekly Monday 02:00 UTC
-  workflow_dispatch:
-
-jobs:
-  config-scan:
-    uses: sbaerlocher/.github/.github/workflows/security-config.yml@2026-02-14
-    with:
-      scan-terraform: true
-
-  secret-scan:
-    uses: sbaerlocher/.github/.github/workflows/security-secrets.yml@2026-02-14
-
-  dependency-scan:
-    uses: sbaerlocher/.github/.github/workflows/security-deps.yml@2026-02-14
-    with:
-      language: 'go'
-```
-
-**Schedule Frequency:**
-
-Scheduled workflows should run **weekly** (not daily) to minimize unnecessary workflow runs:
-
-```yaml
-schedule:
-  - cron: '0 6 * * 1' # Weekly Monday 06:00 UTC
-```
-
-Common schedules:
-
-- `drift.yml`: Monday 06:00 UTC
-- `security.yml`: Monday 02:00 UTC
-
-**Workflow Trigger Strategy (Avoid Duplicate Runs):**
-
-To prevent workflows from running twice on the same code (once on PR, once on merge to main), use this pattern:
-
-```yaml
-# ✅ ci.yml - Only on PR and workflow_call
+# ci.yml — on PR only, and when called by other workflows
 on:
   pull_request:
     branches: [main]
   workflow_call:
 
-# ✅ deploy.yml - Only on push to main, calls ci.yml
+# deploy.yml — on push to main, calls ci.yml internally
 on:
   push:
     branches: [main]
   workflow_dispatch:
-
-jobs:
-  ci:
-    name: Continuous Integration
-    uses: ./.github/workflows/ci.yml
-
-  deploy:
-    name: Deploy
-    needs: ci
-    runs-on: ubuntu-latest
-    # ... deployment steps
 ```
 
-**Benefits:**
+This ensures CI runs once on PR and once on merge (as part of deploy) — not twice on main.
 
-- CI runs once on PR (validation)
-- Deploy runs once on merge (includes CI + deployment)
-- No duplicate test/lint runs on main branch
-- Cleaner workflow history
+### Scheduled Workflows
 
-**Anti-Pattern (Avoid):**
+Run weekly, not daily: `cron: '0 6 * * 1'` (Monday 06:00 UTC).
 
-```yaml
-# ❌ WRONG - Runs twice (PR + push to main)
-on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
-```
+Never add `security.yml` or `drift.yml` as required status checks — they run on schedule,
+not on PRs, and would block every merge.
 
-**ci.yml Structure:**
+### AI Workflows (Private Repos Only)
 
-See [.github/workflows/ci.yml](./workflows/ci.yml)
-
-**Benefits:**
-
-- `workflow_call` enables reuse by other workflows
-- `quality` and `test` run in parallel
-- `build` only after both are green
-- `format:check` validates formatting before other checks
-- Faster feedback on failures
-
-**By Repo Type:**
-
-| Repo Type                | Required                               | Optional                | Notes                                                 |
-| ------------------------ | -------------------------------------- | ----------------------- | ----------------------------------------------------- |
-| **Software Projects**    | `ci.yml`, `release.yml`                | -                       | Produce releasable artifacts (Docker, Helm, Binaries) |
-| **Infrastructure (IaC)** | `ci.yml`, `deploy.yml`, `security.yml` | `drift.yml`, `docs.yml` | Terraform IaC                                         |
-| **GitOps**               | `ci.yml`, `deploy.yml`                 | -                       | Kubernetes via Fleet                                  |
-| **Packages**             | `ci.yml`, `release.yml`                | -                       | NPM, Go, Python packages                              |
-| **Serverless**           | `ci.yml`, `deploy.yml`                 | -                       | Cloudflare Workers                                    |
-
-**Workflow Distinction:**
-
-Software projects (like `tsmetrics`, `functions`) **release** artifacts - they use `release.yml`:
-
-- Docker images pushed to registry
-- Helm charts published to OCI registry
-- Binaries released via GoReleaser
-- Semantic versioning (v1.2.3)
-- Triggered by git tags
-
-Infrastructure projects (like `authentication`, `observability`) **deploy** infrastructure - they use `deploy.yml`:
-
-- Terraform plan & apply
-- Environment-based (dev, staging, prod)
-- State-based (no versioned releases)
-- Triggered by pushes to main or manual dispatch
-
-**Notes**:
-
-- **ci.yml**: All validation (YAML, Fleet, Terraform, Helm, Kubernetes manifests, tests)
-  - Software: tests, linting, type-checking, security scans (gosec, govulncheck, trivy)
-  - GitOps: yamllint, Fleet validation, Helm lint, kubeconform
-  - IaC: yamllint, terraform fmt/validate, tflint
-- **build.yml**: Build artifacts for testing (Software projects only)
-  - Single-platform Docker build (linux/amd64)
-  - Helm chart validation with Kind
-  - Container structure tests
-  - Not pushed to registry (test only)
-- **release.yml**: Release artifacts (Software projects only)
-  - Multi-platform Docker build (linux/amd64, linux/arm64)
-  - Push to container registry
-  - Publish Helm chart to OCI
-  - Create GitHub Release with binaries
-- **deploy.yml**: Deploy infrastructure (Infrastructure/GitOps projects only)
-  - Terraform: plan & apply
-  - GitOps: Fleet sync verification
-- **drift.yml**: Scheduled drift detection for Terraform (optional)
-- **security.yml**: Comprehensive security scanning (PR + scheduled + manual)
-  - **Code Analysis**: Calls `security-code.yml` (CodeQL multi-language SAST - required for public repos)
-  - **IaC/GitOps**: Calls `security-config.yml` (Terraform/K8s/Ansible security)
-  - **All repos**: Calls `security-secrets.yml` (Gitleaks + TruffleHog)
-  - **With dependencies**: Calls `security-deps.yml` (Language-specific: Go, JS/TS, Python)
-  - **Strategy**: CodeQL runs on PR for fast feedback, deep scans run weekly
-
-**Security Scanning Output:**
-
-- **Public Repos**: SARIF upload to GitHub Security tab (free)
-- **Private Repos**:
-  - Artifact upload (JSON/Table format)
-  - SARIF upload requires GitHub Advanced Security license
-  - Use `exit-code: 0` for non-blocking scans
-
-**Additionally for all repos**:
-
-- **Public Repos**: `security.yml` with CodeQL job (Required)
-- **Private Repos**: `claude.yml` + `claude-code-review.yml` (Recommended)
-
-### Claude GitHub Actions (Private Repos)
-
-Two workflows for AI-assisted development:
-
-**1. claude-code-review.yml - Automatic Code Review**
-
-See [.github/workflows/claude-code-review.yml](./workflows/claude-code-review.yml)
-
-**2. claude.yml - On-Demand @claude Mentions**
-
-See [.github/workflows/claude.yml](./workflows/claude.yml)
-
-**Setup:**
-
-1. OAuth Token: <https://console.anthropic.com>
-2. Secret: Repository → Settings → Secrets → `CLAUDE_CODE_OAUTH_TOKEN`
-
-**Why Private Repos Only?**
-
-- OAuth Token is personal/paid
-- On public repos anyone could trigger `@claude`
-
-### Testing & Coverage
-
-**Test Framework:** Vitest (for JS/TS projects)
-
-**package.json Scripts:**
-
-```json
-{
-  "scripts": {
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
-  }
-}
-```
-
-**vitest.config.ts:**
-
-See [templates/vitest.config.ts](https://github.com/sbaerlocher/sbaerlocher/tree/main/templates/vitest.config.ts)
-
-**Dependencies:**
-
-```json
-{
-  "devDependencies": {
-    "vitest": "^3.0.0",
-    "@vitest/coverage-v8": "^3.0.0"
-  }
-}
-```
-
-**Codecov:** Coverage upload in CI with `codecov/codecov-action`.
-
-### Renovate Configuration
-
-Shared presets in root can be extended by other repos.
-
-**Available Presets:**
-
-| Preset               | Extends | Use For                 |
-| -------------------- | ------- | ----------------------- |
-| `renovate-base`      | -       | All repos (base config) |
-| `renovate-js`        | base    | JS/TS projects          |
-| `renovate-terraform` | base    | Terraform/IaC           |
-| `renovate-gitops`    | base    | GitOps/Helm             |
-
-**Usage in your repo's `.github/renovate.json`:**
-
-```json
-{
-  "extends": ["github>sbaerlocher/.github:renovate/renovate-base"]
-}
-```
-
-Or for JS/TS projects:
-
-```json
-{
-  "extends": ["github>sbaerlocher/.github:renovate/renovate-js"]
-}
-```
-
-See [templates/](https://github.com/sbaerlocher/sbaerlocher/tree/main/templates/) for copy-paste examples.
-
-**Project → Preset Mapping:**
-
-| Project          | Preset               | Reason                        |
-| ---------------- | -------------------- | ----------------------------- |
-| `applications`   | `renovate-gitops`    | Fleet/Helm GitOps             |
-| `authentication` | `renovate-terraform` | Terraform/IaC                 |
-| `infrastructure` | `renovate-gitops`    | Terraform + Ansible + K8s     |
-| `observability`  | `renovate-terraform` | Terraform/IaC                 |
-| `functions`      | `renovate-js`        | TypeScript/Cloudflare Workers |
-| `sbaerlocher.ch` | `renovate-js`        | Astro/TypeScript              |
-| `sbaerlo.ch`     | `renovate-js`        | Astro/TypeScript              |
-| `vue.aareguru`   | `renovate-js`        | Vue/TypeScript                |
-| `dotfiles`       | `renovate-base`      | Nix + GitHub Actions          |
-| `helm-chart`     | `renovate-gitops`    | Helm Charts                   |
-| `savvy`          | `renovate-base`      | Go                            |
-| `tsmetrics`      | `renovate-base`      | Go                            |
-| `loyalty-system` | `renovate-base`      | Go                            |
-
-**Anti-Pattern (Never Do):**
-
-```json
-// ❌ WRONG - Duplicates base config inline instead of extending preset
-{
-  "extends": ["config:recommended", ":semanticCommits"],
-  "schedule": ["before 6am on Monday"],
-  "timezone": "Europe/Zurich",
-  "labels": ["dependencies"],
-  "prConcurrentLimit": 5
-}
-
-// ✅ CORRECT - Extend shared preset, only add project-specific rules
-{
-  "extends": ["github>sbaerlocher/.github:renovate/renovate-js"],
-  "packageRules": [
-    { "groupName": "astro", "matchPackageNames": ["/^astro/", "/^@astrojs/"] }
-  ]
-}
-```
-
-**Note:** `lockFileMaintenance` is disabled by default. Normal dependency updates and `vulnerabilityAlerts` already cover transitive dependencies.
-
-### Extended Documentation (Larger Projects)
-
-For more complex projects additionally:
-
-| File                 | Purpose                                | When                                             |
-| -------------------- | -------------------------------------- | ------------------------------------------------ |
-| `README.md`          | Project overview, setup basics         | All repos - keep minimal, avoid excessive detail |
-| `ARCHITECTURE.md`    | System design, components, decisions   | Infrastructure, monorepos                        |
-| `OPERATIONS.md`      | Runbooks, troubleshooting, maintenance | Production services                              |
-| `DEPLOYMENT.md`      | Deploy process, environments           | When more complex than 1 command                 |
-| `.github/SECRETS.md` | Secrets documentation                  | **Required** when repo uses any secrets          |
-
-**Naming:** Uppercase, English.
-
-**ARCHITECTURE.md Content:** (from architect perspective)
-
-- System overview (Mermaid diagram)
-- Components and interfaces
-- Tradeoffs and limitations
-- Security concept
-
-**OPERATIONS.md Content:**
-
-- Monitoring & Alerts
-- Troubleshooting guide
-- Maintenance tasks
-- Incident response
-
-**.github/SECRETS.md Content:**
-
-- Secret naming schema
-- Architecture diagram (how secrets flow)
-- GitHub repository secrets
-- External secret store references (Bitwarden, Vault, etc.)
-- Setup instructions
-- Rotation checklist
-- Troubleshooting
-
-### CONTRIBUTING.md
-
-| Repo Type   | Required                                          |
-| ----------- | ------------------------------------------------- |
-| **Public**  | Yes (open source)                                 |
-| **Private** | Only for team projects with external contributors |
-
-### CODE_OF_CONDUCT.md
-
-Only for public community projects. For personal repos: Not needed.
+- `ai-claude-review.yml`: Automatic code review on PRs — reads `REVIEW.md` as context
+- `ai-claude.yml`: On-demand via `@claude` mentions in issues/PRs
+- Required secret: `CLAUDE_CODE_OAUTH_TOKEN` (from Anthropic Console)
 
 ---
 
-## What Does NOT Belong in Every Repo
+## Renovate
 
-| File               | Reason                                         |
-| ------------------ | ---------------------------------------------- |
-| docs/ folder       | README is usually enough, no separate doc site |
-| SECURITY.md        | Only for public packages                       |
-| Issue/PR Templates | Overkill for personal repos                    |
+Shared presets in `sbaerlocher/.github`. Each repo extends exactly one:
 
----
-
-## Formatter by Language
-
-| Language  | Formatter     | Config File      |
-| --------- | ------------- | ---------------- |
-| JS/TS     | Prettier      | `.prettierrc`    |
-| Go        | gofmt         | - (built-in)     |
-| Terraform | terraform fmt | - (built-in)     |
-| Python    | Black/Ruff    | `pyproject.toml` |
-| YAML      | Prettier      | `.prettierrc`    |
-
-Only add when the language is used in the repo.
-
-### Prettier Configuration (JS/TS)
-
-**.prettierrc:**
-
-See [templates/.prettierrc](https://github.com/sbaerlocher/sbaerlocher/tree/main/templates/.prettierrc)
-
-**.prettierignore:**
-
-See [templates/.prettierignore](https://github.com/sbaerlocher/sbaerlocher/tree/main/templates/.prettierignore)
-
-**package.json Scripts:**
+| Repo type       | Preset               |
+| --------------- | -------------------- |
+| JS/TS           | `renovate-js`        |
+| Terraform/IaC   | `renovate-terraform` |
+| GitOps/Helm     | `renovate-gitops`    |
+| Everything else | `renovate-base`      |
 
 ```json
-{
-  "scripts": {
-    "format": "prettier --write .",
-    "format:check": "prettier --check ."
-  }
-}
+{ "extends": ["github>sbaerlocher/.github:renovate/renovate-base"] }
 ```
 
-**Dependencies:**
-
-```json
-{
-  "devDependencies": {
-    "prettier": "^3.0.0",
-    "prettier-plugin-astro": "^0.14.0",
-    "prettier-plugin-svelte": "^3.0.0"
-  }
-}
-```
-
-Add plugins as needed per framework (astro, svelte, tailwind, etc.).
-
-### YAML Linting
-
-**Configuration**: `.yamllint.yml`
-
-```yaml
-extends: default
-
-rules:
-  line-length:
-    max: 120
-    level: warning
-  indentation:
-    spaces: 2
-  comments:
-    min-spaces-from-content: 1
-```
-
-**Usage**:
-
-```bash
-# Lint all YAML files
-yamllint .
-
-# Lint specific file
-yamllint file.yaml
-
-# Fix automatically (where possible)
-yamllint --strict .
-```
-
-### Markdown Linting
-
-**Configuration**: `.markdownlint.yml`
-
-```yaml
-# Extend default ruleset
-default: true
-
-# Line length
-MD013:
-  line_length: 120
-  code_blocks: false
-  tables: false
-
-# Inline HTML
-MD033: false
-
-# Multiple headings with same content
-MD024:
-  siblings_only: true
-```
-
-**Usage**:
-
-```bash
-# Lint all markdown files
-markdownlint '**/*.md'
-
-# Lint specific file
-markdownlint README.md
-
-# Fix automatically
-markdownlint --fix '**/*.md'
-```
-
-**Common Rules**:
-
-- MD001: Heading levels increment by one
-- MD013: Line length (120 characters)
-- MD024: Multiple headings with same content
-- MD025: Single title/H1 per document
-- MD040: Fenced code blocks should have language
+Project-specific rules go in `packageRules` — never duplicate base config inline.
 
 ---
 
 ## Git Standards
 
-### Commit Convention
-
-**Format:** Conventional Commits with Claude Code signature
+### Commit Format
 
 ```text
 <type>(<scope>): <subject>
 
 <body>
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
 ```
 
-**Types:**
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`
 
-| Type       | Usage              | Description                                                      |
-| ---------- | ------------------ | ---------------------------------------------------------------- |
-| `feat`     | New features       | A new feature for the user                                       |
-| `fix`      | Bug fixes          | A bug fix for the user                                           |
-| `docs`     | Documentation      | Documentation only changes                                       |
-| `style`    | Formatting         | Changes that don't affect code meaning (white-space, formatting) |
-| `refactor` | Code restructuring | Code change that neither fixes a bug nor adds a feature          |
-| `perf`     | Performance        | Code change that improves performance                            |
-| `test`     | Tests              | Adding missing tests or correcting existing tests                |
-| `chore`    | Maintenance        | Changes to build process, dependencies, tooling                  |
-| `ci`       | CI/CD              | Changes to CI configuration files and scripts                    |
-
-**Scopes:**
-
-Project-specific, examples:
-
-- `infrastructure/platform` - Platform provisioning
-- `functions/github-stats` - GitHub Stats function
-- `applications/authentik` - Authentik service
-
-**Examples:**
-
-```text
-feat(functions): add GitHub SVG generator endpoint
-
-Implemented new endpoint to generate SVG badges for GitHub stats.
-Includes caching and error handling.
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-```
-
-```text
-fix(infrastructure): correct CPU normalization for Fleet
-
-Changed CPU limits from "1000m" to "1" format to prevent
-Fleet Modified status.
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-```
+Scopes are project-specific, e.g. `infrastructure/platform`, `functions/github-stats`.
 
 ### Branch Strategy
 
-**Main Branch:** `main` (preferred) or `master`
+| Repo Type              | Strategy                      |
+| ---------------------- | ----------------------------- |
+| GitOps, Infrastructure | Direct to main (CI must pass) |
+| Applications, Packages | Feature branches + PRs        |
 
-**Strategy by Project Type:**
+Feature branch format: `<type>/<short-description>` (e.g. `feat/user-auth`)
 
-| Project Type       | Strategy         | Description                                              |
-| ------------------ | ---------------- | -------------------------------------------------------- |
-| **GitOps**         | Direct to main   | No feature branches, all changes direct after validation |
-| **Infrastructure** | Direct to main   | Fast deployment, CI/CD validation                        |
-| **Applications**   | Feature branches | Use feature branches for complex changes                 |
-| **Packages**       | Feature branches | Always use PRs for version-controlled releases           |
-
-**Direct-to-Main Requirements:**
-
-- CI/CD validation pipeline must pass
-- Auto-rollback on failure (GitOps)
-
-**Feature Branch Naming:**
-
-```text
-<type>/<short-description>
-
-Examples:
-- feat/user-authentication
-- fix/memory-leak
-- chore/update-dependencies
-```
-
-**Tags/Releases:**
-
-- Semantic Versioning: `v1.2.3`
-- Annotated tags: `git tag -a v1.2.3 -m "Release 1.2.3"`
-- Packages: Automated via `release.yml` workflow
+Tags: semantic versioning `v1.2.3`, annotated (`git tag -a v1.2.3 -m "Release 1.2.3"`).
 
 ---
 
-## GitHub Repository Configuration
+## GitHub Repository Settings
 
-All repositories must be configured consistently. Use the `gh` CLI or GitHub API to apply settings
-programmatically.
+| Setting                | Value         | Reason                                             |
+| ---------------------- | ------------- | -------------------------------------------------- |
+| Squash merge           | Yes (default) | Clean, linear commit history                       |
+| Merge commits          | No            | Squash preferred                                   |
+| Rebase merge           | No            | Squash preferred                                   |
+| Delete branch on merge | Yes           | Keeps branch list clean                            |
+| Auto-merge             | Enabled       | Required for Renovate auto-merge                   |
+| GITHUB_TOKEN default   | Read-only     | Workflows declare write permissions explicitly     |
+| Required status check  | `ci`          | Only if repo has `pull_request`-triggered workflow |
 
-### General Repository Settings
-
-```bash
-gh repo edit {owner}/{repo} \
-  --delete-branch-on-merge \
-  --enable-squash-merge \
-  --enable-auto-merge
-
-# gh repo edit has no --disable flags for merge types — use the API directly
-gh api repos/{owner}/{repo} --method PATCH \
-  --field allow_merge_commit=false \
-  --field allow_rebase_merge=false
-```
-
-| Setting                | Value         | Reason                                   |
-| ---------------------- | ------------- | ---------------------------------------- |
-| Delete branch on merge | Yes           | Keeps branch list clean                  |
-| Squash merge           | Yes (default) | Clean, linear commit history             |
-| Merge commits          | No            | Squash preferred                         |
-| Rebase merge           | No            | Squash preferred                         |
-| Auto-merge             | Enabled       | Required for Renovate auto-merge to work |
-
-**Exception:** GitOps/Infrastructure repos (`applications`, `infrastructure`) may prefer rebase merge
-to preserve individual commit messages for auditability.
-
----
-
-### GITHUB_TOKEN Default Permissions
-
-**Set repository-level default to read-only.** Workflows must explicitly request write permissions.
-This limits blast radius if a workflow is compromised.
-
-```bash
-gh api repos/{owner}/{repo} --method PATCH \
-  --field default_workflow_permissions=read \
-  --field can_approve_pull_request_reviews=false
-```
-
-Workflows that need write access declare it explicitly:
-
-```yaml
-permissions:
-  contents: write # only if needed (e.g. release)
-  pull-requests: write # only if needed (e.g. claude-code-review)
-```
-
-**Anti-pattern (avoid):**
-
-```yaml
-# ❌ WRONG — grants full write to all resources
-permissions: write-all
-```
-
----
-
-### Branch Protection — Repository Rulesets
-
-Use **Repository Rulesets** (modern replacement for classic branch protection rules).
-
-**Required rules for the `main` branch:**
-
-| Rule                                | Setting                 | Reason                                |
-| ----------------------------------- | ----------------------- | ------------------------------------- |
-| Restrict deletions                  | Block                   | Protect main from accidental deletion |
-| Block force pushes                  | Block                   | Protect commit history                |
-| Require pull request before merging | Yes                     | All changes via PR                    |
-| Required approving reviews          | 0 (personal) / 1 (team) | Flexible per project                  |
-| Dismiss stale reviews on push       | Yes (team repos)        | Re-review after new commits           |
-| Require status checks to pass       | Yes                     | CI must be green before merge         |
-| Require branches to be up to date   | Yes                     | No merges on stale branches           |
-
-**Bypass actors:** By default no bypass list — admins are also bound by the ruleset. Add bypass
-actors only when automation requires it (e.g. release bots), and document the reason.
-
-**Configure via `gh` CLI (personal repo):**
-
-```bash
-gh api repos/{owner}/{repo}/rulesets --method POST --input - <<'EOF'
-{
-  "name": "main-branch-protection",
-  "target": "branch",
-  "enforcement": "active",
-  "bypass_actors": [],
-  "conditions": {
-    "ref_name": {
-      "include": ["refs/heads/main"],
-      "exclude": []
-    }
-  },
-  "rules": [
-    { "type": "deletion" },
-    { "type": "non_fast_forward" },
-    {
-      "type": "pull_request",
-      "parameters": {
-        "required_approving_review_count": 0,
-        "dismiss_stale_reviews_on_push": false,
-        "require_code_owner_review": false,
-        "require_last_push_approval": false,
-        "required_review_thread_resolution": false
-      }
-    },
-    {
-      "type": "required_status_checks",
-      "parameters": {
-        "strict_required_status_checks_policy": true,
-        "required_status_checks": [
-          { "context": "ci" }
-        ]
-      }
-    }
-  ]
-}
-EOF
-```
-
-**For team repos** (set `required_approving_review_count: 1` and `dismiss_stale_reviews_on_push:
-true`):
-
-```json
-{
-  "type": "pull_request",
-  "parameters": {
-    "required_approving_review_count": 1,
-    "dismiss_stale_reviews_on_push": true,
-    "require_code_owner_review": true,
-    "require_last_push_approval": false,
-    "required_review_thread_resolution": true
-  }
-}
-```
-
----
-
-### Required Status Check Context Format
-
-The `context` value must **exactly** match the string GitHub shows in the Check Suite. The format
-depends on how the workflow is called:
-
-| Workflow type     | Context format         | Example              |
-| ----------------- | ---------------------- | -------------------- |
-| Direct job        | `<job-id>`             | `ci`                 |
-| Reusable workflow | `<caller-job> / <job>` | `ci / terraform`     |
-| Matrix job        | `<job-id> (<matrix>)`  | `ci (ubuntu-latest)` |
-
-**Verify the exact string** by opening a PR and checking the "Checks" tab before adding it as a
-required check.
-
-**Required checks by repo type:**
-
-| Repo Type                 | Required Checks | Notes                                    |
-| ------------------------- | --------------- | ---------------------------------------- |
-| Software / Packages       | `ci`            | Has `ci.yml` with `pull_request` trigger |
-| Infrastructure (IaC)      | `ci`            | Has `ci.yml` with `pull_request` trigger |
-| GitOps                    | `ci`            | Has `ci.yml` with `pull_request` trigger |
-| Reusable workflow library | —               | No PR-triggered workflow → omit the rule |
-
-**Only add `required_status_checks` if the repo has a workflow with a direct `pull_request`
-trigger.** Repos that only contain `workflow_call` workflows (e.g. `.github`) must omit this rule —
-the check would never run and block every PR.
-
-**Never add as required checks:**
-
-- `security` — runs on weekly schedule, would block all PRs
-- `drift` — runs on weekly schedule, would block all PRs
-
----
-
-### Full Setup Script
-
-For consistent setup when creating a new repository:
-
-```bash
-#!/usr/bin/env bash
-# Usage: ./scripts/setup-repo.sh <owner/repo>
-set -euo pipefail
-
-REPO=$1
-
-# General settings
-gh repo edit "$REPO" \
-  --delete-branch-on-merge \
-  --enable-squash-merge \
-  --enable-auto-merge
-
-gh api "repos/$REPO" --method PATCH \
-  --field allow_merge_commit=false \
-  --field allow_rebase_merge=false
-
-# GITHUB_TOKEN: read-only by default
-gh api "repos/$REPO" --method PATCH \
-  --field default_workflow_permissions=read \
-  --field can_approve_pull_request_reviews=false
-
-# Branch ruleset
-gh api "repos/$REPO/rulesets" --method POST --input - <<'EOF'
-{
-  "name": "main-branch-protection",
-  "target": "branch",
-  "enforcement": "active",
-  "bypass_actors": [],
-  "conditions": {
-    "ref_name": {
-      "include": ["refs/heads/main"],
-      "exclude": []
-    }
-  },
-  "rules": [
-    { "type": "deletion" },
-    { "type": "non_fast_forward" },
-    {
-      "type": "pull_request",
-      "parameters": {
-        "required_approving_review_count": 0,
-        "dismiss_stale_reviews_on_push": false,
-        "require_code_owner_review": false,
-        "require_last_push_approval": false,
-        "required_review_thread_resolution": false
-      }
-    },
-    {
-      "type": "required_status_checks",
-      "parameters": {
-        "strict_required_status_checks_policy": true,
-        "required_status_checks": [
-          { "context": "ci" }
-        ]
-      }
-    }
-  ]
-}
-EOF
-```
+See [SETUP.md](./SETUP.md) for the full setup script and branch ruleset commands.
 
 ---
 
 ## Secret Management
 
-**CRITICAL**: Secrets must NEVER be committed to Git.
+**Never commit**: `.env` files, credentials, API keys, `.tfvars` with secrets, SSH keys,
+Kubernetes secrets in YAML.
 
-### Prohibited Patterns
+| Environment        | Method                                     |
+| ------------------ | ------------------------------------------ |
+| Kubernetes         | External Secrets Operator + Bitwarden      |
+| CI/CD              | GitHub Repository Secrets                  |
+| Cloudflare Workers | `wrangler secret put <NAME>`               |
+| Local dev          | `.env.local` (gitignored, never committed) |
 
-**NEVER commit**:
-
-- `.env` files with secrets
-- `credentials.json`
-- API keys in code
-- Terraform `.tfvars` with secrets
-- Kubernetes secrets in YAML
-- SSH keys, certificates
-- Database passwords
-
-### Approved Secret Storage
-
-| Environment            | Method                    | Usage                         |
-| ---------------------- | ------------------------- | ----------------------------- |
-| **Kubernetes**         | External Secrets Operator | All K8s secrets via Bitwarden |
-| **CI/CD**              | GitHub Repository Secrets | Workflow secrets              |
-| **Cloudflare Workers** | Wrangler Secrets          | `wrangler secret put <NAME>`  |
-| **Local Development**  | `.env.local` (gitignored) | Never committed               |
-
-### External Secrets Operator Pattern
-
-**For Kubernetes services**:
-
-```yaml
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: service-credentials
-  namespace: service
-spec:
-  refreshInterval: 15m
-  secretStoreRef:
-    name: bitwarden-secretstore
-    kind: ClusterSecretStore
-  target:
-    name: service-secret
-    creationPolicy: Owner
-  data:
-    - secretKey: password
-      remoteRef:
-        key: <bitwarden-item-id>
-        property: password
-```
-
-### Secret Naming Schema
-
-**Standard across all repositories** (Bitwarden Secrets Manager):
-
-```text
-<Project> | <Service/Component> | <Verwendungsort/Scope> | <Permission> | <Type>
-```
-
-**Field Descriptions:**
-
-- **Project**: Main project using this secret (e.g., `Functions`, `Infrastructure`, `Authentication`, `OpenArchiver`)
-- **Service/Component**: External service or component (e.g., `GitHub API`, `Cloudflare DNS`, `Storj S3`)
-- **Verwendungsort/Scope**: Where the secret is used (e.g., `nuvulus-cluster`, `sbaerlocher/functions`, `uptime-service`)
-- **Permission**: Permission level (e.g., `read-only`, `read-write`, `admin`, `confidential`)
-- **Type**: Credential type (e.g., `API Token`, `Access Key`, `Secret Key`, `Client Secret`)
-
-**Important**: Not all fields are required for every secret. Field count is flexible, but order must be consistent.
-
-**Examples:**
-
-```text
-# GitOps/Kubernetes
-Infrastructure | Hetzner Cloud | nuvulus-cluster | read-write | API Token
-Database | PostgreSQL | nuvulus-cluster | superuser | Password
-OpenArchiver | Storj S3 | storage | read-write | Access Key
-
-# Cloudflare Workers
-Functions | Cloudflare Workers Deploy | sbaerlocher/functions | edit | API Token
-Functions | GitHub API | sbaerlocher/functions repository | read-only | Personal Access Token
-Functions | Grafana Synthetic Monitoring | uptime-service | read | API Token
-
-# Terraform
-Terraform | Cloudflare R2 | all-projects | read-write | Access Key ID
-Authentication | Authentik API | terraform | admin | API Token
-```
-
-### Secret Scanning
-
-**Automated Detection**:
-
-- **CI/CD**: gitleaks action in workflows
-- **GitHub**: Secret scanning alerts (public repos)
-
-**gitleaks Configuration**:
-
-See [templates/.gitleaks.toml](https://github.com/sbaerlocher/sbaerlocher/tree/main/templates/.gitleaks.toml)
-
-### .gitignore for Secrets
-
-**Required entries**:
-
-```gitignore
-# Secrets
-.env
-.env.local
-.env.*.local
-*.pem
-*.key
-*.crt
-credentials.json
-secrets.yaml
-*-credentials.json
-
-# Terraform
-*.tfvars
-!example.tfvars
-terraform.tfstate
-terraform.tfstate.backup
-
-# Kubernetes
-kubeconfig
-*-secret.yaml
-!*-secret.example.yaml
-```
-
-### Secret Rotation
-
-**Regular rotation required for**:
-
-- Database passwords (quarterly)
-- API keys (semi-annually)
-- Certificates (before expiry)
-- Service account tokens (annually)
-
-**Process**:
-
-1. Generate new secret
-2. Update in secret store (Bitwarden)
-3. External Secrets refreshes automatically
-4. Verify services still functional
-5. Deactivate old secret
+Secret naming: `<Project> | <Service> | <Scope> | <Permission> | <Type>`
 
 ---
 
-## AI Agent Documentation
-
-AI instructions belong in a separate file, **not** in README.
-
-**Recommended Structure:**
-
-```text
-repository/
-├── AGENTS.md              # AI instructions (main file)
-├── CLAUDE.md              # Only import: @AGENTS.md
-├── .claude/
-│   ├── commands/          # Custom Slash Commands (optional)
-│   └── settings.local.json
-└── README.md              # Human-readable docs
-```
-
-**CLAUDE.md Content (minimal):**
-
-```markdown
-@AGENTS.md
-```
-
-**AGENTS.md Content:**
-
-- Project context for AI
-- Code conventions
-- Architecture overview
-- Important patterns
-- What AI should not do
-
-**Why this approach?**
-
-- AGENTS.md is the emerging standard (20,000+ repos)
-- Claude Code currently only supports CLAUDE.md
-- With `@AGENTS.md` import it works today
-- Future-proof when AGENTS.md is officially supported
-
-### .claude/commands/
-
-Custom Slash Commands for recurring tasks.
-
-**Standard Commands (all repos):**
-
-| Command          | File               | Description                                                    |
-| ---------------- | ------------------ | -------------------------------------------------------------- |
-| `/code-review`   | `code-review.md`   | Code review for file/folder                                    |
-| `/commit`        | `commit.md`        | Git commit with Conventional Commits                           |
-| `/quality-check` | `quality-check.md` | All checks before PR                                           |
-| `/actions-check` | `actions-check.md` | GitHub Actions best practices (SHA pinning, permissions, etc.) |
-
-**Templates**: See [templates/commands/](https://github.com/sbaerlocher/sbaerlocher/tree/main/templates/commands/) for copy-paste examples.
-
-**Project-specific Commands:**
-
-| Repo Type          | Commands                          |
-| ------------------ | --------------------------------- |
-| Terraform          | `tf-plan.md`, `tf-apply.md`       |
-| GitOps             | `fleet-check.md`, `helm-check.md` |
-| Cloudflare Workers | `deploy.md`, `new-service.md`     |
-| Packages           | `release.md`, `test.md`           |
-
-**Format:**
-
-```markdown
----
-description: Short description for /help
----
-
-Instructions for Claude...
-
-$ARGUMENTS = Parameters from user
-```
-
----
-
-## Kubernetes Resource Standards
-
-**For GitOps and Kubernetes projects**
-
-### Resource Limits & Requests
-
-**CRITICAL**: CPU values >= 1000m must use normalized string format
-
-### Size Classes
-
-Use standardized resource sizes:
-
-| Size       | CPU Requests | CPU Limits | Memory Requests | Memory Limits |
-| ---------- | ------------ | ---------- | --------------- | ------------- |
-| **Micro**  | 50m          | 250m       | 64Mi            | 256Mi         |
-| **Small**  | 100m         | 500m       | 128Mi           | 512Mi         |
-| **Medium** | 200m         | "1"        | 256Mi           | 1Gi           |
-| **Large**  | 500m         | "2"        | 512Mi           | 2Gi           |
-| **XLarge** | "1"          | "4"        | 1Gi             | 4Gi           |
-
-### CPU Normalization
-
-**Why**: Kubernetes normalizes CPU values internally, causing Fleet "Modified" status
-
-**Rules**:
-
-```yaml
-# ✅ CORRECT
-resources:
-  limits:
-    cpu: "1"      # >= 1000m use string format
-    cpu: "2"      # >= 1000m use string format
-    memory: 2Gi
-  requests:
-    cpu: 500m     # < 1000m can use millicores
-    memory: 512Mi
-
-# ❌ WRONG
-resources:
-  limits:
-    cpu: 1000m    # Will be normalized to "1" → Fleet drift!
-    cpu: 2000m    # Will be normalized to "2" → Fleet drift!
-```
-
-### Deployment Strategies
-
-**Resource-Constrained Clusters** (CPU >95%):
-
-```yaml
-spec:
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 0 # No extra pods during update
-      maxUnavailable: 1 # Old pod terminated first
-```
-
-**Standard Clusters** (CPU <90%):
-
-```yaml
-spec:
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1 # One extra pod during update
-      maxUnavailable: 0 # Zero downtime
-```
-
-### Service Assignments
-
-**By Service Type**:
-
-- **Large**: Databases (PostgreSQL), Ingress (Traefik)
-- **Medium**: External Secrets, Monitoring, Authentik, n8n
-- **Small**: Cert-Manager, Operators, External-DNS
-- **Micro**: Reflector, lightweight operators
-
-### Health Checks
-
-**Required for all services**:
-
-```yaml
-livenessProbe:
-  httpGet:
-    path: /health
-    port: 8080
-  initialDelaySeconds: 30
-  periodSeconds: 10
-  failureThreshold: 3
-
-readinessProbe:
-  httpGet:
-    path: /ready
-    port: 8080
-  initialDelaySeconds: 5
-  periodSeconds: 5
-  failureThreshold: 3
-```
-
----
-
-## Monitoring Standards
-
-**For services with metrics**
-
-### Grafana Alloy Annotations
-
-**Required for Prometheus scraping**:
-
-```yaml
-metadata:
-  annotations:
-    k8s.grafana.com/scrape: 'true'
-    k8s.grafana.com/metrics.portNumber: '9187'
-    k8s.grafana.com/metrics.path: '/metrics'
-    k8s.grafana.com/job: '<service-name>'
-    k8s.grafana.com/metrics.scrapeInterval: '60s' # Optional
-```
-
-### Common Metrics Ports
-
-| Service               | Port  | Path     | Key Metrics                            |
-| --------------------- | ----- | -------- | -------------------------------------- |
-| **External Secrets**  | 8080  | /metrics | `externalsecret_status_condition`      |
-| **Cert-Manager**      | 9402  | /metrics | `certmanager_certificate_ready_status` |
-| **PostgreSQL (CNPG)** | 9187  | /metrics | `cnpg_pg_database_size_bytes`          |
-| **Traefik**           | 9100  | /metrics | `traefik_service_requests_total`       |
-| **Alloy**             | 12345 | /metrics | `prometheus_target_scrapes_total`      |
-
-### Metrics Naming Convention
-
-**Format**: `<namespace>_<resource>_<metric>_<unit>`
-
-**Examples**:
-
-- `http_requests_total` (counter)
-- `http_request_duration_seconds` (histogram)
-- `database_connections_active` (gauge)
-- `cache_hits_total` (counter)
-
-### Alert Thresholds
-
-**Standard SLOs**:
-
-- **Availability**: 99.9% (max 43.8 min downtime/month)
-- **Latency (p95)**: < 500ms
-- **Error Rate**: < 1%
-- **Saturation**: < 80% CPU/Memory
-
----
-
-## Template for New Repos
-
-```text
-new-repo/
-├── .github/
-│   ├── CODEOWNERS
-│   └── renovate.json
-├── AGENTS.md
-├── CLAUDE.md
-├── .editorconfig
-├── .gitignore
-├── LICENSE                    # public repos only
-├── README.md
-└── [project files]
-```
-
-**CLAUDE.md:**
-
-```markdown
-@AGENTS.md
-```
-
-**AGENTS.md:**
-
-```markdown
-# Project Name
-
-## Context
-
-[What the project does, for AI]
-
-## Conventions
-
-[Code style, patterns]
-
-## Structure
-
-[Important folders/files]
-```
-
-**README.md:**
-
-```markdown
-# project-name
-
-What the project does (1 sentence).
-
-## Setup
-
-\`\`\`bash
-
-# Installation/start commands
-
-\`\`\`
-
-## License
-
-MIT
-```
-
----
-
-## Summary
-
-**Principles:**
-
-1. Less is more
-2. README is the main documentation
-3. LICENSE always included
-4. CHANGELOG only for releases
-5. Workflows only what's needed
-6. No template files that stay empty
+## Code Quality
+
+| Language  | Formatter     | Linter        | Config           |
+| --------- | ------------- | ------------- | ---------------- |
+| JS/TS     | Prettier      | ESLint        | `.prettierrc`    |
+| Go        | gofmt         | golangci-lint | —                |
+| Terraform | terraform fmt | tflint        | —                |
+| Python    | Black/Ruff    | Ruff          | `pyproject.toml` |
+| YAML      | Prettier      | yamllint      | `.yamllint.yml`  |
+
+Line length: 120 characters. Only add formatter config when the language is used in the repo.
+
+See [templates](https://github.com/sbaerlocher/sbaerlocher/tree/main/templates/) for
+`.prettierrc`, `.editorconfig`, `.yamllint.yml`, `.markdownlint.yml`, and `.gitleaks.toml`.


### PR DESCRIPTION
## Summary

- Add `REVIEW.md` as required file for all repositories — provides consistent review context for human and AI reviewers (`ai-claude-review.yml` reads it automatically)
- Rewrite `STANDARDS.md` from 1549 → ~280 lines: remove YAML examples, Kubernetes/Monitoring details, and `.claude/commands/` section; focus on rules only
- Add `SETUP.md` with GitHub repo setup script and branch ruleset commands (extracted from STANDARDS.md)
- Sync `AGENTS.md` workflow categories with actual files: remove deleted `ops-drift-detection.yml` / `ops-sync-secrets.yml`, add missing AI workflows section

## Changes

| File | Change |
| --- | --- |
| `REVIEW.md` | New — code review guidelines for this repo (reference implementation) |
| `STANDARDS.md` | Rewritten — focused, concise, agent-oriented |
| `SETUP.md` | New — GitHub setup commands and branch ruleset |
| `AGENTS.md` | Synced workflow tables, added AI section, fixed linting warnings |
| `CHANGELOG.md` | Updated |