### PR TITLE
chore: rolling release 2026-04-22

### DIFF
--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -41,7 +41,7 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           claude_args: |
             --max-turns 100
-            --model claude-opus-4-6
+            --model claude-opus-4-7
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Task,Agent,Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git log:*),Bash(gh api repos/*/pulls/*/comments*),Bash(gh api repos/*/pulls/comments*),Bash(gh api graphql:*)"
           prompt: |
             REPO: ${{ github.repository }}

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -503,7 +503,6 @@ jobs:
         with:
           fail-on-severity: moderate
           allow-licenses: Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MIT, 0BSD, LGPL-2.1+, MPL-2.0, BlueOak-1.0.0, CC-BY-4.0, CC0-1.0, LicenseRef-scancode-google-patent-license-golang, BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang
-          allow-unknown-licenses: true
 
   summary:
     name: Create Summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ This is a rolling release - changes are deployed continuously to `main`.
 
 ---
 
+## 2026-04-22
+
+### Fixed
+
+- **ai-claude-review.yml**: Bump `--model` from `claude-opus-4-6` to `claude-opus-4-7`
+  - Align the parent review agent with the current latest Opus; plugin subagents
+    (haiku/sonnet/opus) are unaffected
+- **ci-js.yml**: Remove deprecated `allow-unknown-licenses` input from
+  `dependency-review-action` step (unsupported since v4.9.0, emitted a warning
+  on every PR CI run)
+
+### Changed
+
+- Dependency refreshes since 2026-04-11 (all via Renovate):
+  - `anthropics/claude-code-action` digest → `0d2971c` (#63)
+  - `bitwarden/sm-action` → v3 (#67)
+  - `softprops/action-gh-release` → v3 (#65)
+  - `pnpm/action-setup` → v6 (#62)
+  - `actions/github-script` → v9 (#61)
+  - Grouped GitHub Actions minor/patch bumps (#59, #60, #64, #66, #69)
+
+---
+
 ## 2026-04-11
 
 ### Fixed


### PR DESCRIPTION
## Summary

- **fix(ai-claude-review)**: Bump parent review agent model from `claude-opus-4-6` to `claude-opus-4-7`
- **fix(ci-js)**: Remove deprecated `allow-unknown-licenses` input from `dependency-review-action` (unsupported since v4.9.0)
- **docs(changelog)**: Add `2026-04-22` entry covering all changes since tag `2026-04-11`

## Test plan

- [ ] CI green on this PR
- [ ] Spot-check a downstream consumer repo's next PR: Claude review runs with opus-4-7, no license-input warning from `ci-js`