### PR TITLE
fix(ci): allow unknown licenses in dependency review

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -503,6 +503,7 @@ jobs:
         with:
           fail-on-severity: moderate
           allow-licenses: Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MIT, 0BSD, LGPL-2.1+, MPL-2.0, BlueOak-1.0.0, CC-BY-4.0, CC0-1.0, LicenseRef-scancode-google-patent-license-golang, BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang
+          allow-unknown-licenses: true
 
   summary:
     name: Create Summary


### PR DESCRIPTION
## Problem

`dependency-review-action` treats referenced reusable workflows (`uses: sbaerlocher/.github/...`) as packages. Since `sbaerlocher/.github` has no SPDX license manifest, they appear as "Unknown License" and are blocked by the `allow-licenses` allowlist.

Reported in: sbaerlocher/vue.aareguru#418

## Fix

Add `allow-unknown-licenses: true` to suppress false positives from GitHub Actions reusable workflow references.