### PR TITLE
feat(ci): add node-version input to ci-js workflow

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -132,8 +132,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: ${{ inputs.node-version != '' && inputs.node-version || '' }}
-          node-version-file: ${{ inputs.node-version == '' && inputs.node-version-file || '' }}
+          node-version: ${{ inputs.node-version }}
+          node-version-file: ${{ inputs.node-version-file }}
 
       - name: Setup pnpm
         if: inputs.package-manager == 'pnpm'
@@ -387,8 +387,8 @@ jobs:
         if: matrix.scanner == 'dependency-audit'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: ${{ inputs.node-version != '' && inputs.node-version || '' }}
-          node-version-file: ${{ inputs.node-version == '' && inputs.node-version-file || '' }}
+          node-version: ${{ inputs.node-version }}
+          node-version-file: ${{ inputs.node-version-file }}
 
       - name: Setup pnpm
         if: matrix.scanner == 'dependency-audit' && inputs.package-manager == 'pnpm'

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -8,10 +8,14 @@ on:
         type: string
         default: 'pnpm'
         description: 'Package manager to use (npm, pnpm, yarn, bun)'
+      node-version:
+        type: string
+        default: ''
+        description: 'Node.js version to use (overrides node-version-file when set)'
       node-version-file:
         type: string
         default: '.nvmrc'
-        description: 'Node version file path'
+        description: 'Node version file path (used when node-version is not set)'
       working-directory:
         type: string
         default: '.'
@@ -128,7 +132,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version-file: ${{ inputs.node-version-file }}
+          node-version: ${{ inputs.node-version != '' && inputs.node-version || '' }}
+          node-version-file: ${{ inputs.node-version == '' && inputs.node-version-file || '' }}
 
       - name: Setup pnpm
         if: inputs.package-manager == 'pnpm'
@@ -382,7 +387,8 @@ jobs:
         if: matrix.scanner == 'dependency-audit'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version-file: ${{ inputs.node-version-file }}
+          node-version: ${{ inputs.node-version != '' && inputs.node-version || '' }}
+          node-version-file: ${{ inputs.node-version == '' && inputs.node-version-file || '' }}
 
       - name: Setup pnpm
         if: matrix.scanner == 'dependency-audit' && inputs.package-manager == 'pnpm'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,27 @@ This is a rolling release - changes are deployed continuously to `main`.
   - Validates YAML syntax, Fleet bundle configuration, and Kubernetes manifests
   - Checks `fleet.yaml` presence, Helm chart structure, and HelmRelease CRD usage
   - Consolidates all GitOps CI checks that were previously implemented locally per consumer repo
+- **ci-js.yml**: Add `node-version` input for explicit Node.js version selection
+  - Callers can now pass a specific version (`node-version: '20'`) to enable matrix testing
+  - Falls back to `node-version-file` (`.nvmrc`) when not set — fully backwards compatible
+
+### Fixed
+
+- **ai-claude-review.yml**: Enable inline comments in code review (#32)
+  - Remove `track_progress: true` which forced single-comment mode
+  - Add `classify_inline_comments: 'false'` to post inline comments immediately
+- **ai-claude-review.yml**: Add `Task`, `Agent`, `Read`, `Glob`, `Grep` to `allowedTools` (#33)
+  - The `code-review` plugin spawns parallel sub-agents and reads CLAUDE.md files
+  - Missing tools caused 4 permission denials per run, preventing inline comment posting
+- **ai-claude-review.yml**: Increase `--max-turns` from 30 to 100 (#34)
+  - Sub-agent workflow requires significantly more turns than single-agent mode
+- **renovate-kubernetes.json**: Replace RE2-incompatible lookahead in Fleet Helm chart regex (#35)
+  - `(?:(?!repo:)[\s\S])*?` used a negative lookahead unsupported by RE2
+  - Replaced with RE2-safe alternation `(?:[^r]|r[^e]|re[^p]|rep[^o]|repo[^:])*?`
+  - Preserves cross-block boundary guard without requiring lookahead support
+- **SETUP.md**: Clarify branch ruleset status check context format (#36)
+  - GitHub uses the job `name:` field, not the job ID, for context strings
+  - Reusable workflows show as `caller job name / job name`, not `caller-job / job`
 
 ### Removed
 


### PR DESCRIPTION
## Summary

Add optional `node-version` input to `ci-js.yml` so callers can specify an explicit Node.js version. This enables matrix testing across multiple versions from the consumer side.

## Usage

```yaml
strategy:
  matrix:
    node: ['18', '20', '22']

jobs:
  ci:
    uses: sbaerlocher/.github/.github/workflows/ci-js.yml@v1
    with:
      node-version: ${{ matrix.node }}
```

## Backwards compatibility

When `node-version` is empty (the default), the workflow falls back to `node-version-file` (`.nvmrc`) — existing consumers are unaffected.