### PR TITLE
fix(ai): increase max-turns to 100 for sub-agent workflow

### DIFF
--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -40,7 +40,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           claude_args: |
-            --max-turns 30
+            --max-turns 100
             --model claude-opus-4-6
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Task,Agent,Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git log:*)"
           prompt: |


### PR DESCRIPTION
## Summary

- Increase `--max-turns` from `30` to `100` in `ai-claude-review.yml`

## Root cause

After PR #33 added `Task`/`Agent` to `allowedTools`, the code-review plugin now properly spawns 6+ parallel sub-agents (PR check, CLAUDE.md file search, PR summary, 4 parallel review agents, validation agents per issue). Each sub-agent consumes turns from the global turn budget.

With `--max-turns 30`, the run hit `error_max_turns` before the review could complete.

## Test plan

- [ ] Trigger a new run and verify it completes without `error_max_turns`
- [ ] Verify inline comments appear on the PR