### PR TITLE
feat(ci): add primary input to ci-js to avoid redundant matrix runs

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -12,6 +12,10 @@ on:
         type: string
         default: ''
         description: 'Node.js version to use (overrides node-version-file when set)'
+      primary:
+        type: boolean
+        default: true
+        description: 'Run security scans and dependency review (set false for non-primary matrix jobs)'
       node-version-file:
         type: string
         default: '.nvmrc'
@@ -372,7 +376,7 @@ jobs:
     name: Security (${{ matrix.scanner }})
     runs-on: ubuntu-latest
     needs: [setup, quality-and-test]
-    if: inputs.enable-security-scans && needs.setup.outputs.should-run-security == 'true' && (needs.quality-and-test.result == 'success' || needs.quality-and-test.result == 'skipped')
+    if: inputs.primary && inputs.enable-security-scans && needs.setup.outputs.should-run-security == 'true' && (needs.quality-and-test.result == 'success' || needs.quality-and-test.result == 'skipped')
     timeout-minutes: 15
     strategy:
       matrix:
@@ -487,7 +491,7 @@ jobs:
   dependency-review:
     name: Review Dependencies
     runs-on: ubuntu-latest
-    if: inputs.enable-dependency-review && github.event_name == 'pull_request' && github.event.repository.visibility == 'public'
+    if: inputs.primary && inputs.enable-dependency-review && github.event_name == 'pull_request' && github.event.repository.visibility == 'public'
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
## Problem

With the new `node-version` input enabling matrix testing, the entire pipeline runs once per Node version — including security scans and dependency review, which are version-agnostic.

## Solution

New `primary` boolean input (default: `true`) gates `security-scan` and `dependency-review` jobs. Only the designated primary matrix job runs those checks.

## Usage

```yaml
strategy:
  matrix:
    node: ['18', '20', '22']
jobs:
  ci:
    uses: sbaerlocher/.github/.github/workflows/ci-js.yml@v1
    with:
      node-version: ${{ matrix.node }}
      primary: ${{ matrix.node == '20' }}  # security scans only on LTS
```

## Backwards compatibility

`primary` defaults to `true` — single-version consumers are unaffected.