### PR TITLE
fix(renovate): ensure co-dependent packages bump together in one PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,53 @@ This is a rolling release - changes are deployed continuously to `main`.
 
 ---
 
+## 2026-04-11
+
+### Fixed
+
+- **renovate-js.json**, **renovate-kubernetes.json**, **renovate-go.json**: Ensure
+  co-dependent packages bump together in a single PR to prevent peer-dependency
+  CI failures
+  - **Peer-dependency grouping** (`renovate-js.json`): Co-dependent packages that
+    previously landed in separate PRs now share one group:
+    - `typescript-eslint` + `@typescript-eslint/*` added to "Code quality tools"
+      group (peer dep on `eslint` — ESLint 9→10 would otherwise split and fail)
+    - `vitest` + `@vitest/*` merged into "Build tooling (Vite + Vitest)" group
+      (Vitest has a hard peer dep on Vite; Vite major without Vitest breaks
+      `pnpm install`)
+    - `vue-router`, `pinia`, `@pinia/*`, `@vitejs/plugin-vue*` added to
+      "Vue packages" group (all have peer deps on `vue`)
+    - `@vitejs/plugin-svelte*` added to "Svelte packages" group
+    - Legacy unscoped `graphql-codegen-*` added to "GraphQL packages" group
+    - Testing tools group renamed to "Jest" (vitest moved out)
+  - **Branch-name collapsing** (`major.additionalBranchPrefix: ""`): Strip the
+    `major-N-` branch prefix for grouped major updates so co-dependent packages
+    with _different_ major version numbers (e.g. Vue 4 + plugin-vue 6) share one
+    branch/PR despite `separateMultipleMajor: true` in base
+    - Applied to: Code quality tools, Build tooling (Vite + Vitest), Astro, Vue,
+      Svelte, TailwindCSS, Cloudflare Workers, Hono, GraphQL, Turborepo
+    - Applied to Helm charts group in `renovate-kubernetes.json`
+    - Applied to Go platform packages group in `renovate-go.json` (critical for
+      `k8s.io/*` + `sigs.k8s.io/*` major-version lock-step)
+  - **Regex precision**: All `matchPackageNames` patterns now use proper anchors
+    (`/^pkg$/` instead of `/^pkg/`) and escaped slashes (`/^@scope\\//`) to
+    prevent false-positive matches like `vuex-persist` landing in the Vue group
+
+### Changed
+
+- **renovate-js.json**: Remove `:preserveSemverRanges` from `extends`
+  - `:preserveSemverRanges` sets `rangeStrategy: "replace"`, conflicting with
+    base's `rangeStrategy: "bump"`
+  - `bump` is the correct strategy for apps (always updates the version in
+    `package.json`, better for reproducibility)
+  - Library repos (e.g. `vue.aareguru`) can override locally if flexible ranges
+    are preferred
+- **renovate-js.json**: Add `minimumReleaseAge: "14 days"` to "Build tooling
+  (Vite + Vitest)" group for extra stability on ecosystem churn (previously
+  only applied to majors)
+
+---
+
 ## 2026-04-09
 
 ### Fixed

--- a/renovate-go.json
+++ b/renovate-go.json
@@ -23,7 +23,7 @@
       "semanticCommitScope": "deps"
     },
     {
-      "description": "Go platform packages - gRPC, Kubernetes, Prometheus",
+      "description": "Go platform packages - gRPC, Kubernetes, Prometheus. Strip major-N- prefix so co-dependent k8s.io/* + sigs.k8s.io/* majors share one branch/PR.",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
         "google.golang.org/**",
@@ -35,7 +35,10 @@
       "groupName": "Go platform packages",
       "semanticCommitScope": "platform",
       "minimumReleaseAge": "7 days",
-      "labels": ["platform"]
+      "labels": ["platform"],
+      "major": {
+        "additionalBranchPrefix": ""
+      }
     },
     {
       "description": "Go dev tooling - testing, linting, build tools",

--- a/renovate-js.json
+++ b/renovate-js.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "JavaScript/TypeScript Renovate configuration for Node.js, pnpm, Astro, Vue, Cloudflare Workers",
-  "extends": ["github>sbaerlocher/.github:renovate-base#main", ":preserveSemverRanges"],
+  "extends": ["github>sbaerlocher/.github:renovate-base#main"],
   "packageRules": [
     {
       "description": "Node.js version updates - higher stability",
@@ -25,88 +25,145 @@
       "labels": ["typescript"]
     },
     {
-      "description": "Code quality tools - ESLint and Prettier",
+      "description": "Code quality tools - ESLint, typescript-eslint and Prettier (must bump together due to peer deps). Strip major-N- prefix so co-dependent majors share one branch/PR.",
       "groupName": "Code quality tools",
       "semanticCommitScope": "lint",
       "matchPackageNames": [
-        "/^eslint/",
-        "/^@eslint//",
+        "/^eslint$/",
         "/^eslint-/",
-        "/^prettier/",
-        "/^@prettier//"
-      ]
+        "/^@eslint\\//",
+        "/^typescript-eslint$/",
+        "/^@typescript-eslint\\//",
+        "/^prettier$/",
+        "/^@prettier\\//"
+      ],
+      "major": {
+        "additionalBranchPrefix": ""
+      }
     },
     {
-      "description": "Testing tools - Vitest and Jest",
-      "groupName": "Testing tools",
+      "description": "Jest testing framework",
+      "groupName": "Jest",
       "semanticCommitScope": "test",
-      "matchPackageNames": ["/^vitest/", "/^@vitest//", "/^jest/", "/^@jest//"]
+      "matchPackageNames": ["/^jest$/", "/^jest-/", "/^@jest\\//", "/^ts-jest$/", "/^babel-jest$/"]
     },
     {
-      "description": "Group Vite packages",
-      "groupName": "Vite packages",
+      "description": "Build tooling - Vite + Vitest must bump together (peerDependency vite). Strip major-N- prefix so co-dependent majors share one branch/PR. 14 days release age for extra stability on ecosystem churn.",
+      "groupName": "Build tooling (Vite + Vitest)",
       "semanticCommitScope": "build",
-      "matchPackageNames": ["/^vite/", "/^@vitejs//"]
+      "minimumReleaseAge": "14 days",
+      "labels": ["build-tooling"],
+      "matchPackageNames": [
+        "/^vite$/",
+        "/^vite-/",
+        "/^@vitejs\\//",
+        "/^vitest$/",
+        "/^@vitest\\//",
+        "/^rollup$/",
+        "/^@rollup\\//"
+      ],
+      "major": {
+        "additionalBranchPrefix": ""
+      }
     },
     {
-      "description": "Group Astro packages",
+      "description": "Group Astro packages - core, integrations and adapters (peer deps on astro). Strip major-N- prefix so co-dependent majors share one branch/PR.",
       "groupName": "Astro packages",
       "semanticCommitScope": "astro",
       "minimumReleaseAge": "5 days",
       "labels": ["astro"],
-      "matchPackageNames": ["/^astro/", "/^@astrojs//"]
+      "matchPackageNames": ["/^astro$/", "/^astro-/", "/^@astrojs\\//"],
+      "major": {
+        "additionalBranchPrefix": ""
+      }
     },
     {
-      "description": "Group Vue packages",
+      "description": "Group Vue packages - vue core, ecosystem and vite plugin (peer deps on vue). Strip major-N- prefix so co-dependent majors share one branch/PR.",
       "groupName": "Vue packages",
       "semanticCommitScope": "vue",
       "minimumReleaseAge": "5 days",
       "labels": ["vue"],
-      "matchPackageNames": ["/^vue/", "/^@vue//"]
+      "matchPackageNames": [
+        "/^vue$/",
+        "/^vue-/",
+        "/^@vue\\//",
+        "/^pinia$/",
+        "/^@pinia\\//",
+        "/^@vitejs\\/plugin-vue/",
+        "/^@vue\\/eslint-config/"
+      ],
+      "major": {
+        "additionalBranchPrefix": ""
+      }
     },
     {
-      "description": "Group Svelte packages",
+      "description": "Group Svelte packages - svelte core, kit, and vite plugin (peer deps on svelte). Strip major-N- prefix so co-dependent majors share one branch/PR.",
       "groupName": "Svelte packages",
       "semanticCommitScope": "svelte",
       "minimumReleaseAge": "5 days",
       "labels": ["svelte"],
-      "matchPackageNames": ["/^svelte/", "/^@sveltejs//"]
+      "matchPackageNames": [
+        "/^svelte$/",
+        "/^svelte-/",
+        "/^@sveltejs\\//",
+        "/^@vitejs\\/plugin-svelte/"
+      ],
+      "major": {
+        "additionalBranchPrefix": ""
+      }
     },
     {
-      "description": "Group TailwindCSS packages",
+      "description": "Group TailwindCSS packages - core, plugins, postcss and vite integration. Strip major-N- prefix so co-dependent majors (v3→v4) share one branch/PR.",
       "groupName": "TailwindCSS packages",
       "semanticCommitScope": "tailwindcss",
-      "matchPackageNames": ["/^tailwindcss/", "/^@tailwindcss//"]
+      "matchPackageNames": ["/^tailwindcss$/", "/^tailwindcss-/", "/^@tailwindcss\\//"],
+      "major": {
+        "additionalBranchPrefix": ""
+      }
     },
     {
-      "description": "Group Cloudflare Workers packages",
+      "description": "Group Cloudflare Workers packages - wrangler and runtime types. Strip major-N- prefix so co-dependent majors share one branch/PR.",
       "groupName": "Cloudflare Workers packages",
       "semanticCommitScope": "workers",
       "labels": ["cloudflare"],
-      "matchPackageNames": ["/^@cloudflare//", "/^wrangler/"]
+      "matchPackageNames": ["/^@cloudflare\\//", "/^wrangler$/", "/^miniflare$/"],
+      "major": {
+        "additionalBranchPrefix": ""
+      }
     },
     {
-      "description": "Group Hono framework packages",
+      "description": "Group Hono framework packages. Strip major-N- prefix so co-dependent majors share one branch/PR.",
       "groupName": "Hono packages",
       "semanticCommitScope": "hono",
-      "matchPackageNames": ["/^hono/", "/^@hono//"]
+      "matchPackageNames": ["/^hono$/", "/^@hono\\//"],
+      "major": {
+        "additionalBranchPrefix": ""
+      }
     },
     {
-      "description": "Group GraphQL packages",
+      "description": "Group GraphQL packages - core, tools, codegen and apollo (must bump together). Strip major-N- prefix so co-dependent majors share one branch/PR.",
       "groupName": "GraphQL packages",
       "semanticCommitScope": "graphql",
       "matchPackageNames": [
-        "/^graphql/",
-        "/^@graphql-tools//",
-        "/^@graphql-codegen//",
-        "/^@apollo//"
-      ]
+        "/^graphql$/",
+        "/^graphql-/",
+        "/^@graphql-tools\\//",
+        "/^@graphql-codegen\\//",
+        "/^graphql-codegen-/",
+        "/^@apollo\\//"
+      ],
+      "major": {
+        "additionalBranchPrefix": ""
+      }
     },
     {
-      "description": "Group Turborepo",
+      "description": "Group Turborepo. Strip major-N- prefix so co-dependent majors share one branch/PR.",
       "groupName": "Turborepo",
       "semanticCommitScope": "turbo",
-      "matchPackageNames": ["turbo", "/^@turbo//"]
+      "matchPackageNames": ["/^turbo$/", "/^@turbo\\//"],
+      "major": {
+        "additionalBranchPrefix": ""
+      }
     },
     {
       "description": "Group pnpm package manager",
@@ -122,7 +179,7 @@
       "description": "Group @types packages",
       "groupName": "TypeScript definitions",
       "semanticCommitScope": "types",
-      "matchPackageNames": ["/^@types//"]
+      "matchPackageNames": ["/^@types\\//"]
     },
     {
       "description": "Workspace protocol - internal dependencies",
@@ -135,19 +192,31 @@
       "minimumReleaseAge": "14 days",
       "labels": ["framework", "major-update"],
       "matchPackageNames": [
-        "/^astro/",
-        "/^vue/",
-        "/^svelte/",
-        "/^@astrojs//",
-        "/^@vue//",
-        "/^@sveltejs//"
+        "/^astro$/",
+        "/^astro-/",
+        "/^@astrojs\\//",
+        "/^vue$/",
+        "/^vue-/",
+        "/^@vue\\//",
+        "/^pinia$/",
+        "/^svelte$/",
+        "/^svelte-/",
+        "/^@sveltejs\\//"
       ]
     },
     {
-      "description": "Major build tooling updates - extra stability",
+      "description": "Major build tooling updates - extra stability (Vite, Vitest, Rollup, Webpack)",
       "matchUpdateTypes": ["major"],
       "minimumReleaseAge": "14 days",
-      "matchPackageNames": ["/^vite/", "/^@vitejs//", "/^webpack/", "/^rollup/"]
+      "matchPackageNames": [
+        "/^vite$/",
+        "/^vitest$/",
+        "/^@vitejs\\//",
+        "/^@vitest\\//",
+        "/^webpack$/",
+        "/^rollup$/",
+        "/^@rollup\\//"
+      ]
     },
     {
       "description": "Production dependencies - extra stability",

--- a/renovate-kubernetes.json
+++ b/renovate-kubernetes.json
@@ -18,12 +18,15 @@
   },
   "packageRules": [
     {
-      "description": "Group Helm chart updates",
+      "description": "Group Helm chart updates. Strip major-N- prefix so co-dependent chart majors share one branch/PR.",
       "matchManagers": ["helm-values", "helmfile"],
       "matchDatasources": ["helm"],
       "groupName": "Helm charts",
       "semanticCommitScope": "helm",
-      "minimumReleaseAge": "5 days"
+      "minimumReleaseAge": "5 days",
+      "major": {
+        "additionalBranchPrefix": ""
+      }
     },
     {
       "description": "Container images - pin digests for production",


### PR DESCRIPTION
## Summary

Fix peer-dependency CI failures where Renovate was splitting co-dependent packages into separate PRs that individually couldn't install. Affects all repos consuming `renovate-js`, `renovate-kubernetes`, and `renovate-go` presets.

### Root cause
Two independent issues combined:
1. **Missing group members**: Packages with peer-dep relationships (e.g. `typescript-eslint` → `eslint`, `vitest` → `vite`, `vue-router` → `vue`, `@vitejs/plugin-vue` → `vue`) were spread across different groups, so each landed in its own PR.
2. **Branch-prefix splitting**: Even when packages shared a `groupName`, `separateMultipleMajor: true` in `renovate-base.json` forced Renovate to add a `major-N-` branch prefix per package, meaning co-dependent majors with different version numbers (e.g. Vue 4 + `@vitejs/plugin-vue` 6) ended up on different branches anyway.

### Fix
- **Merge peer-dependent packages into shared groups** in `renovate-js.json`:
  - ESLint group gets `typescript-eslint` + `@typescript-eslint/*`
  - Build tooling group gets `vitest` + `@vitest/*` (Testing tools group renamed to "Jest")
  - Vue group gets `vue-router`, `pinia`, `@pinia/*`, `@vitejs/plugin-vue*`
  - Svelte group gets `@vitejs/plugin-svelte*`
  - GraphQL group gets legacy unscoped `graphql-codegen-*`
- **Collapse branch names for grouped majors** via `major.additionalBranchPrefix: ""` applied to all peer-dep-critical groups in `renovate-js.json`, `renovate-kubernetes.json` (Helm charts), and `renovate-go.json` (Go platform packages for `k8s.io/*` + `sigs.k8s.io/*` lock-step)
- **Remove `:preserveSemverRanges`** from `renovate-js.json` extends — conflicted with base's `rangeStrategy: "bump"` (replace vs bump). `bump` is correct for applications (always updates the version in `package.json` for reproducibility).
- **Tighten regex precision**: all `matchPackageNames` patterns now use proper anchors (`/^pkg$/`) and escaped slashes (`/^@scope\\//`) to prevent false-positive matches like `vuex-persist` accidentally landing in the Vue group.
- **Add `minimumReleaseAge: "14 days"`** to the Build tooling group for extra stability on Vite/Vitest ecosystem churn.

## Test plan

- [x] JSON syntax validation (`python3 -m json.tool` on all three presets)
- [x] Regex patterns manually reviewed for anchor correctness
- [x] Rule ordering verified — framework-specific rules come after broader base rules so `groupName` overrides work as expected
- [ ] Monitor first Renovate runs in consumer repos (`functions`, `sbaerlocher.ch`, `sbaerlo.ch`, `vue.aareguru`, `applications`, `tsmetrics`) to confirm:
  - ESLint + typescript-eslint land in one PR
  - Vite + Vitest land in one PR
  - Vue ecosystem lands in one PR
  - No unexpected package groupings
- [ ] Check for orphaned `major-N-*` branches from previous Renovate runs and close them manually

## Notes

- `:preserveSemverRanges` removal may need local override in `vue.aareguru` if the library wants flexible consumer ranges — can be added in its own `renovate.json` with `"rangeStrategy": "replace"`.
- The `major.additionalBranchPrefix: ""` pattern is an advanced Renovate trick. It works by stripping the `major-N-` prefix that `separateMultipleMajor: true` adds, forcing branch-name collisions for grouped majors. Verified via Renovate docs on `additionalBranchPrefix`, Discussion #18223, and Discussion #25831.
- Terraform Provider majors remain bewusst ungrouped (`groupName: null` in `renovate-terraform.json`) — provider majors require HCL breaking-change reviews individually.