### PR TITLE
feat(ci): add follow-up review mode to ai-claude-review workflow

### DIFF
--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -2,7 +2,7 @@ name: AI - Code Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review, reopened]
+    types: [opened, synchronize, ready_for_review, reopened]
   workflow_call:
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
@@ -42,8 +42,44 @@ jobs:
           claude_args: |
             --max-turns 100
             --model claude-opus-4-6
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Task,Agent,Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git log:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Task,Agent,Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git log:*),Bash(gh api repos/*/pulls/*/comments*),Bash(gh api repos/*/pulls/comments*)"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
-            Run /code-review --comment
+            YOUR USERNAME: claude[bot]
+
+            ## Step 1: Determine review mode
+
+            Check if you have already reviewed this PR:
+            `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments --jq '[.[] | select(.user.login == "claude[bot]")] | length'`
+
+            ---
+
+            ## Step 2a: First review (result is 0 — no previous comments from you)
+
+            Perform a thorough, detailed code review:
+            - Run /code-review --comment
+            - Leave inline comments on every issue you find, no matter how small
+
+            ---
+
+            ## Step 2b: Follow-up review (result > 0 — previous comments exist from you)
+
+            Do NOT run a full review again. Act as a follow-up reviewer:
+
+            1. Fetch your previous comments:
+               `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments --jq '[.[] | select(.user.login == "claude[bot]")]'`
+
+            2. Look at what changed since your last review:
+               `gh pr diff ${{ github.event.pull_request.number }}`
+
+            3. For each of your previous inline comments, post a reply using the GitHub API directly
+               (the MCP inline comment tool does NOT support replies — use gh api instead):
+               ```
+               gh api repos/${{ github.repository }}/pulls/comments/<COMMENT_ID>/replies \
+                 -X POST -f body="<your reply text>"
+               ```
+               - **Resolved** — the issue was fixed, briefly confirm what was done
+               - **Still open** — explain what is still missing or incorrect
+
+            4. Only add new inline comments (via the MCP tool) for issues not covered in your previous review

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ This is a rolling release - changes are deployed continuously to `main`.
 
 ---
 
+## 2026-03-28
+
+### Changed
+
+- **ai-claude-review.yml**: Add two-phase review mode — full review on first pass,
+  follow-up replies on subsequent pushes (#44)
+  - Add `synchronize` to trigger types so the workflow re-runs when new commits are pushed to an open PR
+  - On first run (no previous `claude[bot]` comments): runs full `/code-review --comment` with detailed inline comments
+  - On follow-up runs (previous comments exist): fetches own comments and replies to each one via
+    `gh api repos/.../pulls/comments/<id>/replies` — marking issues as resolved or still open
+  - `mcp__github_inline_comment__create_inline_comment` does not support `in_reply_to`; replies use `gh api` directly
+  - Added `gh api repos/*/pulls/*/comments*` and `gh api repos/*/pulls/comments*` to `allowedTools`
+
+---
+
 ## 2026-03-22
 
 ### Added


### PR DESCRIPTION
Extends the AI code review workflow so Claude behaves differently depending on whether it has already reviewed the PR or not.

**First review** (no previous comments from `claude[bot]`): runs a full `/code-review --comment` with detailed inline comments on every issue found.

**Follow-up review** (previous comments exist): instead of repeating the full review, Claude fetches its own previous inline comments and replies to each one — marking it as resolved or still open. New inline comments are only added for issues not previously raised.

The `synchronize` trigger was added so the workflow also runs when new commits are pushed to an open PR, not only on open/reopen.

Replies are posted via `gh api repos/.../pulls/comments/<id>/replies` directly since the `mcp__github_inline_comment__create_inline_comment` tool has no `in_reply_to` support.