### PR TITLE
feat(ci): add PR approval and thread resolution to follow-up review

### DIFF
--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -42,7 +42,7 @@ jobs:
           claude_args: |
             --max-turns 100
             --model claude-opus-4-6
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Task,Agent,Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git log:*),Bash(gh api repos/*/pulls/*/comments*),Bash(gh api repos/*/pulls/comments*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Task,Agent,Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git log:*),Bash(gh api repos/*/pulls/*/comments*),Bash(gh api repos/*/pulls/comments*),Bash(gh api graphql:*)"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -83,3 +83,36 @@ jobs:
                - **Still open** — explain what is still missing or incorrect
 
             4. Only add new inline comments (via the MCP tool) for issues not covered in your previous review
+
+            5. After replying to all previous comments, check whether all issues are now resolved:
+               - If ALL issues are resolved: approve the PR and resolve all review threads
+               - If ANY issue is still open: do NOT approve, leave the threads unresolved
+
+               Approve the PR:
+               ```
+               gh pr review ${{ github.event.pull_request.number }} --approve --body "All raised issues have been addressed."
+               ```
+
+               Resolve each thread via GraphQL (get thread IDs first, then resolve each):
+               ```
+               gh api graphql -f query='
+                 query {
+                   repository(owner: "${{ github.repository_owner }}", name: "${{ github.event.repository.name }}") {
+                     pullRequest(number: ${{ github.event.pull_request.number }}) {
+                       reviewThreads(first: 100) {
+                         nodes { id isResolved }
+                       }
+                     }
+                   }
+                 }
+               '
+               ```
+               ```
+               gh api graphql -f query='
+                 mutation {
+                   resolveReviewThread(input: {threadId: "<THREAD_ID>"}) {
+                     thread { isResolved }
+                   }
+                 }
+               '
+               ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ This is a rolling release - changes are deployed continuously to `main`.
 
 - **ai-claude-review.yml**: Add two-phase review mode — full review on first pass,
   follow-up replies on subsequent pushes (#44)
+- **ai-claude-review.yml**: Add automatic PR approval and thread resolution after follow-up review (#45)
+  - When all previously raised issues are resolved: approves the PR and resolves all review threads
+  - When any issue is still open: no approval, threads remain unresolved
+  - PR approval via `gh pr review --approve`
+  - Thread resolution via GitHub GraphQL `resolveReviewThread` mutation
+  - Added `Bash(gh pr review:*)` and `Bash(gh api graphql:*)` to `allowedTools`
   - Add `synchronize` to trigger types so the workflow re-runs when new commits are pushed to an open PR
   - On first run (no previous `claude[bot]` comments): runs full `/code-review --comment` with detailed inline comments
   - On follow-up runs (previous comments exist): fetches own comments and replies to each one via


### PR DESCRIPTION
Extends the follow-up review phase with automatic PR approval and conversation resolution.

When Claude has replied to all its previous inline comments and all issues are resolved, it now:
- Approves the PR via `gh pr review --approve`
- Resolves every review thread via the GitHub GraphQL `resolveReviewThread` mutation

If any issue is still open it does not approve and leaves threads unresolved.

New tools added to `allowedTools`:
- `Bash(gh pr review:*)` — for approving
- `Bash(gh api graphql:*)` — for fetching thread IDs and resolving them