### PR TITLE
chore: rolling release 2026-04-25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This is a rolling release - changes are deployed continuously to `main`.
     consumers still invoke type checking by default and therefore need
     the renamed `typecheck` script regardless of whether they set the
     input
+- Dependency refreshes since 2026-04-23 (all via Renovate):
+  - Grouped GitHub Actions SHA bumps (#72, #73, #74)
 
 ---
 


### PR DESCRIPTION
## Summary

Closes out the day's release by adding the missing dependency-refresh section to the 2026-04-25 CHANGELOG entry, so the upcoming `2026-04-25` tag covers everything since `2026-04-23`:

- `chore(ci-js)!: rename type-check input and script to typecheck` (#75) — already documented
- `chore(deps): Update GitHub Actions` (#72, #73, #74) — newly summarised under "Dependency refreshes"

## Test plan

- [ ] `claude-review` green
- [ ] After merge: tag `2026-04-25` (annotated, "Rolling release 2026-04-25") on the resulting `main` HEAD and move `latest`