### PR TITLE
chore(renovate): remove enabledManagers restriction in renovate-js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,19 @@ This is a rolling release - changes are deployed continuously to `main`.
 
 ## 2026-04-09
 
-### Changed
+### Fixed
 
-- **renovate-js.json**: Remove `enabledManagers` restriction
-  - Previously limited managers to `npm`, `nvm`, and `github-actions`
-  - Removing the restriction lets JS/TS repos inherit all managers from the base
-    preset (e.g., `dockerfile`, `docker-compose`), so non-JS files in JS repos are
-    also tracked by Renovate
-  - Package rules in this preset still scope JS-specific behavior correctly
+- **renovate-js.json**: Remove `enabledManagers` to fix silent allowlist clobbering
+  when multiple presets are extended
+  - `enabledManagers` is [non-mergeable by design](https://github.com/renovatebot/renovate/discussions/37059)
+    in Renovate — when multiple presets set it, the last one wins (no union)
+  - Consumers extending both `renovate-js` and `renovate-kubernetes` (e.g. a JS app
+    deployed via Helm) silently lost one allowlist depending on extends order
+  - Removing the allowlist here aligns `renovate-js.json` with `renovate-base.json`,
+    `renovate-docker.json`, and `renovate-go.json`, which already omit `enabledManagers`
+  - JS/TS scoping is already enforced via package rules in this preset
+  - Note: `renovate-kubernetes.json` and `renovate-terraform.json` still define
+    `enabledManagers` — this is intentional for now and tracked separately
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ This is a rolling release - changes are deployed continuously to `main`.
 
 ---
 
+## 2026-04-09
+
+### Changed
+
+- **renovate-js.json**: Remove `enabledManagers` restriction
+  - Previously limited managers to `npm`, `nvm`, and `github-actions`
+  - Removing the restriction lets JS/TS repos inherit all managers from the base
+    preset (e.g., `dockerfile`, `docker-compose`), so non-JS files in JS repos are
+    also tracked by Renovate
+  - Package rules in this preset still scope JS-specific behavior correctly
+
+---
+
 ## 2026-03-28
 
 ### Changed

--- a/renovate-js.json
+++ b/renovate-js.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "JavaScript/TypeScript Renovate configuration for Node.js, pnpm, Astro, Vue, Cloudflare Workers",
   "extends": ["github>sbaerlocher/.github:renovate-base#main", ":preserveSemverRanges"],
-  "enabledManagers": ["npm", "nvm", "github-actions"],
   "packageRules": [
     {
       "description": "Node.js version updates - higher stability",


### PR DESCRIPTION
## Summary

- Drop the `enabledManagers` allowlist (`npm`, `nvm`, `github-actions`) from `renovate-js.json`
- JS/TS repositories now inherit all managers from the base preset, so Dockerfiles and other non-JS manifests in JS repos are also tracked
- Package rules in this preset continue to scope JS-specific behavior correctly
- CHANGELOG.md updated with a 2026-04-09 entry

## Test plan

- [ ] Renovate dry-run / next scheduled run against a JS consumer repo shows the additional managers picking up non-JS files
- [ ] Existing JS package rules still apply as expected