### PR TITLE
chore(ci-js)!: rename type-check input and script to typecheck

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -24,7 +24,7 @@ on:
         type: string
         default: '.'
         description: 'Working directory'
-      enable-type-check:
+      enable-typecheck:
         type: boolean
         default: true
         description: 'Enable TypeScript type checking'
@@ -202,21 +202,21 @@ jobs:
           esac
 
       - name: Type check
-        if: inputs.enable-type-check
+        if: inputs.enable-typecheck
         working-directory: ${{ inputs.working-directory }}
         run: |
           case "${{ inputs.package-manager }}" in
             pnpm)
-              pnpm type-check
+              pnpm typecheck
               ;;
             bun)
-              bun run type-check
+              bun run typecheck
               ;;
             yarn)
-              yarn type-check
+              yarn typecheck
               ;;
             npm)
-              npm run type-check
+              npm run typecheck
               ;;
           esac
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ This is a rolling release - changes are deployed continuously to `main`.
 
 ---
 
+## 2026-04-25
+
+### Changed
+
+- **ci-js.yml** (BREAKING): Rename `enable-type-check` input to `enable-typecheck`
+  and switch invoked package script from `type-check` to `typecheck` for all
+  package managers (pnpm, bun, yarn, npm)
+  - Aligns with the de-facto JS ecosystem convention (`tsc --noEmit` scripts are
+    almost universally named `typecheck`, single word)
+  - Consumer action required: rename the `type-check` script in `package.json`
+    to `typecheck`, and rename the workflow input if explicitly set
+  - Input default value unchanged (`enable-typecheck: true`); existing
+    consumers still invoke type checking by default and therefore need
+    the renamed `typecheck` script regardless of whether they set the
+    input
+
+---
+
 ## 2026-04-23
 
 ### Changed


### PR DESCRIPTION
## Summary

- Rename `enable-type-check` input → `enable-typecheck` in `ci-js.yml`
- Rename the invoked package script `type-check` → `typecheck` for pnpm, bun, yarn and npm
- Document the breaking change in `CHANGELOG.md`

Aligns the reusable workflow with the de-facto JS ecosystem convention where `tsc --noEmit` scripts are named `typecheck` (single word).

## Breaking Change

Consumers must:

1. Rename the `type-check` script in `package.json` to `typecheck`
2. If they set the workflow input explicitly, rename `enable-type-check` → `enable-typecheck`

Default behavior (`enable-typecheck: true`) is unchanged.

## Test plan

- [ ] Verify pnpm consumer (e.g. `functions/`) succeeds with the renamed script
- [ ] Verify a consumer that omits the input keeps default `true` behavior
- [ ] Tag a new date-based release once consumer migrations land