### PR TITLE
fix(ai): add Task, Agent, Read, Glob, Grep to allowedTools

### DIFF
--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -42,7 +42,7 @@ jobs:
           claude_args: |
             --max-turns 30
             --model claude-opus-4-6
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git log:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Task,Agent,Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git log:*)"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- Add `Task`, `Agent`, `Read`, `Glob`, `Grep` to the `allowedTools` whitelist in `ai-claude-review.yml`

## Root cause

The `code-review` plugin from `anthropics/claude-code-plugins` launches **6+ parallel sub-agents** via the `Task`/`Agent` tool and reads CLAUDE.md files via `Read`/`Glob` for compliance checks. These tools were not in the `allowedTools` whitelist.

Result: 4 permission denials per run (visible in `permission_denials_count` in run logs). Claude fell back to a single-agent review, posted everything in a summary PR comment, and skipped the inline comment step entirely — because the sub-agent-based workflow never ran properly.

## Test plan

- [ ] Trigger a new run on an open PR and verify `permission_denials_count: 0` in the run logs
- [ ] Verify inline comments appear on the PR (not just a summary comment)