### PR TITLE
fix(sbom): run npm ci before cyclonedx-npm for npm-package type

### DIFF
--- a/.github/workflows/security-sbom.yml
+++ b/.github/workflows/security-sbom.yml
@@ -80,6 +80,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
         run: |
           npm install -g @cyclonedx/cyclonedx-npm
+          npm ci
           cyclonedx-npm --output-file ../sbom-${{ inputs.artifact-type }}.json
 
       # Validate and upload SBOM


### PR DESCRIPTION
`cyclonedx-npm` uses `npm ls` internally to build the dependency tree. Without `node_modules` being installed first, the command fails with `ELSPROBLEMS` — all dependencies are reported as missing.

**Root cause:** The `Generate SBOM for NPM package` step installs the tool globally but never runs `npm install` in the project directory before invoking it.

**Fix:** Add `npm ci` before `cyclonedx-npm`.

Reproducer: `sbaerlocher/vue.aareguru` release run [#23412292990](https://github.com/sbaerlocher/vue.aareguru/actions/runs/23412292990).