### PR TITLE
fix(renovate): use separateMultipleMajor: false to collapse co-dependent majors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,15 +25,27 @@ This is a rolling release - changes are deployed continuously to `main`.
     - `@vitejs/plugin-svelte*` added to "Svelte packages" group
     - Legacy unscoped `graphql-codegen-*` added to "GraphQL packages" group
     - Testing tools group renamed to "Jest" (vitest moved out)
-  - **Branch-name collapsing** (`major.additionalBranchPrefix: ""`): Strip the
-    `major-N-` branch prefix for grouped major updates so co-dependent packages
-    with _different_ major version numbers (e.g. Vue 4 + plugin-vue 6) share one
-    branch/PR despite `separateMultipleMajor: true` in base
-    - Applied to: Code quality tools, Build tooling (Vite + Vitest), Astro, Vue,
-      Svelte, TailwindCSS, Cloudflare Workers, Hono, GraphQL, Turborepo
+  - **Branch-name collapsing** (`separateMultipleMajor: false` per group):
+    Collapse the `major-N-` segment that Renovate prepends to `groupSlug` for
+    grouped major updates, so co-dependent packages with _different_ major
+    version numbers (e.g. Vue 4 + plugin-vue 6) share one branch/PR despite
+    `separateMultipleMajor: true` in base
+    - Verified against Renovate source
+      ([`lib/workers/repository/updates/branch-name.ts`](https://github.com/renovatebot/renovate/blob/main/lib/workers/repository/updates/branch-name.ts)):
+      the `major-N-` prefix is mutated directly into `groupSlug`, not into
+      `additionalBranchPrefix`. With `separateMultipleMajor: false`,
+      `groupSlug` collapses to `major-<group>` (without the version number),
+      forcing all majors of the group onto a single branch
+    - Side effect (intended): Renovate creates one PR per group for the
+      latest major only, not one PR per intermediate major. For
+      peer-dep-critical groups this is desired — you want to land on a
+      consistent ecosystem state, not chain through broken intermediate
+      states
+    - Applied to: Code quality tools, Build tooling (Vite + Vitest), Astro,
+      Vue, Svelte, TailwindCSS, Cloudflare Workers, Hono, GraphQL, Turborepo
     - Applied to Helm charts group in `renovate-kubernetes.json`
-    - Applied to Go platform packages group in `renovate-go.json` (critical for
-      `k8s.io/*` + `sigs.k8s.io/*` major-version lock-step)
+    - Applied to Go platform packages group in `renovate-go.json` (critical
+      for `k8s.io/*` + `sigs.k8s.io/*` major-version lock-step)
   - **Regex precision**: All `matchPackageNames` patterns now use proper anchors
     (`/^pkg$/` instead of `/^pkg/`) and escaped slashes (`/^@scope\\//`) to
     prevent false-positive matches like `vuex-persist` landing in the Vue group

--- a/renovate-go.json
+++ b/renovate-go.json
@@ -23,7 +23,7 @@
       "semanticCommitScope": "deps"
     },
     {
-      "description": "Go platform packages - gRPC, Kubernetes, Prometheus. Strip major-N- prefix so co-dependent k8s.io/* + sigs.k8s.io/* majors share one branch/PR.",
+      "description": "Go platform packages - gRPC, Kubernetes, Prometheus. separateMultipleMajor: false so co-dependent k8s.io/* + sigs.k8s.io/* majors share one branch/PR.",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
         "google.golang.org/**",
@@ -36,9 +36,7 @@
       "semanticCommitScope": "platform",
       "minimumReleaseAge": "7 days",
       "labels": ["platform"],
-      "major": {
-        "additionalBranchPrefix": ""
-      }
+      "separateMultipleMajor": false
     },
     {
       "description": "Go dev tooling - testing, linting, build tools",

--- a/renovate-js.json
+++ b/renovate-js.json
@@ -25,7 +25,7 @@
       "labels": ["typescript"]
     },
     {
-      "description": "Code quality tools - ESLint, typescript-eslint and Prettier (must bump together due to peer deps). Strip major-N- prefix so co-dependent majors share one branch/PR.",
+      "description": "Code quality tools - ESLint, typescript-eslint and Prettier (must bump together due to peer deps). separateMultipleMajor: false collapses groupSlug from major-N-code-quality-tools to major-code-quality-tools so co-dependent majors share one branch/PR.",
       "groupName": "Code quality tools",
       "semanticCommitScope": "lint",
       "matchPackageNames": [
@@ -37,9 +37,7 @@
         "/^prettier$/",
         "/^@prettier\\//"
       ],
-      "major": {
-        "additionalBranchPrefix": ""
-      }
+      "separateMultipleMajor": false
     },
     {
       "description": "Jest testing framework",
@@ -48,7 +46,7 @@
       "matchPackageNames": ["/^jest$/", "/^jest-/", "/^@jest\\//", "/^ts-jest$/", "/^babel-jest$/"]
     },
     {
-      "description": "Build tooling - Vite + Vitest must bump together (peerDependency vite). Strip major-N- prefix so co-dependent majors share one branch/PR. 14 days release age for extra stability on ecosystem churn.",
+      "description": "Build tooling - Vite + Vitest must bump together (peerDependency vite). separateMultipleMajor: false ensures all Vite/Vitest majors share one branch/PR. 14 days release age for extra stability on ecosystem churn.",
       "groupName": "Build tooling (Vite + Vitest)",
       "semanticCommitScope": "build",
       "minimumReleaseAge": "14 days",
@@ -62,23 +60,19 @@
         "/^rollup$/",
         "/^@rollup\\//"
       ],
-      "major": {
-        "additionalBranchPrefix": ""
-      }
+      "separateMultipleMajor": false
     },
     {
-      "description": "Group Astro packages - core, integrations and adapters (peer deps on astro). Strip major-N- prefix so co-dependent majors share one branch/PR.",
+      "description": "Group Astro packages - core, integrations and adapters (peer deps on astro). separateMultipleMajor: false so co-dependent majors share one branch/PR.",
       "groupName": "Astro packages",
       "semanticCommitScope": "astro",
       "minimumReleaseAge": "5 days",
       "labels": ["astro"],
       "matchPackageNames": ["/^astro$/", "/^astro-/", "/^@astrojs\\//"],
-      "major": {
-        "additionalBranchPrefix": ""
-      }
+      "separateMultipleMajor": false
     },
     {
-      "description": "Group Vue packages - vue core, ecosystem and vite plugin (peer deps on vue). Strip major-N- prefix so co-dependent majors share one branch/PR.",
+      "description": "Group Vue packages - vue core, ecosystem and vite plugin (peer deps on vue). separateMultipleMajor: false so co-dependent majors share one branch/PR.",
       "groupName": "Vue packages",
       "semanticCommitScope": "vue",
       "minimumReleaseAge": "5 days",
@@ -92,12 +86,10 @@
         "/^@vitejs\\/plugin-vue/",
         "/^@vue\\/eslint-config/"
       ],
-      "major": {
-        "additionalBranchPrefix": ""
-      }
+      "separateMultipleMajor": false
     },
     {
-      "description": "Group Svelte packages - svelte core, kit, and vite plugin (peer deps on svelte). Strip major-N- prefix so co-dependent majors share one branch/PR.",
+      "description": "Group Svelte packages - svelte core, kit, and vite plugin (peer deps on svelte). separateMultipleMajor: false so co-dependent majors share one branch/PR.",
       "groupName": "Svelte packages",
       "semanticCommitScope": "svelte",
       "minimumReleaseAge": "5 days",
@@ -108,40 +100,32 @@
         "/^@sveltejs\\//",
         "/^@vitejs\\/plugin-svelte/"
       ],
-      "major": {
-        "additionalBranchPrefix": ""
-      }
+      "separateMultipleMajor": false
     },
     {
-      "description": "Group TailwindCSS packages - core, plugins, postcss and vite integration. Strip major-N- prefix so co-dependent majors (v3→v4) share one branch/PR.",
+      "description": "Group TailwindCSS packages - core, plugins, postcss and vite integration. separateMultipleMajor: false so co-dependent majors (v3→v4) share one branch/PR.",
       "groupName": "TailwindCSS packages",
       "semanticCommitScope": "tailwindcss",
       "matchPackageNames": ["/^tailwindcss$/", "/^tailwindcss-/", "/^@tailwindcss\\//"],
-      "major": {
-        "additionalBranchPrefix": ""
-      }
+      "separateMultipleMajor": false
     },
     {
-      "description": "Group Cloudflare Workers packages - wrangler and runtime types. Strip major-N- prefix so co-dependent majors share one branch/PR.",
+      "description": "Group Cloudflare Workers packages - wrangler and runtime types. separateMultipleMajor: false so co-dependent majors share one branch/PR.",
       "groupName": "Cloudflare Workers packages",
       "semanticCommitScope": "workers",
       "labels": ["cloudflare"],
       "matchPackageNames": ["/^@cloudflare\\//", "/^wrangler$/", "/^miniflare$/"],
-      "major": {
-        "additionalBranchPrefix": ""
-      }
+      "separateMultipleMajor": false
     },
     {
-      "description": "Group Hono framework packages. Strip major-N- prefix so co-dependent majors share one branch/PR.",
+      "description": "Group Hono framework packages. separateMultipleMajor: false so co-dependent majors share one branch/PR.",
       "groupName": "Hono packages",
       "semanticCommitScope": "hono",
       "matchPackageNames": ["/^hono$/", "/^@hono\\//"],
-      "major": {
-        "additionalBranchPrefix": ""
-      }
+      "separateMultipleMajor": false
     },
     {
-      "description": "Group GraphQL packages - core, tools, codegen and apollo (must bump together). Strip major-N- prefix so co-dependent majors share one branch/PR.",
+      "description": "Group GraphQL packages - core, tools, codegen and apollo (must bump together). separateMultipleMajor: false so co-dependent majors share one branch/PR.",
       "groupName": "GraphQL packages",
       "semanticCommitScope": "graphql",
       "matchPackageNames": [
@@ -152,18 +136,14 @@
         "/^graphql-codegen-/",
         "/^@apollo\\//"
       ],
-      "major": {
-        "additionalBranchPrefix": ""
-      }
+      "separateMultipleMajor": false
     },
     {
-      "description": "Group Turborepo. Strip major-N- prefix so co-dependent majors share one branch/PR.",
+      "description": "Group Turborepo. separateMultipleMajor: false so co-dependent majors share one branch/PR.",
       "groupName": "Turborepo",
       "semanticCommitScope": "turbo",
       "matchPackageNames": ["/^turbo$/", "/^@turbo\\//"],
-      "major": {
-        "additionalBranchPrefix": ""
-      }
+      "separateMultipleMajor": false
     },
     {
       "description": "Group pnpm package manager",

--- a/renovate-kubernetes.json
+++ b/renovate-kubernetes.json
@@ -18,15 +18,13 @@
   },
   "packageRules": [
     {
-      "description": "Group Helm chart updates. Strip major-N- prefix so co-dependent chart majors share one branch/PR.",
+      "description": "Group Helm chart updates. separateMultipleMajor: false so co-dependent chart majors share one branch/PR.",
       "matchManagers": ["helm-values", "helmfile"],
       "matchDatasources": ["helm"],
       "groupName": "Helm charts",
       "semanticCommitScope": "helm",
       "minimumReleaseAge": "5 days",
-      "major": {
-        "additionalBranchPrefix": ""
-      }
+      "separateMultipleMajor": false
     },
     {
       "description": "Container images - pin digests for production",


### PR DESCRIPTION
## Summary

- Replace the no-op `major.additionalBranchPrefix: ""` (introduced in #57) with `separateMultipleMajor: false` per grouped rule
- Verified against Renovate source: the `major-N-` prefix is mutated into `groupSlug`, not into `additionalBranchPrefix`, so the previous fix had no effect
- Applied to all peer-dep-critical groups across `renovate-js.json`, `renovate-kubernetes.json`, `renovate-go.json`
- CHANGELOG entry under 2026-04-11 rewritten to describe the correct mechanism

## Why the previous fix was wrong

Renovate [`lib/workers/repository/updates/branch-name.ts`](https://github.com/renovatebot/renovate/blob/main/lib/workers/repository/updates/branch-name.ts):

```ts
// additionalBranchPrefix defaults to ""
// group.branchTopic: "{{{groupSlug}}}"

if (update.updateType === 'major' && update.separateMajorMinor) {
  if (update.separateMultipleMajor) {
    update.groupSlug = `major-${newMajor}-${update.groupSlug}`;
  } else {
    update.groupSlug = `major-${update.groupSlug}`;
  }
}
```

Setting `additionalBranchPrefix: ""` changes nothing — it's already the default. The `major-N-` segment is part of `groupSlug`, so the only way to collapse co-dependent majors (e.g. Vue 4 + plugin-vue 6) onto one branch is `separateMultipleMajor: false`.

## Side effect (intended)

Renovate creates one PR per group for the latest major only, not one PR per intermediate major. For peer-dep-critical groups this is desired — land on a consistent ecosystem state, not chain through broken intermediate states.

## Test plan

- [ ] Renovate dry-run or on-demand run on a consumer repo to confirm grouped majors share one branch
- [ ] Verify branch name collapses to `renovate/major-<group>` (not `renovate/major-N-<group>`)