### PR TITLE
chore: cross-cutting audit fixes (workflows, renovate, templates, docs)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,127 @@
+name: Bug Report
+description: Report a bug in any sbaerlocher repository
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report.
+
+        > **Security note:** if this is a security vulnerability, do **not**
+        > open a public issue. Use [GitHub Security Advisories](https://github.com/sbaerlocher/.github/security/advisories/new)
+        > or follow [SECURITY.md](https://github.com/sbaerlocher/.github/blob/main/SECURITY.md).
+        >
+        > **Before pasting logs**, redact any secrets, API tokens, credentials,
+        > or personal data. They cannot be removed once submitted.
+
+  - type: input
+    id: repository
+    attributes:
+      label: Affected repository
+      description: Which repository is affected? (org/repo)
+      placeholder: e.g. sbaerlocher/functions, sbaerlocher/.github
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: A clear and concise description of the bug.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+      placeholder: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: A minimal sequence that reproduces the bug.
+      placeholder: |
+        1. Go to '...'
+        2. Run '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How severe is this bug? (Triage may adjust.)
+      options:
+        - Low — cosmetic or minor inconvenience
+        - Medium — broken feature with workaround
+        - High — broken feature without workaround
+        - Critical — data loss, security, or production outage
+      default: 1
+    validations:
+      required: true
+
+  - type: dropdown
+    id: regression
+    attributes:
+      label: Is this a regression?
+      description: Did this work in a previous version?
+      options:
+        - "No / not sure"
+        - "Yes — it worked before"
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error output / logs
+      description: |
+        Paste relevant error messages or logs.
+        ⚠️ Redact secrets, tokens, API keys, and personal data first.
+      render: shell
+      placeholder: Paste error output here
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Version, commit SHA, image tag, or workflow date tag.
+      placeholder: e.g. 1.2.3, abc1234, 2026-04-25
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS / runtime / browser / cluster — whatever is relevant.
+      placeholder: e.g. macOS 15.3, Node 22.11, Chrome 130, Kubernetes 1.32
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Anything else that helps diagnose the issue.
+      placeholder: Optional
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched existing issues to avoid duplicates
+          required: true
+        - label: I redacted secrets, tokens, and personal data from logs
+          required: true
+        - label: This is not a security vulnerability (use Security Advisories instead)
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/sbaerlocher/.github/security/advisories/new
+    about: Report security issues privately via GitHub Security Advisories.
+  - name: Question or Discussion
+    url: https://github.com/sbaerlocher/.github/discussions
+    about: Ask a question or share an idea in Discussions.
+  - name: Repository Standards
+    url: https://github.com/sbaerlocher/.github/blob/main/STANDARDS.md
+    about: Conventions, required files, and workflow patterns.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,96 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a new feature. Please describe the idea
+        in enough detail that a maintainer can decide on scope and approach.
+
+  - type: input
+    id: repository
+    attributes:
+      label: Affected repository
+      description: Which repository is this feature for? (org/repo)
+      placeholder: e.g. sbaerlocher/functions, sbaerlocher/.github
+    validations:
+      required: true
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Feature type
+      options:
+        - New functionality
+        - Enhancement to existing feature
+        - New configuration option
+        - New platform support
+        - Performance improvement
+        - Documentation improvement
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: Which problem does this feature solve, and for whom?
+      placeholder: Today, when I try to ..., I run into ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the change you'd like to see.
+      placeholder: I would like to ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What does "done" look like? List measurable, verifiable criteria.
+      placeholder: |
+        - [ ] Workflow accepts a new `foo` input with default `bar`
+        - [ ] Documentation in STANDARDS.md updated
+        - [ ] CHANGELOG entry added
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you evaluated and why they were dismissed.
+      placeholder: Optional
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Screenshots, links, prior art, related issues.
+      placeholder: Optional
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I would be willing to submit a pull request for this feature
+          required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched existing issues to avoid duplicates
+          required: true
+        - label: This feature is in scope for the affected repository
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+<!--
+PR title MUST follow Conventional Commits: <type>(<scope>): <subject>
+Allowed types: feat, fix, chore, docs, refactor, perf, test, ci, build, style
+Scopes are project-specific (e.g. functions/github-stats, infrastructure/platform).
+See STANDARDS.md for details.
+-->
+
+## Description
+
+<!-- Clear, concise description of what this PR changes and why. -->
+
+## Related Issue
+
+<!--
+"Fixes #123" auto-closes the linked issue when merged into the default branch.
+Remove this section if there is no related issue.
+-->
+
+## Changes
+
+<!-- Bullet list of the substantive changes. -->
+
+-
+-
+
+## Testing
+
+<!--
+How did you verify the change? Include commands, screenshots, or links to CI runs.
+Redact any secrets, tokens, or PII before posting logs.
+-->
+
+- [ ] Automated tests pass (or N/A)
+- [ ] Manual verification completed (or N/A)
+
+## Breaking Changes
+
+<!-- If this PR introduces breaking changes, describe them here and include migration notes. Otherwise write "None". -->
+
+## Checklist
+
+- [ ] PR title follows Conventional Commits
+- [ ] Self-review completed; no leftover debug code or commented blocks
+- [ ] Documentation updated where behavior or usage changed
+- [ ] No secrets, tokens, or credentials added to the repository

--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1
+      - uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1.0.107
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           classify_inline_comments: 'false'

--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1.0.107
+      - uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           classify_inline_comments: 'false'

--- a/.github/workflows/ai-claude.yml
+++ b/.github/workflows/ai-claude.yml
@@ -27,8 +27,8 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1
+      - uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1.0.107
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/ci-ansible.yml
+++ b/.github/workflows/ci-ansible.yml
@@ -32,6 +32,10 @@ on:
         type: boolean
         default: false
         description: 'Run yamllint on YAML files'
+      yamllint-strict:
+        type: boolean
+        default: true
+        description: 'Fail the job when yamllint reports any issue'
       ansible-lint-strict:
         type: boolean
         default: false
@@ -39,6 +43,10 @@ on:
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validation:
@@ -157,5 +165,9 @@ jobs:
         run: |
           echo "::group::Run yamllint"
           echo "Linting YAML files in ${{ inputs.working-directory }}..."
-          yamllint -f parsable . || true
+          if [ "${{ inputs.yamllint-strict }}" = "true" ]; then
+            yamllint -f parsable .
+          else
+            yamllint -f parsable . || true
+          fi
           echo "::endgroup::"

--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -278,10 +278,16 @@ jobs:
           curl --fail --silent --show-error --location -o "$tarball" "$base/$tarball"
           curl --fail --silent --show-error --location -o CHECKSUMS "$base/CHECKSUMS"
 
-          grep " $tarball\$" CHECKSUMS | sha256sum -c -
-          tar xzf "$tarball"
+          # CHECKSUMS is in GNU sha256sum text-mode format ("<hash>  <file>", two spaces).
+          # If upstream ever switches to binary mode ("<hash> *<file>"), the grep below
+          # would fail to find the line and pipefail aborts the step — fail-closed is
+          # the desired behaviour here.
+          grep -E "  ${tarball}\$" CHECKSUMS | sha256sum -c -
+
+          # Extract only the binary; LICENSE and other archive members are irrelevant.
+          tar -xzf "$tarball" kubeconform
           sudo install -m 0755 kubeconform /usr/local/bin/
-          rm -f kubeconform LICENSE "$tarball" CHECKSUMS
+          rm -f kubeconform "$tarball" CHECKSUMS
 
       - name: Validate Kubernetes manifests
         env:

--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -18,9 +18,10 @@ on:
         required: false
         default: '4.1.3'
       kubeconform-version:
-        description: 'kubeconform version'
+        description: 'kubeconform version (without v prefix)'
         type: string
         required: false
+        # renovate: datasource=github-releases depName=yannh/kubeconform extractVersion=^v(?<version>.+)$
         default: '0.7.0'
       enable-yaml-lint:
         description: 'Run YAML syntax validation'
@@ -44,6 +45,16 @@ on:
         default: true
       enable-k8s-validation:
         description: 'Validate Kubernetes manifests with kubeconform'
+        type: boolean
+        required: false
+        default: true
+      yaml-lint-strict:
+        description: 'Fail the job when yamllint reports any issue'
+        type: boolean
+        required: false
+        default: true
+      k8s-validation-strict:
+        description: 'Fail the job when kubeconform reports invalid manifests'
         type: boolean
         required: false
         default: true
@@ -93,7 +104,18 @@ jobs:
 
       - name: Validate YAML files
         run: |
-          find . -name "*.yaml" -o -name "*.yml" | xargs yamllint -c .yamllint.yml || true
+          set -euo pipefail
+          if [ ! -f .yamllint.yml ]; then
+            echo "::warning::.yamllint.yml not found - using default config"
+          fi
+          # -print0 / xargs -0 to survive paths with spaces
+          if [ "${{ inputs.yaml-lint-strict }}" = "true" ]; then
+            find . \( -name '*.yaml' -o -name '*.yml' \) -print0 \
+              | xargs -0 yamllint ${{ hashFiles('.yamllint.yml') != '' && '-c .yamllint.yml' || '' }} -f parsable
+          else
+            find . \( -name '*.yaml' -o -name '*.yml' \) -print0 \
+              | xargs -0 yamllint ${{ hashFiles('.yamllint.yml') != '' && '-c .yamllint.yml' || '' }} -f parsable || true
+          fi
 
   validate-fleet-configs:
     name: Validate Fleet Configurations
@@ -246,16 +268,45 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install kubeconform
+        env:
+          KUBECONFORM_VERSION: ${{ inputs.kubeconform-version }}
         run: |
-          curl -L https://github.com/yannh/kubeconform/releases/download/v${{ inputs.kubeconform-version }}/kubeconform-linux-amd64.tar.gz | tar xz
-          sudo mv kubeconform /usr/local/bin/
+          set -euo pipefail
+          tarball="kubeconform-linux-amd64.tar.gz"
+          base="https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}"
+
+          curl --fail --silent --show-error --location -o "$tarball" "$base/$tarball"
+          curl --fail --silent --show-error --location -o CHECKSUMS "$base/CHECKSUMS"
+
+          grep " $tarball\$" CHECKSUMS | sha256sum -c -
+          tar xzf "$tarball"
+          sudo install -m 0755 kubeconform /usr/local/bin/
+          rm -f kubeconform LICENSE "$tarball" CHECKSUMS
 
       - name: Validate Kubernetes manifests
+        env:
+          FLEET_PATHS: ${{ inputs.fleet-paths }}
+          STRICT: ${{ inputs.k8s-validation-strict }}
         run: |
+          set -euo pipefail
           echo "Validating Kubernetes manifests with kubeconform..."
-          find ${{ inputs.fleet-paths }} -name "*.yaml" -o -name "*.yml" | \
-            grep -E "(templates|manifests)" | \
-            xargs kubeconform -summary -output json -ignore-missing-schemas || true
+
+          mapfile -t manifests < <(
+            find ${FLEET_PATHS} \( -name '*.yaml' -o -name '*.yml' \) \
+              | grep -E '(templates|manifests)' \
+              || true
+          )
+
+          if [ ${#manifests[@]} -eq 0 ]; then
+            echo "::notice::No Kubernetes manifests found under: ${FLEET_PATHS}"
+            exit 0
+          fi
+
+          if [ "$STRICT" = "true" ]; then
+            kubeconform -summary -output json -ignore-missing-schemas "${manifests[@]}"
+          else
+            kubeconform -summary -output json -ignore-missing-schemas "${manifests[@]}" || true
+          fi
 
   check-documentation:
     name: Check Documentation

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -93,6 +93,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   setup:
     name: Setup
@@ -168,7 +172,8 @@ jobs:
       - name: Run staticcheck
         uses: dominikh/staticcheck-action@9716614d4101e79b4340dd97b10e54d68234e431 # v1.4.1
         with:
-          version: 'latest'
+          # renovate: datasource=github-releases depName=dominikh/go-tools
+          version: '2025.1.1'
           install-go: false
 
       - name: Set test environment variables
@@ -293,7 +298,8 @@ jobs:
       - name: Run staticcheck
         uses: dominikh/staticcheck-action@9716614d4101e79b4340dd97b10e54d68234e431 # v1.4.1
         with:
-          version: 'latest'
+          # renovate: datasource=github-releases depName=dominikh/go-tools
+          version: '2025.1.1'
           install-go: false
 
       - name: Set test environment variables
@@ -396,19 +402,25 @@ jobs:
 
       - name: Run gosec Security Scanner
         if: matrix.scanner == 'gosec'
+        env:
+          # renovate: datasource=github-releases depName=securego/gosec
+          GOSEC_VERSION: 'v2.22.10'
         run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@latest
+          go install "github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION}"
           gosec -no-fail -fmt sarif -out gosec.sarif ./...
 
       - name: Run govulncheck
         if: matrix.scanner == 'govulncheck'
+        env:
+          # renovate: datasource=go depName=golang.org/x/vuln
+          GOVULNCHECK_VERSION: 'v1.1.4'
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
           govulncheck -json ./... | tee govulncheck.json
-          # Show summary
-          if [ -s govulncheck.json ]; then
+          # govulncheck always emits JSON (progress + findings); use exit code instead.
+          if grep -q '"finding"' govulncheck.json; then
             echo "::warning::Vulnerabilities detected by govulncheck"
-            jq -r '.message // empty' govulncheck.json | head -10
+            jq -r '.finding // empty | .osv' govulncheck.json | sort -u | head -10
           else
             echo "::notice::No vulnerabilities found by govulncheck"
           fi
@@ -426,7 +438,7 @@ jobs:
 
       - name: Upload SARIF file
         if: inputs.enable-sarif-upload && (matrix.scanner == 'gosec' || matrix.scanner == 'trivy-fs')
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: ${{ matrix.scanner }}.sarif
           category: ${{ matrix.scanner }}
@@ -448,15 +460,15 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           languages: go
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           category: '/language:go'
 

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -416,14 +416,22 @@ jobs:
           GOVULNCHECK_VERSION: 'v1.1.4'
         run: |
           go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
+          # govulncheck exits 3 on findings; under the runner's `bash -eo pipefail`
+          # the pipe would abort before we summarise, so disable -e for the run.
+          set +e
           govulncheck -json ./... | tee govulncheck.json
-          # govulncheck always emits JSON (progress + findings); use exit code instead.
+          rc=${PIPESTATUS[0]}
+          set -e
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 3 ]; then
+            echo "::error::govulncheck failed (exit $rc)"
+            exit "$rc"
+          fi
           if grep -q '"finding"' govulncheck.json; then
             echo "::warning::Vulnerabilities detected by govulncheck"
             jq -r '.finding // empty | .osv' govulncheck.json | sort -u | head -10
-          else
-            echo "::notice::No vulnerabilities found by govulncheck"
+            exit 1
           fi
+          echo "::notice::No vulnerabilities found by govulncheck"
 
       - name: Run Trivy filesystem scanner
         if: matrix.scanner == 'trivy-fs'

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -100,6 +100,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   setup:
     name: Setup
@@ -482,7 +486,7 @@ jobs:
 
       - name: Upload SARIF file
         if: inputs.enable-sarif-upload && matrix.scanner == 'trivy-fs'
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: trivy-fs.sarif
           category: trivy-fs

--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -20,7 +20,10 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   TF_IN_AUTOMATION: 'true'
@@ -88,7 +91,8 @@ jobs:
       - name: Setup TFLint
         uses: terraform-linters/setup-tflint@b480b8fcdaa6f2c577f8e4fa799e89e756bb7c93 # v6.2.2
         with:
-          tflint_version: latest
+          # renovate: datasource=github-releases depName=terraform-linters/tflint
+          tflint_version: 'v0.59.1'
 
       - name: TFLint Init
         working-directory: ${{ inputs.working-directory }}
@@ -147,7 +151,7 @@ jobs:
 
       - name: Upload Trivy SARIF to GitHub Security
         if: ${{ inputs.enable-sarif-upload }}
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: 'trivy-results.sarif'
           category: 'trivy'

--- a/.github/workflows/deploy-cloudflare-workers.yml
+++ b/.github/workflows/deploy-cloudflare-workers.yml
@@ -40,6 +40,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     name: Deploy Worker (${{ matrix.worker }})

--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -252,7 +252,7 @@ jobs:
 
       - name: 'Plan Artifact Storage'
         if: steps.plan.outputs.outcome != 'error'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: terraform-plan-${{ inputs.project-name }}-${{ inputs.environment }}
           path: '${{ inputs.working-directory }}/*.tfplan'

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -59,6 +59,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e-docker:
     name: E2E (Docker Compose)
@@ -169,7 +173,7 @@ jobs:
       # PR Comment
       - name: Comment PR with test results
         if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/ops-terraform-orchestration.yml
+++ b/.github/workflows/ops-terraform-orchestration.yml
@@ -46,6 +46,13 @@ on:
         description: 'Terraform workspace name'
         value: ${{ jobs.orchestration.outputs.workspace }}
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   orchestration:
     name: Orchestrate Pipeline
@@ -70,55 +77,48 @@ jobs:
       - name: 'Detect Infrastructure Changes'
         id: enhanced_changes
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          FORCE_DEPLOY: ${{ github.event.inputs.force_deploy }}
+          FORCED_PUSH: ${{ github.event.forced }}
+          TF_PATTERN: ${{ inputs.terraform-patterns }}
+          CFG_PATTERN: ${{ inputs.config-patterns }}
         run: |
-          set -e
+          set -euo pipefail
 
-          # Initialize outputs
           terraform_changed="false"
           configuration_changed="false"
 
-          # Handle different event types
-          case "${{ github.event_name }}" in
-            "workflow_dispatch")
-              # For manual dispatch, assume changes if force_deploy is true
-              if [ "${{ github.event.inputs.force_deploy }}" = "true" ]; then
+          diff_changed() {
+            local pattern="$1"
+            git diff --name-only HEAD~1 HEAD | grep -E -- "$pattern" >/dev/null
+          }
+
+          case "$EVENT_NAME" in
+            workflow_dispatch)
+              if [ "$FORCE_DEPLOY" = "true" ]; then
                 terraform_changed="true"
                 configuration_changed="true"
               else
-                # Check against HEAD~1 for manual dispatch
-                if git diff --name-only HEAD~1 HEAD | grep -E '${{ inputs.terraform-patterns }}' > /dev/null; then
-                  terraform_changed="true"
-                fi
-                if git diff --name-only HEAD~1 HEAD | grep -E '${{ inputs.config-patterns }}' > /dev/null; then
-                  configuration_changed="true"
-                fi
+                if diff_changed "$TF_PATTERN"; then terraform_changed="true"; fi
+                if diff_changed "$CFG_PATTERN"; then configuration_changed="true"; fi
               fi
               ;;
-            "push")
-              # For push events, check if we can diff against the previous commit
-              if [ "${{ github.event.forced }}" = "true" ] || ! git rev-parse HEAD~1 >/dev/null 2>&1; then
-                # Force push or no previous commit - assume everything changed
-                echo "Force push detected or no previous commit available, assuming all changes"
+            push)
+              if [ "$FORCED_PUSH" = "true" ] || ! git rev-parse HEAD~1 >/dev/null 2>&1; then
+                echo "Force push or no previous commit — assuming all changes"
                 terraform_changed="true"
                 configuration_changed="true"
               else
-                # Normal push - check changes against previous commit
-                if git diff --name-only HEAD~1 HEAD | grep -E '${{ inputs.terraform-patterns }}' > /dev/null; then
-                  terraform_changed="true"
-                fi
-                if git diff --name-only HEAD~1 HEAD | grep -E '${{ inputs.config-patterns }}' > /dev/null; then
-                  configuration_changed="true"
-                fi
+                if diff_changed "$TF_PATTERN"; then terraform_changed="true"; fi
+                if diff_changed "$CFG_PATTERN"; then configuration_changed="true"; fi
               fi
               ;;
           esac
 
           echo "terraform=$terraform_changed" >> "$GITHUB_OUTPUT"
           echo "configuration=$configuration_changed" >> "$GITHUB_OUTPUT"
-
-          echo "Infrastructure change detection results:"
-          echo "  Terraform: $terraform_changed"
-          echo "  Configuration: $configuration_changed"
+          echo "Detection: terraform=$terraform_changed configuration=$configuration_changed"
 
       - name: 'Pipeline Configuration'
         id: config

--- a/.github/workflows/ops-terraform-orchestration.yml
+++ b/.github/workflows/ops-terraform-orchestration.yml
@@ -122,35 +122,50 @@ jobs:
 
       - name: 'Pipeline Configuration'
         id: config
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          SHA: ${{ github.sha }}
+          PROJECT_NAME: ${{ inputs.project-name }}
+          DEFAULT_ENV: ${{ inputs.default-environment }}
+          DISPATCH_ENV: ${{ github.event.inputs.environment }}
+          TERRAFORM_CHANGED: ${{ steps.enhanced_changes.outputs.terraform }}
+          CONFIGURATION_CHANGED: ${{ steps.enhanced_changes.outputs.configuration }}
         run: |
-          case "${{ github.event_name }}" in
-            "push")
-              if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-                ENVIRONMENT="${{ inputs.default-environment }}"
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            push)
+              if [ "$REF" = "refs/heads/main" ]; then
+                ENVIRONMENT="$DEFAULT_ENV"
                 DEPLOYMENT_MODE="production"
               else
+                echo "::error::push event on non-main ref ($REF) is not deployable"
                 exit 1
               fi
               ;;
-            "workflow_dispatch")
-              ENVIRONMENT="${{ github.event.inputs.environment || inputs.default-environment }}"
+            workflow_dispatch)
+              ENVIRONMENT="${DISPATCH_ENV:-$DEFAULT_ENV}"
               DEPLOYMENT_MODE="manual"
               ;;
             *)
+              echo "::error::unsupported event: $EVENT_NAME"
               exit 1
               ;;
           esac
 
-          WORKSPACE="${ENVIRONMENT}"
+          WORKSPACE="$ENVIRONMENT"
           SHOULD_DEPLOY="false"
 
           if [ "$DEPLOYMENT_MODE" = "validation" ]; then
             SHOULD_DEPLOY="false"
-          elif [ "${{ steps.enhanced_changes.outputs.terraform }}" = "true" ] || [ "${{ steps.enhanced_changes.outputs.configuration }}" = "true" ] || [ "$DEPLOYMENT_MODE" = "production" ] || [ "$DEPLOYMENT_MODE" = "manual" ]; then
+          elif [ "$TERRAFORM_CHANGED" = "true" ] \
+            || [ "$CONFIGURATION_CHANGED" = "true" ] \
+            || [ "$DEPLOYMENT_MODE" = "production" ] \
+            || [ "$DEPLOYMENT_MODE" = "manual" ]; then
             SHOULD_DEPLOY="true"
           fi
 
-          DEPLOYMENT_ID="${{ inputs.project-name }}-deploy-$(date +%Y%m%d-%H%M%S)-$(echo '${{ github.sha }}' | cut -c1-8)"
+          DEPLOYMENT_ID="${PROJECT_NAME}-deploy-$(date +%Y%m%d-%H%M%S)-${SHA:0:8}"
 
           {
             echo "environment=$ENVIRONMENT"

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -90,6 +90,10 @@ permissions:
   contents: read
   packages: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   docker-build:
     name: Build & Push
@@ -187,7 +191,7 @@ jobs:
 
       - name: Upload Trivy SARIF
         if: inputs.enable-trivy-scan && inputs.enable-sarif-upload
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: 'trivy-image.sarif'
           category: 'trivy-image'

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -39,6 +39,10 @@ permissions:
   contents: write
   packages: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   goreleaser:
     name: Build & Release
@@ -57,7 +61,7 @@ jobs:
           cache: true
 
       - name: Cache Go build artifacts
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
@@ -76,7 +80,7 @@ jobs:
           echo "$EXTRA_ENV" >> "$GITHUB_ENV"
 
       - name: Create release with GoReleaser
-        uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7
+        uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
         with:
           distribution: goreleaser
           version: ${{ inputs.goreleaser-version }}

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -46,6 +46,10 @@ permissions:
   contents: read
   packages: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   helm-release:
     name: Package & Publish

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -378,6 +378,12 @@ jobs:
             fi
           done
 
+  # Inlined here intentionally: a previous version called
+  # `uses: ./.github/workflows/security-sbom.yml`, which only resolves inside
+  # this repo and silently broke for every consumer. The CycloneDX/npm logic
+  # below duplicates security-sbom.yml — when bumping CYCLONEDX_NPM_VERSION,
+  # update both files. Long-term TODO: extract into a composite action under
+  # `.github/actions/sbom-npm/` so both workflows can call it cross-repo.
   generate-sbom:
     name: Generate SBOM
     needs: [pre-release-checks, publish]

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -67,6 +67,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   pre-release-checks:
     name: Validate Package
@@ -378,11 +382,52 @@ jobs:
     name: Generate SBOM
     needs: [pre-release-checks, publish]
     if: inputs.enable-sbom && needs.pre-release-checks.outputs.should-publish == 'true' && !inputs.dry-run
-    uses: ./.github/workflows/security-sbom.yml
-    with:
-      artifact-type: npm-package
-      artifact-ref: ${{ inputs.working-directory }}
-      sbom-format: cyclonedx-json
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: ${{ inputs.node-version-file }}
+
+      - name: Setup pnpm
+        if: inputs.package-manager == 'pnpm'
+        uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
+
+      - name: Setup Bun
+        if: inputs.package-manager == 'bun'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Install dependencies
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          case "${{ inputs.package-manager }}" in
+            pnpm) pnpm install --frozen-lockfile ;;
+            bun) bun install --frozen-lockfile ;;
+            yarn) yarn install --frozen-lockfile ;;
+            npm) npm ci ;;
+          esac
+
+      - name: Generate CycloneDX SBOM
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          npx --yes @cyclonedx/cyclonedx-npm@2.0.0 \
+            --output-format JSON \
+            --output-file sbom-npm-package.cdx.json
+          echo "✓ SBOM generated"
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom-npm-package
+          path: ${{ inputs.working-directory }}/sbom-npm-package.cdx.json
+          retention-days: 90
+          if-no-files-found: error
 
   github-release:
     name: Create Release
@@ -443,7 +488,7 @@ jobs:
 
       - name: Create GitHub Release
         id: create-release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: v${{ needs.pre-release-checks.outputs.version }}
           name: Release v${{ needs.pre-release-checks.outputs.version }}

--- a/.github/workflows/security-code.yml
+++ b/.github/workflows/security-code.yml
@@ -78,7 +78,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           languages: ${{ matrix.language }}
           queries: ${{ inputs.queries }}
@@ -102,7 +102,7 @@ jobs:
       # Setup language-specific environments
       - name: Install pnpm
         if: matrix.language == 'javascript-typescript' && steps.detect-pm.outputs.manager == 'pnpm'
-        uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
+        uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
 
       - name: Setup Node.js
         if: matrix.language == 'javascript-typescript'
@@ -156,10 +156,10 @@ jobs:
 
       - name: Autobuild
         if: inputs.build-command == '' && matrix.language != 'javascript-typescript' && matrix.language != 'python'
-        uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           category: '/language:${{ matrix.language }}'
           upload: ${{ inputs.enable-sarif-upload && 'always' || 'never' }}
@@ -167,7 +167,7 @@ jobs:
 
       - name: Upload SARIF as artifact
         if: ${{ !inputs.enable-sarif-upload }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: codeql-sarif-${{ matrix.language }}
           path: codeql-results/*.sarif

--- a/.github/workflows/security-config.yml
+++ b/.github/workflows/security-config.yml
@@ -230,11 +230,14 @@ jobs:
           # renovate: datasource=docker depName=kubesec/kubesec
           KUBESEC_IMAGE_VERSION: 'v2.14.2'
         run: |
-          # Glob expansion happens on the host, then files are bind-mounted via the workspace.
-          shopt -s globstar nullglob
-          mapfile -t manifests < <(printf '%s\n' **/*.yaml **/*.yml)
+          # Match the same scope the gating step established (find-manifests above):
+          # only files under */templates/*. This avoids feeding kubesec non-manifest
+          # YAML like Chart.yaml, values.yaml, kustomization.yaml or CI configs.
+          mapfile -t manifests < <(
+            find . -type f \( -name '*.yaml' -o -name '*.yml' \) -path '*/templates/*'
+          )
           if [ ${#manifests[@]} -eq 0 ]; then
-            echo "::notice::No YAML manifests found for kubesec"
+            echo "::notice::No Kubernetes manifests found under */templates/*"
             echo "[]" > kubesec-results.json
             exit 0
           fi

--- a/.github/workflows/security-config.yml
+++ b/.github/workflows/security-config.yml
@@ -49,6 +49,10 @@ permissions:
   contents: read
   security-events: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   trivy-config-scan:
     name: Trivy Config Scan
@@ -72,7 +76,7 @@ jobs:
         if: |
           inputs.enable-sarif && always() &&
           github.event.repository.visibility == 'public'
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: 'trivy-config-results.sarif'
           category: 'trivy-config'
@@ -88,11 +92,15 @@ jobs:
 
       - name: Generate Trivy report
         if: always()
+        env:
+          # renovate: datasource=docker depName=aquasec/trivy
+          TRIVY_IMAGE_VERSION: '0.59.1'
+          SEVERITY: ${{ inputs.severity-threshold }}
         run: |
           echo "Generating detailed Trivy report..."
           docker run --rm -v "$(pwd):/workspace" \
-            aquasec/trivy:0.35.0 config /workspace \
-            --severity ${{ inputs.severity-threshold }},HIGH,CRITICAL \
+            "aquasec/trivy:${TRIVY_IMAGE_VERSION}" config /workspace \
+            --severity "${SEVERITY},HIGH,CRITICAL" \
             --format table \
             | tee trivy-config-report.txt
 
@@ -142,7 +150,7 @@ jobs:
           inputs.enable-sarif && always() &&
           steps.sarif_check.outputs.exists == 'true' &&
           github.event.repository.visibility == 'public'
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: 'trivy-results.sarif'
           category: 'trivy-terraform'
@@ -218,9 +226,20 @@ jobs:
       - name: Run Kubesec
         if: steps.find-manifests.outputs.found == 'true'
         working-directory: ${{ inputs.kubernetes-path }}
+        env:
+          # renovate: datasource=docker depName=kubesec/kubesec
+          KUBESEC_IMAGE_VERSION: 'v2.14.2'
         run: |
-          docker run --rm -v "$(pwd):/workspace" \
-            kubesec/kubesec:v2 scan /workspace/**/*.yaml \
+          # Glob expansion happens on the host, then files are bind-mounted via the workspace.
+          shopt -s globstar nullglob
+          mapfile -t manifests < <(printf '%s\n' **/*.yaml **/*.yml)
+          if [ ${#manifests[@]} -eq 0 ]; then
+            echo "::notice::No YAML manifests found for kubesec"
+            echo "[]" > kubesec-results.json
+            exit 0
+          fi
+          docker run --rm -v "$(pwd):/workspace" -w /workspace \
+            "kubesec/kubesec:${KUBESEC_IMAGE_VERSION}" scan "${manifests[@]}" \
             | tee kubesec-results.json
 
           # Check for critical issues
@@ -277,8 +296,18 @@ jobs:
           python-version: '3.12'
 
       - name: Install Ansible and ansible-lint
+        env:
+          # renovate: datasource=pypi depName=ansible
+          ANSIBLE_VERSION: '11.10.0'
+          # renovate: datasource=pypi depName=ansible-lint
+          ANSIBLE_LINT_VERSION: '25.11.0'
+          # renovate: datasource=pypi depName=yamllint
+          YAMLLINT_VERSION: '1.37.1'
         run: |
-          pip install ansible ansible-lint yamllint
+          pip install \
+            "ansible==${ANSIBLE_VERSION}" \
+            "ansible-lint==${ANSIBLE_LINT_VERSION}" \
+            "yamllint==${YAMLLINT_VERSION}"
 
       - name: Run ansible-lint
         working-directory: ${{ inputs.ansible-path }}

--- a/.github/workflows/security-containers.yml
+++ b/.github/workflows/security-containers.yml
@@ -33,6 +33,10 @@ permissions:
   contents: read
   security-events: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   trivy-image:
     name: Scan with Trivy
@@ -62,7 +66,7 @@ jobs:
 
       - name: Upload Trivy SARIF
         if: inputs.enable-sarif-upload
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: 'trivy-image.sarif'
           category: 'trivy-image'

--- a/.github/workflows/security-deps.yml
+++ b/.github/workflows/security-deps.yml
@@ -40,6 +40,10 @@ permissions:
   pull-requests: write
   security-events: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dependency-review:
     name: Dependency Review (GitHub)
@@ -77,13 +81,17 @@ jobs:
       # Vulnerability scanning
       - name: Run govulncheck
         working-directory: ${{ inputs.working-directory }}
+        env:
+          # renovate: datasource=go depName=golang.org/x/vuln
+          GOVULNCHECK_VERSION: 'v1.1.4'
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
           govulncheck -json ./... | tee govulncheck.json
 
-          if [ -s govulncheck.json ]; then
+          # govulncheck always emits JSON (progress + findings); use grep instead of -s.
+          if grep -q '"finding"' govulncheck.json; then
             echo "::warning::Vulnerabilities detected by govulncheck"
-            jq -r '.message // empty' govulncheck.json | head -10
+            jq -r '.finding // empty | .osv' govulncheck.json | sort -u | head -10
           else
             echo "::notice::No vulnerabilities found"
           fi
@@ -92,10 +100,14 @@ jobs:
       - name: Check Go licenses
         if: inputs.enable-license-check
         working-directory: ${{ inputs.working-directory }}
+        env:
+          # renovate: datasource=go depName=github.com/google/go-licenses
+          GO_LICENSES_VERSION: 'v1.6.0'
+          ALLOWED_LICENSES: ${{ inputs.allowed-licenses }}
         run: |
-          go install github.com/google/go-licenses@latest
+          go install "github.com/google/go-licenses@${GO_LICENSES_VERSION}"
           echo "Checking Go dependency licenses..."
-          go-licenses check ./... --allowed_licenses=${{ inputs.allowed-licenses }} 2>&1 | tee go-licenses.txt || true
+          go-licenses check ./... --allowed_licenses="${ALLOWED_LICENSES}" 2>&1 | tee go-licenses.txt || true
           go-licenses csv ./... > go-licenses.csv 2>&1 || true
 
       - name: Upload audit results
@@ -167,13 +179,16 @@ jobs:
       - name: Check JavaScript licenses
         if: inputs.enable-license-check
         working-directory: ${{ inputs.working-directory }}
+        env:
+          # renovate: datasource=npm depName=license-checker
+          LICENSE_CHECKER_VERSION: '25.0.1'
+          DENIED: ${{ inputs.denied-licenses }}
         run: |
-          npm install -g license-checker
+          npm install -g "license-checker@${LICENSE_CHECKER_VERSION}"
           echo "Checking JavaScript dependency licenses..."
           license-checker --json > js-licenses.json 2>&1 || true
           license-checker --summary > js-licenses-summary.txt 2>&1 || true
 
-          DENIED="${{ inputs.denied-licenses }}"
           if [ -n "$DENIED" ]; then
             license-checker --failOn "$DENIED" 2>&1 | tee js-licenses-violations.txt || true
           fi
@@ -216,8 +231,11 @@ jobs:
       # Vulnerability scanning
       - name: Install and run safety
         working-directory: ${{ inputs.working-directory }}
+        env:
+          # renovate: datasource=pypi depName=safety
+          SAFETY_VERSION: '3.6.2'
         run: |
-          pip install safety
+          pip install "safety==${SAFETY_VERSION}"
           if [ -f requirements.txt ]; then
             safety check --file requirements.txt --json > safety-results.json || true
           fi
@@ -226,8 +244,11 @@ jobs:
       - name: Check Python licenses
         if: inputs.enable-license-check
         working-directory: ${{ inputs.working-directory }}
+        env:
+          # renovate: datasource=pypi depName=pip-licenses
+          PIP_LICENSES_VERSION: '5.0.0'
         run: |
-          pip install pip-licenses
+          pip install "pip-licenses==${PIP_LICENSES_VERSION}"
           echo "Checking Python dependency licenses..."
           pip-licenses --format=json > python-licenses.json 2>&1 || true
           pip-licenses --format=markdown > python-licenses.md 2>&1 || true

--- a/.github/workflows/security-deps.yml
+++ b/.github/workflows/security-deps.yml
@@ -86,9 +86,16 @@ jobs:
           GOVULNCHECK_VERSION: 'v1.1.4'
         run: |
           go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
+          # govulncheck exits 3 on findings; under the runner's `bash -eo pipefail`
+          # the pipe would abort before we summarise, so disable -e for the run.
+          set +e
           govulncheck -json ./... | tee govulncheck.json
-
-          # govulncheck always emits JSON (progress + findings); use grep instead of -s.
+          rc=${PIPESTATUS[0]}
+          set -e
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 3 ]; then
+            echo "::error::govulncheck failed (exit $rc)"
+            exit "$rc"
+          fi
           if grep -q '"finding"' govulncheck.json; then
             echo "::warning::Vulnerabilities detected by govulncheck"
             jq -r '.finding // empty | .osv' govulncheck.json | sort -u | head -10

--- a/.github/workflows/security-sbom.yml
+++ b/.github/workflows/security-sbom.yml
@@ -24,6 +24,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   generate-sbom:
     name: Generate SBOM
@@ -64,9 +68,13 @@ jobs:
       - name: Generate SBOM for Go binary
         if: inputs.artifact-type == 'go-binary'
         working-directory: ${{ inputs.working-directory }}
+        env:
+          # renovate: datasource=github-releases depName=CycloneDX/cyclonedx-gomod
+          CYCLONEDX_GOMOD_VERSION: 'v1.10.0'
+          ARTIFACT_TYPE: ${{ inputs.artifact-type }}
         run: |
-          go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest
-          cyclonedx-gomod mod -json -output ../sbom-${{ inputs.artifact-type }}.json
+          go install "github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@${CYCLONEDX_GOMOD_VERSION}"
+          cyclonedx-gomod mod -json -output "../sbom-${ARTIFACT_TYPE}.json"
 
       # NPM Package SBOM
       - name: Setup Node.js
@@ -78,10 +86,14 @@ jobs:
       - name: Generate SBOM for NPM package
         if: inputs.artifact-type == 'npm-package'
         working-directory: ${{ inputs.working-directory }}
+        env:
+          # renovate: datasource=npm depName=@cyclonedx/cyclonedx-npm
+          CYCLONEDX_NPM_VERSION: '2.0.0'
+          ARTIFACT_TYPE: ${{ inputs.artifact-type }}
         run: |
-          npm install -g @cyclonedx/cyclonedx-npm
+          npm install -g "@cyclonedx/cyclonedx-npm@${CYCLONEDX_NPM_VERSION}"
           npm ci
-          cyclonedx-npm --output-file ../sbom-${{ inputs.artifact-type }}.json
+          cyclonedx-npm --output-file "../sbom-${ARTIFACT_TYPE}.json"
 
       # Validate and upload SBOM
       - name: Validate SBOM

--- a/.github/workflows/security-secrets.yml
+++ b/.github/workflows/security-secrets.yml
@@ -30,6 +30,10 @@ permissions:
   actions: read
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gitleaks:
     name: Scan with Gitleaks
@@ -43,7 +47,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 **Repository Type**: Centralized Workflow Repository
 **Purpose**: Provide reusable GitHub Actions workflows for all sbaerlocher projects
 **Visibility**: Public
-**Last Updated**: 2026-02-14
+**Last Updated**: 2026-04-26
 
 ---
 
@@ -43,7 +43,7 @@ directly impacting the CI/CD pipelines of multiple projects.
 - `release-*.yml` - Release workflows
 - `ops-*.yml` - Operational workflows
 - `ai-*.yml` - AI-assisted workflows
-- `docs-*.yml` - Documentation workflows
+- `e2e-*.yml` - End-to-end test workflows
 
 **Workflow Names** (`name:` field):
 
@@ -78,19 +78,23 @@ uses: actions/setup-node@v4.0.2
 
 ### Workflow Versioning
 
-**Recommended**: Use version tags (`@v1`) for stable references
+This repository uses a **rolling release** model with date-based tags
+(`YYYY-MM-DD`). There are no `v1`/`v2` semver tags.
 
 ```yaml
-# Consumer repository
-uses: sbaerlocher/.github/.github/workflows/ci-js.yml@v1
+# Consumer repository — pin to a specific release date
+uses: sbaerlocher/.github/.github/workflows/ci-js.yml@2026-04-25
 ```
 
-**Not Recommended**: Using `@main` (breaking changes affect all repos immediately)
+**Rules**:
 
-**Tagging Strategy**:
-
-- Major versions: `v1`, `v2` (updated via Renovate or manually)
-- Point releases: `v1.0.0`, `v1.1.0` (documented in CHANGELOG.md)
+- Consumers MUST reference workflows by date tag.
+- `@main` is forbidden in consumer repos — breaking changes would propagate
+  immediately to all of them.
+- New tags are cut from `main` after a batch of changes has settled. The
+  cadence is documented in `CHANGELOG.md`.
+- Renovate updates date tags in consumer repos automatically via the
+  custom manager defined in `renovate-base.json`.
 
 ---
 
@@ -131,7 +135,7 @@ uses: sbaerlocher/.github/.github/workflows/ci-js.yml@v1
 **Strategy**:
 
 - **PR**: CodeQL only (fast feedback)
-- **Weekly**: Deep scans (scheduled Monday 02:00 UTC)
+- **Weekly**: Deep scans (scheduled Monday 06:00 UTC)
 - **Public Repos**: SARIF upload to GitHub Security tab (free)
 - **Private Repos**: Artifact upload (JSON/Table format)
 
@@ -184,9 +188,9 @@ uses: sbaerlocher/.github/.github/workflows/ci-js.yml@v1
 
 **Purpose**: End-to-end testing with Docker Compose
 
-| Workflow   | File              | Description                     |
-| ---------- | ----------------- | ------------------------------- |
-| E2E Docker | `e2e-docker.yml` | E2E tests via Docker Compose    |
+| Workflow   | File             | Description                  |
+| ---------- | ---------------- | ---------------------------- |
+| E2E Docker | `e2e-docker.yml` | E2E tests via Docker Compose |
 
 ---
 
@@ -208,9 +212,10 @@ uses: sbaerlocher/.github/.github/workflows/ci-js.yml@v1
 **Process**:
 
 1. **Test First**: Create a test version (e.g., `ci-js-test.yml`)
-2. **Consumer Testing**: Test in 1-2 consumer repos with test workflow
-3. **Breaking Changes**: Increment major version tag (`v1` → `v2`)
-4. **Non-Breaking**: Can update existing version tag
+2. **Consumer Testing**: Test in 1-2 consumer repos pointing at `@main`
+3. **Breaking Changes**: Cut a new dated tag and call out the break in
+   `CHANGELOG.md` so consumers know not to bump until they migrate
+4. **Non-Breaking**: A regular dated tag is sufficient
 5. **Document**: Update CHANGELOG.md with all changes
 
 **Breaking Changes Include**:
@@ -302,7 +307,7 @@ on:
 
 jobs:
   ci:
-    uses: sbaerlocher/.github/.github/workflows/ci-js.yml@v1
+    uses: sbaerlocher/.github/.github/workflows/ci-js.yml@2026-04-25
     with:
       package-manager: pnpm
       enable-security-scans: true
@@ -334,7 +339,7 @@ Error: Unable to resolve action sbaerlocher/.github/.github/workflows/ci-js.yml@
 **Solution**: Check the nested path structure
 
 ```yaml
-uses: sbaerlocher/.github/.github/workflows/ci-js.yml@v1
+uses: sbaerlocher/.github/.github/workflows/ci-js.yml@2026-04-25
 #     ^^^^^^^^^^^ Repo      ^^^^^^^^^^^^^^^^ Nested .github directory
 ```
 
@@ -378,25 +383,28 @@ Ensure lock files are committed:
 .github/
 ├── .github/
 │   ├── workflows/           # 21 reusable workflows
-│   │   ├── ci-*.yml        # CI workflows
-│   │   ├── security-*.yml  # Security workflows
-│   │   ├── deploy-*.yml    # Deploy workflows
-│   │   ├── release-*.yml   # Release workflows
-│   │   ├── ops-*.yml       # Operations workflows
 │   │   ├── ai-*.yml        # AI workflows
-│   │   └── docs-*.yml      # Documentation workflows
-│   ├── actions/            # Custom composite actions
+│   │   ├── ci-*.yml        # CI workflows
+│   │   ├── deploy-*.yml    # Deploy workflows
+│   │   ├── e2e-*.yml       # End-to-end test workflows
+│   │   ├── ops-*.yml       # Operations workflows
+│   │   ├── release-*.yml   # Release workflows
+│   │   └── security-*.yml  # Security workflows
+│   ├── ISSUE_TEMPLATE/     # Org-default issue forms
 │   ├── CODEOWNERS          # Repository owners
+│   ├── pull_request_template.md
 │   └── renovate.json       # Renovate configuration
 ├── AGENTS.md               # AI agent documentation (this file)
 ├── CLAUDE.md               # Claude Code import
 ├── README.md               # Human-readable documentation
 ├── CHANGELOG.md            # Version history
+├── SECURITY.md             # Org-default security policy
 ├── STANDARDS.md            # Repository standards
 ├── SETUP.md                # GitHub repo setup commands & branch rulesets
 ├── REVIEW.md               # Code review guidelines for this repo
 ├── LICENSE                 # MIT License
 ├── .editorconfig           # Editor consistency
+├── .prettierrc             # Prettier configuration
 ├── .gitignore              # Git ignore patterns
 ├── renovate-*.json         # Shared Renovate presets
 └── renovate.json           # Main Renovate config
@@ -432,21 +440,22 @@ Ensure lock files are committed:
 
 ### What You Should NOT Do
 
-❌ **Breaking Changes Without Versioning**:
+❌ **Breaking Changes Without a New Date Tag**:
 
-- NEVER make breaking changes to existing workflows without incrementing version
-- NEVER remove inputs/outputs without deprecation notice
-- NEVER change default behavior without testing impact
+- NEVER ship a breaking change without cutting a new dated release tag and
+  noting the break in `CHANGELOG.md`
+- NEVER remove inputs/outputs without a deprecation notice
+- NEVER change default behavior without testing impact in a consumer repo
 
 ❌ **Security Anti-Patterns**:
 
-- NEVER use tag-only action references (`@v4`)
+- NEVER use tag-only action references (`@v4`) for third-party actions
 - NEVER log secrets or sensitive data
 - NEVER skip security scans without justification
 
 ❌ **Workflow Anti-Patterns**:
 
-- NEVER use `@main` for consumer references (use `@v1`)
+- NEVER use `@main` for consumer references (use a date tag like `@2026-04-25`)
 - NEVER duplicate logic across workflows (use composite actions)
 - NEVER hard-code values (use inputs)
 
@@ -464,15 +473,16 @@ Ensure lock files are committed:
 
 ## Renovate Preset Conventions
 
-**Gotchas beim Bearbeiten der Renovate-Presets**:
+**Gotchas when editing the Renovate presets**:
 
-- `renovate.json` (eigene Konfiguration dieses Repos) muss den `#main`-Suffix verwenden:
-  `github>sbaerlocher/.github:renovate-base#main` — ohne `#main` referenziert Renovate
-  ggf. einen alten gepinnten Commit von sich selbst
-- `lockFileMaintenance` gehört **nicht** in `packageRules` — Renovate behandelt es als
-  Top-Level-Scheduler, nicht als Package Rule
-- JS-Framework-Gruppenregeln (Svelte, Vue, React usw.) benötigen explizite
-  `matchPackageNames`-Einträge, damit Major-Updates korrekt abgefangen werden
+- This repo's own `renovate.json` MUST use the `#main` suffix when extending
+  its own presets: `github>sbaerlocher/.github:renovate-base#main`. Without
+  `#main`, Renovate may resolve to an older pinned commit of this repo.
+  Consumer repos should omit `#main` and use the default resolution.
+- `lockFileMaintenance` is a top-level scheduler, not a package rule —
+  it does **not** belong inside `packageRules`.
+- JS framework group rules (Svelte, Vue, React, …) need explicit
+  `matchPackageNames` entries; otherwise major updates are not captured.
 
 ---
 
@@ -505,5 +515,5 @@ Ensure lock files are committed:
 
 ---
 
-**Last Updated**: 2026-02-14
-**Version**: 1.1.0
+**Last Updated**: 2026-04-26
+**Version**: 1.2.0

--- a/README.md
+++ b/README.md
@@ -1,27 +1,37 @@
 # Reusable GitHub Actions Workflows
 
-**Model:** Rolling Release
-**Total Workflows:** 27 (consolidated from 30+)
-**Last Updated:** 2026-02-14
+Centralized CI/CD building blocks for all repositories under
+[`sbaerlocher`](https://github.com/sbaerlocher). Consumer repositories pin
+each workflow by date tag and let Renovate keep them current.
+
+- **Model:** rolling release with date tags (`YYYY-MM-DD`)
+- **Total workflows:** 21
+- **Last updated:** 2026-04-26
+
+See [STANDARDS.md](./STANDARDS.md) for repository conventions and
+[AGENTS.md](./AGENTS.md) for AI-agent context.
 
 ---
 
-## 🚀 Quick Start
+## Quick Start
 
-### JavaScript/TypeScript Projects
+Pick the most recent date tag from
+<https://github.com/sbaerlocher/.github/tags> (used as `<TAG>` below) and
+reference workflows from your consumer repository.
+
+### JavaScript / TypeScript
 
 ```yaml
 # .github/workflows/ci.yml
-name: CI
-
+name: Continuous Integration
 on:
   pull_request:
-  push:
     branches: [main]
+  workflow_call:
 
 jobs:
   ci:
-    uses: sbaerlocher/.github/.github/workflows/ci-js.yml@v1
+    uses: sbaerlocher/.github/.github/workflows/ci-js.yml@<TAG>
     with:
       package-manager: pnpm
       enable-security-scans: true
@@ -29,31 +39,30 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 ```
 
-### Go Projects
+### Go
 
 ```yaml
-# .github/workflows/ci.yml
 jobs:
   ci:
-    uses: sbaerlocher/.github/.github/workflows/ci-go.yml@v1
+    uses: sbaerlocher/.github/.github/workflows/ci-go.yml@<TAG>
     with:
       go-version: '1.25'
 ```
 
-### Terraform Projects
+### Terraform
 
 ```yaml
 # .github/workflows/ci.yml
 jobs:
   terraform:
-    uses: sbaerlocher/.github/.github/workflows/ci-terraform.yml@v1
+    uses: sbaerlocher/.github/.github/workflows/ci-terraform.yml@<TAG>
 
-# .github/workflows/deploy.yml (on: push main)
+# .github/workflows/deploy.yml — on push to main
 jobs:
   deploy:
-    uses: sbaerlocher/.github/.github/workflows/deploy-terraform.yml@v1
+    uses: sbaerlocher/.github/.github/workflows/deploy-terraform.yml@<TAG>
     with:
-      environment: 'production'
+      environment: production
       bw-secrets: |
         <uuid> > ENV_VAR
     secrets:
@@ -62,896 +71,168 @@ jobs:
 
 ---
 
-## 📂 Workflow Categories
+## Workflow Catalogue
 
-### CI - Continuous Integration (4)
+All files live in [.github/workflows/](./.github/workflows/).
 
-- **[ci-ansible.yml](./.github/workflows/ci-ansible.yml)** - Ansible Linting & Validation
-- **[ci-go.yml](./.github/workflows/ci-go.yml)** - Go Build, Test & Security
-- **[ci-js.yml](./.github/workflows/ci-js.yml)** - JavaScript/TypeScript All-in-One
-- **[ci-terraform.yml](./.github/workflows/ci-terraform.yml)** - Terraform Validation
+### CI — Continuous Integration (5)
 
-### Security - Scanning & Analysis (6)
+| File                                                       | Purpose                                  |
+| ---------------------------------------------------------- | ---------------------------------------- |
+| [`ci-ansible.yml`](./.github/workflows/ci-ansible.yml)     | Ansible syntax & ansible-lint            |
+| [`ci-gitops.yml`](./.github/workflows/ci-gitops.yml)       | Fleet, Helm, kubeconform validation      |
+| [`ci-go.yml`](./.github/workflows/ci-go.yml)               | Build, test, golangci-lint, gosec        |
+| [`ci-js.yml`](./.github/workflows/ci-js.yml)               | Quality, tests, audit (multi-pm)         |
+| [`ci-terraform.yml`](./.github/workflows/ci-terraform.yml) | `terraform fmt`, validate, tflint, Trivy |
 
-- **[security-code.yml](./.github/workflows/security-code.yml)** - SAST (CodeQL Multi-Language)
-- **[security-config.yml](./.github/workflows/security-config.yml)** - Infrastructure Config (TF/K8s/Ansible)
-- **[security-deps.yml](./.github/workflows/security-deps.yml)** - Dependencies & Licenses
-- **[security-secrets.yml](./.github/workflows/security-secrets.yml)** - Secret Detection
-- **[security-containers.yml](./.github/workflows/security-containers.yml)** - Container Security
-- **[security-supply-chain.yml](./.github/workflows/security-supply-chain.yml)** - SBOM & Signing
+### Security — Scanning & Analysis (6)
 
-### Deploy - Deployment Operations (2)
+| File                                                                     | Tools                          |
+| ------------------------------------------------------------------------ | ------------------------------ |
+| [`security-code.yml`](./.github/workflows/security-code.yml)             | CodeQL (multi-language SAST)   |
+| [`security-config.yml`](./.github/workflows/security-config.yml)         | Checkov, kubeconform, kubesec  |
+| [`security-containers.yml`](./.github/workflows/security-containers.yml) | Trivy + Grype                  |
+| [`security-deps.yml`](./.github/workflows/security-deps.yml)             | govulncheck, npm audit, safety |
+| [`security-sbom.yml`](./.github/workflows/security-sbom.yml)             | CycloneDX SBOM generation      |
+| [`security-secrets.yml`](./.github/workflows/security-secrets.yml)       | Gitleaks + TruffleHog          |
 
-- **[deploy-terraform.yml](./.github/workflows/deploy-terraform.yml)** - Terraform Deployment
-- **[deploy-cloudflare-workers.yml](./.github/workflows/deploy-cloudflare-workers.yml)** - Cloudflare Workers
+### Deploy (2)
 
-### Release - Release Management (4)
+- [`deploy-cloudflare-workers.yml`](./.github/workflows/deploy-cloudflare-workers.yml)
+  — Cloudflare Workers via Wrangler
+- [`deploy-terraform.yml`](./.github/workflows/deploy-terraform.yml)
+  — Terraform plan & apply with Bitwarden secret injection
 
-- **[release-go.yml](./.github/workflows/release-go.yml)** - Go Binary Release (GoReleaser)
-- **[release-helm.yml](./.github/workflows/release-helm.yml)** - Helm Chart Release
-- **[release-docker.yml](./.github/workflows/release-docker.yml)** - Docker Image Build & Push
-- **[release-npm.yml](./.github/workflows/release-npm.yml)** - NPM Package with Provenance
+### Release (4)
 
-### Operations - Operational Tasks (4)
+| File                                                              | Output                               |
+| ----------------------------------------------------------------- | ------------------------------------ |
+| [`release-docker.yml`](./.github/workflows/release-docker.yml)    | Multi-arch Docker images to GHCR     |
+| [`release-go.yml`](./.github/workflows/release-go.yml)            | GoReleaser binaries + GitHub Release |
+| [`release-helm.yml`](./.github/workflows/release-helm.yml)        | Helm OCI chart publish               |
+| [`release-npm.yml`](./.github/workflows/release-npm.yml)          | NPM publish with provenance + SBOM   |
 
-- **[drift-terraform.yml](./.github/workflows/drift-terraform.yml)** - Terraform Drift Detection (Legacy)
-- **[ops-drift-detection.yml](./.github/workflows/ops-drift-detection.yml)** - Terraform Drift Detection
-- **[ops-sync-secrets.yml](./.github/workflows/ops-sync-secrets.yml)** - Cloudflare Workers Secret Sync
-- **[ops-terraform-orchestration.yml](./.github/workflows/ops-terraform-orchestration.yml)** - Multi-Environment
+### Operations (1)
 
-### Testing & Quality (3)
+- [`ops-terraform-orchestration.yml`](./.github/workflows/ops-terraform-orchestration.yml)
+  — Multi-environment Terraform deployment driver
 
-- **[e2e-docker.yml](./.github/workflows/e2e-docker.yml)** - E2E Testing with Docker Compose
-- **[helm-test.yml](./.github/workflows/helm-test.yml)** - Helm Chart Testing with Kind
-- **[quality-benchmarks.yml](./.github/workflows/quality-benchmarks.yml)** - Performance Benchmarking
+### AI — Private Repos Only (2)
 
-### Other (4)
+- [`ai-claude.yml`](./.github/workflows/ai-claude.yml)
+  — On-demand `@claude` mentions in issues and PRs
+- [`ai-claude-review.yml`](./.github/workflows/ai-claude-review.yml)
+  — Automatic code review on PRs (uses REVIEW.md as context)
 
-- **AI**: [ai-claude.yml](./.github/workflows/ai-claude.yml), [ai-claude-review.yml](./.github/workflows/ai-claude-review.yml)
-- **Docs**: [docs-terraform.yml](./.github/workflows/docs-terraform.yml)
-- **Notify**: [notify-deployment.yml](./.github/workflows/notify-deployment.yml)
+### E2E (1)
 
----
-
-## 🎯 Key Features
-
-### 1. Consolidation Strategy
-
-**Security Workflows**: 9 → 6 (-33% complexity, +100% coverage)
-
-- Multi-language support (Go + JS/TS + Python in one workflow)
-- Multi-tool defense (Trivy + Grype, Gitleaks + TruffleHog)
-- Supply chain security (SBOM + Cosign signing)
-
-**JavaScript CI**: 3 → 1
-
-- All-in-one workflow with smart conditionals
-- Quality + Tests + Security in one call
-- Supports pnpm, npm, yarn, bun
-
-### 2. Enterprise-Grade Security
-
-- **SAST**: CodeQL for 6+ languages
-- **Secrets**: Gitleaks + TruffleHog
-- **Dependencies**: govulncheck, npm audit, safety
-- **Containers**: Trivy + Grype
-- **Licenses**: Compliance for Go, JS/TS, Python
-- **SBOM**: CycloneDX + SPDX formats
-- **Signing**: Cosign keyless signing
-
-### 3. Performance Optimized
-
-- Parallel security scans (matrix strategy)
-- Smart caching (dependencies + Turborepo)
-- Conditional execution (skip unnecessary scans)
-- Typical CI time: 5-12 minutes
-
-### 4. Production Ready
-
-- SARIF upload for GitHub Security tab
-- PR comments for dependency review
-- Fail-on-findings options
-- Comprehensive summary reports
+| File                                                   | Purpose                             |
+| ------------------------------------------------------ | ----------------------------------- |
+| [`e2e-docker.yml`](./.github/workflows/e2e-docker.yml) | End-to-end tests via Docker Compose |
 
 ---
 
-## 📖 Usage Examples
+## Project Type Guide
 
-### Complete CI/CD Pipeline (JavaScript)
+**Per language / stack:**
+
+- **JavaScript / TypeScript** — `ci-js.yml`; optional `release-npm.yml`,
+  `deploy-cloudflare-workers.yml`
+- **Go** — `ci-go.yml`; optional `release-go.yml`, `release-docker.yml`
+- **Terraform / IaC** — `ci-terraform.yml`, `deploy-terraform.yml`;
+  optional `ops-terraform-orchestration.yml`
+- **GitOps (Fleet / Helm)** — `ci-gitops.yml`; optional `release-helm.yml`
+- **Serverless (CF Workers)** — `ci-js.yml`, `deploy-cloudflare-workers.yml`
+
+**Cross-cutting:**
+
+- **Public repos (any language)** — add `security-code.yml` (CodeQL).
+  Weekly `security-*` scans recommended.
+- **Private repos (any language)** — add `ai-claude-review.yml` and
+  `ai-claude.yml`.
+
+Weekly security scans should be scheduled at `0 6 * * 1` (Monday 06:00 UTC).
+Never wire scheduled workflows as required status checks — they don't run on
+PRs and would block every merge.
+
+---
+
+## Versioning
+
+Reference workflows from a consumer repo by **date tag**:
 
 ```yaml
-# .github/workflows/ci.yml
-name: CI
-on: [pull_request, push]
-
-jobs:
-  ci:
-    uses: sbaerlocher/.github/.github/workflows/ci-js.yml@v1
-    with:
-      package-manager: pnpm
-      enable-security-scans: true
-      enable-dependency-review: true
-
-# .github/workflows/security.yml
-name: Security
-on:
-  schedule:
-    - cron: '0 6 * * *'  # Daily at 6 AM UTC
-
-jobs:
-  code-analysis:
-    uses: sbaerlocher/.github/.github/workflows/security-code.yml@v1
-    with:
-      languages: '["javascript-typescript"]'
-
-  deps-and-licenses:
-    uses: sbaerlocher/.github/.github/workflows/security-deps.yml@v1
-    with:
-      language: 'javascript'
-      enable-license-check: true
-
-  secret-detection:
-    uses: sbaerlocher/.github/.github/workflows/security-secrets.yml@v1
-
-# .github/workflows/deploy.yml
-name: Deploy
-on:
-  push:
-    branches: [main]
-
-jobs:
-  deploy:
-    uses: sbaerlocher/.github/.github/workflows/deploy-cloudflare-workers.yml@v1
-    with:
-      workers: '["worker1", "worker2"]'
-      package-manager: pnpm
-    secrets:
-      BW_ACCESS_TOKEN: ${{ secrets.BW_ACCESS_TOKEN }}
-
-# .github/workflows/release.yml
-name: Release
-on:
-  push:
-    tags: ['v*']
-
-jobs:
-  release:
-    uses: sbaerlocher/.github/.github/workflows/release-npm.yml@v1
-
-  sbom:
-    uses: sbaerlocher/.github/.github/workflows/security-supply-chain.yml@v1
-    with:
-      artifact-type: 'npm-package'
-      artifact-ref: '.'
-      enable-sbom: true
+uses: sbaerlocher/.github/.github/workflows/ci-js.yml@2026-04-25
 ```
+
+Rules:
+
+- Date tag is mandatory in consumer repos. `@main` and `@v1` are not
+  supported.
+- New tags are cut from `main` after a batch of changes settles.
+  See [CHANGELOG.md](./CHANGELOG.md) for the history.
+- Renovate updates these tags automatically via the custom manager in
+  [`renovate-base.json`](./renovate-base.json).
 
 ---
 
-## 📋 Project Type Guide
+## Required Secrets in Consumer Repos
 
-### Required Workflows by Repository Type
-
-| Repository Type                | Required Workflows                                                                                      | Optional Workflows                                                      | Triggers              |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | --------------------- |
-| **JavaScript/TypeScript**      | `ci.yml` (ci-js)<br>`security.yml` (code-analysis)                                                      | `release.yml` (release-npm)<br>`deploy.yml` (deploy-cloudflare-workers) | PR, Push, Weekly      |
-| **Go Projects**                | `ci.yml` (ci-go)<br>`security.yml` (code-analysis)                                                      | `release.yml` (release-go, release-docker)                              | PR, Push, Weekly      |
-| **Infrastructure (Terraform)** | `ci.yml` (ci-terraform)<br>`deploy.yml` (deploy-terraform)<br>`security.yml` (config-scan, secret-scan) | `drift.yml` (drift-detection)<br>`docs.yml` (terraform-docs)            | PR, Push main, Weekly |
-| **GitOps (Fleet/Helm)**        | `ci.yml` (fleet/helm validation)<br>`deploy.yml` (fleet sync)<br>`security.yml` (config-scan)           | -                                                                       | PR, Push main         |
-| **Packages (NPM/Go)**          | `ci.yml`<br>`release.yml`<br>`security.yml`                                                             | -                                                                       | PR, Tag push          |
-| **Serverless (CF Workers)**    | `ci.yml` (ci-js)<br>`deploy.yml` (deploy-cloudflare-workers)<br>`security.yml`                          | `ops/sync-secrets.yml`                                                  | PR, Push main         |
-
-### Security Requirements
-
-**Public Repositories:**
-
-- ✅ **Required**: `security.yml` with `code-analysis` job (CodeQL)
-- ✅ **Recommended**: Weekly scheduled security scans
-- ✅ **SARIF Upload**: Free GitHub Security tab integration
-
-**Private Repositories:**
-
-- 🔧 **Optional**: `security.yml` (requires GitHub Advanced Security license for SARIF)
-- ✅ **Recommended**: `claude.yml` + `claude-code-review.yml` for AI assistance
-- 📝 **Note**: Artifact uploads work without license
+| Secret                    | Purpose                            | Required for                      |
+| ------------------------- | ---------------------------------- | --------------------------------- |
+| `BW_ACCESS_TOKEN`         | Bitwarden Secrets Manager          | `deploy-terraform`, CF Workers    |
+| `CODECOV_TOKEN`           | Code coverage upload               | `ci-js`, `ci-go` (optional)       |
+| `NPM_TOKEN`               | NPM publish                        | `release-npm`                     |
+| `CLAUDE_CODE_OAUTH_TOKEN` | Claude AI workflows                | private repos only                |
 
 ---
 
-## 📚 Workflow Reference
+## Troubleshooting
 
-### CI Workflows
+### Workflow not found
 
-#### ci-go.yml
-
-**Purpose**: Go project validation, testing & security
-**When to use**: All Go projects
-**Triggers**: `pull_request`, `workflow_call`
-
-```yaml
-jobs:
-  ci:
-    uses: sbaerlocher/.github/.github/workflows/ci-go.yml@v1
-    with:
-      go-version: '1.25'
-      enable-security-scans: true
+```text
+Error: Unable to resolve action sbaerlocher/.github/.github/workflows/ci-js.yml@<TAG>
 ```
 
-**Features**:
+Check the nested path: it's `sbaerlocher/.github` (the repo) followed by
+`/.github/workflows/<file>` (the path inside the repo). Both `.github`
+segments are required.
 
-- Build & Test with coverage
-- golangci-lint + gofmt
-- gosec + govulncheck security scans
-- Parallel matrix execution
+### Cache misses
 
----
+Ensure your lockfile is committed (`pnpm-lock.yaml`, `package-lock.json`,
+`yarn.lock`, `bun.lockb`, or `go.sum`).
 
-#### ci-js.yml
+### Security scans too slow on PRs
 
-**Purpose**: JavaScript/TypeScript all-in-one validation
-**When to use**: JS/TS, Vue, React, Astro, Node.js projects
-**Triggers**: `pull_request`, `workflow_call`
-
-```yaml
-jobs:
-  ci:
-    uses: sbaerlocher/.github/.github/workflows/ci-js.yml@v1
-    with:
-      package-manager: pnpm
-      enable-security-scans: true
-      enable-dependency-review: true
-```
-
-**Features**:
-
-- Quality: Prettier, ESLint, Type-checking
-- Tests: Vitest with coverage
-- Security: npm audit, dependency review
-- Smart caching (pnpm/npm/yarn/bun)
-
----
-
-#### ci-terraform.yml
-
-**Purpose**: Terraform validation
-**When to use**: All Terraform/IaC projects
-**Triggers**: `pull_request`, `workflow_call`
-
-```yaml
-jobs:
-  terraform:
-    uses: sbaerlocher/.github/.github/workflows/ci-terraform.yml@v1
-    with:
-      terraform-version: '1.14.3'
-```
-
-**Features**:
-
-- terraform fmt, validate
-- tflint scanning
-- YAML validation
-- Multi-environment support
-
----
-
-### Security Workflows
-
-#### security-code.yml
-
-**Purpose**: SAST (Static Application Security Testing) with CodeQL
-**When to use**: **Required for public repos**, optional for private
-**Triggers**: `pull_request`, `push`, `schedule`
-
-```yaml
-jobs:
-  code-analysis:
-    uses: sbaerlocher/.github/.github/workflows/security-code.yml@v1
-    with:
-      languages: '["javascript-typescript", "go", "python"]'
-```
-
-**Supported Languages**:
-
-- JavaScript/TypeScript
-- Go, Python, Java
-- C/C++, C#, Ruby
-
-**Features**:
-
-- Multi-language parallel scanning
-- SARIF upload to GitHub Security tab
-- CVE detection in code logic
-
----
-
-#### security-config.yml
-
-**Purpose**: Infrastructure-as-Code security scanning
-**When to use**: Terraform, Kubernetes, Ansible projects
-**Triggers**: `schedule` (weekly)
-
-```yaml
-jobs:
-  config-scan:
-    uses: sbaerlocher/.github/.github/workflows/security-config.yml@v1
-    with:
-      scan-terraform: true
-      scan-kubernetes: true
-```
-
-**Features**:
-
-- Checkov (Terraform/K8s)
-- Kubeconform validation
-- Ansible-lint
-- Best practices enforcement
-
----
-
-#### security-secrets.yml
-
-**Purpose**: Secret detection in code
-**When to use**: All repositories
-**Triggers**: `schedule` (weekly), `workflow_dispatch`
-
-```yaml
-jobs:
-  secret-scan:
-    uses: sbaerlocher/.github/.github/workflows/security-secrets.yml@v1
-```
-
-**Features**:
-
-- Gitleaks + TruffleHog (dual scanners)
-- API keys, passwords, tokens detection
-- SARIF results
-
----
-
-#### security-deps.yml
-
-**Purpose**: Dependency vulnerability scanning
-**When to use**: Projects with dependencies (Go, JS/TS, Python)
-**Triggers**: `schedule` (weekly)
-
-```yaml
-jobs:
-  dependency-scan:
-    uses: sbaerlocher/.github/.github/workflows/security-deps.yml@v1
-    with:
-      language: 'javascript'
-      enable-license-check: true
-```
-
-**Features**:
-
-- govulncheck (Go), npm audit (JS), safety (Python)
-- License compliance checking
-- Dependency review on PRs
-
----
-
-#### security-containers.yml
-
-**Purpose**: Container image security scanning
-**When to use**: Projects building Docker images
-**Triggers**: `schedule` (weekly)
-
-```yaml
-jobs:
-  container-scan:
-    uses: sbaerlocher/.github/.github/workflows/security-containers.yml@v1
-    with:
-      image: 'ghcr.io/user/app:latest'
-```
-
-**Features**:
-
-- Trivy + Grype scanners
-- CVE database scanning
-- OS package vulnerabilities
-
----
-
-#### security-supply-chain.yml
-
-**Purpose**: SBOM generation & artifact signing
-**When to use**: Release workflows, production deployments
-**Triggers**: `workflow_call` (from release workflows)
-
-```yaml
-jobs:
-  sbom:
-    uses: sbaerlocher/.github/.github/workflows/security-supply-chain.yml@v1
-    with:
-      artifact-type: 'docker'
-      artifact-ref: 'ghcr.io/user/app:v1.0.0'
-      enable-sbom: true
-      enable-signing: true
-```
-
-**Features**:
-
-- CycloneDX + SPDX SBOM formats
-- Cosign keyless signing
-- Artifact attestation
-
----
-
-### Deploy Workflows
-
-#### deploy-terraform.yml
-
-**Purpose**: Terraform plan & apply
-**When to use**: Infrastructure/IaC deployments
-**Triggers**: `push` (main branch), `workflow_dispatch`
-
-```yaml
-jobs:
-  deploy:
-    uses: sbaerlocher/.github/.github/workflows/deploy-terraform.yml@v1
-    with:
-      environment: 'production'
-      terraform-version: '1.14.3'
-      bw-secrets: |
-        uuid-1 > TF_VAR_api_token
-        uuid-2 > TF_VAR_password
-    secrets:
-      BW_ACCESS_TOKEN: ${{ secrets.BW_ACCESS_TOKEN }}
-```
-
-**Features**:
-
-- Bitwarden Secrets Manager integration
-- Terraform plan preview
-- Apply with approval gates
-- State locking
-
----
-
-#### deploy-cloudflare-workers.yml
-
-**Purpose**: Cloudflare Workers deployment
-**When to use**: Serverless function deployments
-**Triggers**: `push` (main), `workflow_dispatch`
-
-```yaml
-jobs:
-  deploy:
-    uses: sbaerlocher/.github/.github/workflows/deploy-cloudflare-workers.yml@v1
-    with:
-      workers: '["worker1", "worker2"]'
-      package-manager: pnpm
-    secrets:
-      BW_ACCESS_TOKEN: ${{ secrets.BW_ACCESS_TOKEN }}
-```
-
-**Features**:
-
-- Multi-worker matrix deployment
-- Wrangler CLI
-- Secret injection from Bitwarden
-- Monorepo support (pnpm workspaces)
-
----
-
-### Release Workflows
-
-#### release-go.yml
-
-**Purpose**: Go binary releases with GoReleaser
-**When to use**: Go CLI tools, applications
-**Triggers**: `push` (tags `v*`)
-
-```yaml
-jobs:
-  release:
-    uses: sbaerlocher/.github/.github/workflows/release-go.yml@v1
-```
-
-**Features**:
-
-- Multi-platform binaries (Linux, macOS, Windows)
-- GitHub Release creation
-- Changelog generation
-- Homebrew formula (optional)
-
----
-
-#### release-docker.yml
-
-**Purpose**: Multi-platform Docker image builds
-**When to use**: Containerized applications
-**Triggers**: `push` (tags `v*`)
-
-```yaml
-jobs:
-  release:
-    uses: sbaerlocher/.github/.github/workflows/release-docker.yml@v1
-    with:
-      image-name: 'ghcr.io/${{ github.repository }}'
-      platforms: 'linux/amd64,linux/arm64'
-```
-
-**Features**:
-
-- Multi-architecture builds (amd64, arm64)
-- Push to GHCR/Docker Hub
-- Provenance attestation
-- Layer caching
-
----
-
-#### release-helm.yml
-
-**Purpose**: Helm chart publishing
-**When to use**: Kubernetes applications
-**Triggers**: `push` (tags `v*`)
-
-```yaml
-jobs:
-  release:
-    uses: sbaerlocher/.github/.github/workflows/release-helm.yml@v1
-    with:
-      chart-path: './charts/app'
-```
-
-**Features**:
-
-- Helm package & push to OCI registry
-- Chart validation
-- Dependency updates
-- Artifact signing
-
----
-
-#### release-npm.yml
-
-**Purpose**: NPM package publishing
-**When to use**: JavaScript/TypeScript libraries
-**Triggers**: `push` (tags `v*`)
-
-```yaml
-jobs:
-  release:
-    uses: sbaerlocher/.github/.github/workflows/release-npm.yml@v1
-```
-
-**Features**:
-
-- Publish to npm registry
-- Provenance attestation
-- Package validation
-- Automated versioning
-
----
-
-### Operations Workflows
-
-#### ops-drift-detection.yml
-
-**Purpose**: Terraform state drift detection
-**When to use**: Production Terraform deployments
-**Triggers**: `schedule` (weekly Monday 06:00 UTC)
-
-```yaml
-jobs:
-  drift:
-    uses: sbaerlocher/.github/.github/workflows/ops-drift-detection.yml@v1
-    with:
-      environment: 'production'
-    secrets:
-      BW_ACCESS_TOKEN: ${{ secrets.BW_ACCESS_TOKEN }}
-```
-
-**Features**:
-
-- Scheduled drift checks
-- Slack/email notifications
-- Detailed diff reports
-
----
-
-#### ops-terraform-orchestration.yml
-
-**Purpose**: Multi-environment Terraform orchestration
-**When to use**: Complex infrastructure with dev/staging/prod
-**Triggers**: `workflow_dispatch`, `workflow_call`
-
-```yaml
-jobs:
-  orchestrate:
-    uses: sbaerlocher/.github/.github/workflows/ops-terraform-orchestration.yml@v1
-    with:
-      environments: '["dev", "staging", "production"]'
-```
-
-**Features**:
-
-- Sequential environment deployments
-- Approval gates between environments
-- Rollback capabilities
-
----
-
-#### ops-sync-secrets.yml
-
-**Purpose**: Sync secrets from Bitwarden to Cloudflare Workers
-**When to use**: Cloudflare Workers with secrets
-**Triggers**: `workflow_dispatch`, `schedule`
-
-```yaml
-jobs:
-  sync:
-    uses: sbaerlocher/.github/.github/workflows/ops-sync-secrets.yml@v1
-    with:
-      workers: '["worker1", "worker2"]'
-      secrets-mapping: |
-        uuid-1 > API_TOKEN
-        uuid-2 > DATABASE_URL
-```
-
-**Features**:
-
-- Bitwarden → Cloudflare Workers sync
-- Matrix-based multi-worker updates
-- Verification after sync
-
----
-
-### Testing & Quality Workflows
-
-#### e2e-docker.yml
-
-**Purpose**: End-to-end testing using Docker Compose
-**When to use**: Applications with Docker Compose configurations
-**Triggers**: `pull_request`, `workflow_call`
-
-```yaml
-jobs:
-  e2e:
-    uses: sbaerlocher/.github/.github/workflows/e2e-docker.yml@v1
-    with:
-      compose-file: 'docker-compose.test.yml'
-      test-command: 'npm run test:e2e'
-```
-
-**Features**:
-
-- Docker Compose orchestration
-- Service health checks
-- Log collection on failure
-- Cleanup after tests
-
----
-
-#### helm-test.yml
-
-**Purpose**: Helm chart validation and testing with Kind
-**When to use**: Helm chart repositories
-**Triggers**: `pull_request`, `workflow_call`
-
-```yaml
-jobs:
-  helm-test:
-    uses: sbaerlocher/.github/.github/workflows/helm-test.yml@v1
-    with:
-      chart-path: './charts/myapp'
-```
-
-**Features**:
-
-- Helm lint validation
-- Kind cluster deployment
-- Chart installation testing
-- Template rendering validation
-
----
-
-#### quality-benchmarks.yml
-
-**Purpose**: Performance benchmarking and regression detection
-**When to use**: Performance-critical applications
-**Triggers**: `pull_request`, `workflow_dispatch`
-
-```yaml
-jobs:
-  benchmarks:
-    uses: sbaerlocher/.github/.github/workflows/quality-benchmarks.yml@v1
-    with:
-      benchmark-command: 'go test -bench=. -benchmem'
-```
-
-**Features**:
-
-- Automated benchmark execution
-- Performance regression detection
-- Historical comparison
-- Results artifacts
-
----
-
-#### notify-deployment.yml
-
-**Purpose**: Send deployment notifications to communication channels
-**When to use**: After successful deployments
-**Triggers**: `workflow_call`
-
-```yaml
-jobs:
-  notify:
-    uses: sbaerlocher/.github/.github/workflows/notify-deployment.yml@v1
-    with:
-      environment: 'production'
-      status: 'success'
-    secrets:
-      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-```
-
-**Features**:
-
-- Slack/Discord notifications
-- Deployment status tracking
-- Rich formatting with metadata
-- Failure alerts
-
----
-
-### AI & Documentation Workflows
-
-#### ai-claude.yml
-
-**Purpose**: On-demand @claude mentions in issues/PRs
-**When to use**: Private repositories only
-**Triggers**: `issue_comment`, `pull_request_review_comment`
-
-```yaml
-jobs:
-  claude:
-    uses: sbaerlocher/.github/.github/workflows/ai-claude.yml@v1
-    secrets:
-      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-```
-
----
-
-#### ai-claude-review.yml
-
-**Purpose**: Automatic AI code review on PRs
-**When to use**: Private repositories only
-**Triggers**: `pull_request` (opened, synchronize)
-
-```yaml
-jobs:
-  claude-review:
-    uses: sbaerlocher/.github/.github/workflows/ai-claude-review.yml@v1
-    secrets:
-      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-```
-
----
-
-#### docs-terraform.yml
-
-**Purpose**: Auto-generate Terraform documentation
-**When to use**: Terraform modules with README
-**Triggers**: `push` (main), `pull_request`
-
-```yaml
-jobs:
-  docs:
-    uses: sbaerlocher/.github/.github/workflows/docs-terraform.yml@v1
-```
-
-**Features**:
-
-- terraform-docs generation
-- Auto-commit to PR
-- Module documentation
-
----
-
-## ⚙️ Workflow Versioning
-
-**Rolling Release Model**: This repository uses continuous deployment to `main`.
-
-**Recommended Usage**:
-
-```yaml
-# Option 1: Rolling (always latest) - Use for development/testing
-uses: sbaerlocher/.github/.github/workflows/ci-js.yml@main
-
-# Option 2: Pinned commit SHA - Use for production stability
-uses: sbaerlocher/.github/.github/workflows/ci-js.yml@a386f88
-
-# Option 3: Date-based tags (if created) - Use for reproducible builds
-uses: sbaerlocher/.github/.github/workflows/ci-js.yml@2026-02-14
-```
-
-**Best Practice**:
-
-- Development: Use `@main` for latest features
-- Production: Pin to specific commit SHA for stability
-- Renovate will automatically update SHA references
-
----
-
-## 🛠️ Troubleshooting
-
-### Workflow Not Found
-
-```
-Error: Unable to resolve action sbaerlocher/.github/.github/workflows/ci-js.yml@main
-```
-
-**Solution**: Check the nested path structure
-
-```yaml
-uses: sbaerlocher/.github/.github/workflows/ci-js.yml@v1
-#     ^^^^^^^^^^^ Repo      ^^^^^^^^^^^^^^^^ Nested .github directory
-```
-
-### Security Scans Too Slow
-
-Disable security scans in PRs, run only on main:
+Disable scheduled-only scans on `pull_request`:
 
 ```yaml
 with:
   enable-security-scans: ${{ github.ref == 'refs/heads/main' }}
 ```
 
-### Cache Misses
+### SARIF upload fails on private repo
 
-Ensure lock files are committed:
-
-- pnpm-lock.yaml
-- package-lock.json
-- yarn.lock
-- go.sum
+`security-code.yml` and friends only upload SARIF when
+`enable-sarif-upload: true` *and* the repo is public (or has GitHub
+Advanced Security). Private repos without GHAS should leave the input at
+its default `false` and rely on artifact uploads instead.
 
 ---
 
-## 📊 Workflow Statistics
+## Related Documentation
 
-```
-Total Workflows:    27
-Security:            6 (22%)  ← Primary focus
-Release:             4 (15%)
-CI:                  4 (15%)
-Operations:          4 (15%)
-Testing & Quality:   3 (11%)
-Other:               6 (22%)
-
-Consolidation:      -33% workflow complexity
-Feature Coverage:   +100% (multi-language, multi-tool)
-Avg CI Time:        5-12 minutes (PR → Main)
-```
+- [STANDARDS.md](./STANDARDS.md) — repository standards & conventions
+- [SETUP.md](./SETUP.md) — `gh` commands to bootstrap a new repo
+- [REVIEW.md](./REVIEW.md) — code review guidelines for this repo
+- [CHANGELOG.md](./CHANGELOG.md) — release history
+- [AGENTS.md](./AGENTS.md) — AI agent context
+- [SECURITY.md](./SECURITY.md) — vulnerability reporting
 
 ---
 
-## 🤝 Contributing
+## License
 
-This is a private workflow repository. For issues or questions:
-
-1. Check [AGENTS.md](./AGENTS.md) for AI agent documentation
-2. Review [CHANGELOG.md](./CHANGELOG.md) for recent updates
-3. Create an issue in this repository
-
----
-
-## 📝 License
-
-MIT License - See individual project repositories for details
-
----
-
-## 🔗 Related Resources
-
-- **[sbaerlocher/STANDARDS.md](https://github.com/sbaerlocher/sbaerlocher/blob/main/STANDARDS.md)** - Repository standards & conventions
-- **[GitHub Actions Documentation](https://docs.github.com/en/actions)** - Official GitHub Actions docs
-- **[Reusable Workflows Guide](https://docs.github.com/en/actions/using-workflows/reusing-workflows)** - GitHub's official guide
-
----
-
-**Maintained by:** Simon Bärlocher (@sbaerlocher)
-**Powered by:** Claude Sonnet 4.5
-**Last Updated:** 2026-02-14
+[MIT](./LICENSE) — Simon Bärlocher.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+This is the default security policy for all repositories under
+[`sbaerlocher`](https://github.com/sbaerlocher) that do not provide their own
+`SECURITY.md`. Individual repositories may override this policy.
+
+## Reporting a Vulnerability
+
+**Do not report security issues via public GitHub issues, pull requests,
+or discussions.**
+
+Use one of the private channels below:
+
+1. **Preferred — GitHub Security Advisory**
+   Open a draft advisory on the affected repository:
+   `https://github.com/<owner>/<repo>/security/advisories/new`
+   For repositories without an own advisory page, use the central one at
+   <https://github.com/sbaerlocher/.github/security/advisories/new>.
+
+2. **Email** — `security@sbaerlo.ch` with subject prefix `[SECURITY]`.
+
+Please include:
+
+- Affected repository, version, commit SHA or image tag
+- Reproduction steps or proof-of-concept
+- Impact assessment (what an attacker can achieve)
+- Any suggested mitigation
+
+## Response Expectations
+
+| Stage                    | Target                             |
+| ------------------------ | ---------------------------------- |
+| Acknowledgement          | Within 5 business days             |
+| Initial assessment       | Within 10 business days            |
+| Fix or mitigation plan   | Depends on severity and complexity |
+| Public disclosure window | Coordinated with reporter          |
+
+There is no bug bounty programme. Researchers acting in good faith are
+credited in the published advisory unless they prefer to remain anonymous.
+
+## Scope
+
+In scope:
+
+- Code, workflows, and configuration in repositories under `sbaerlocher/*`
+- Reusable GitHub Actions workflows in `sbaerlocher/.github`
+- Renovate presets and templates published from this repository
+
+Out of scope:
+
+- Third-party services, dependencies, and forks
+- Issues that require physical access or already-compromised credentials
+- Denial-of-service against personal infrastructure

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -87,12 +87,19 @@ Files that do NOT belong in every repo: `docs/`, `SECURITY.md`, issue/PR templat
 
 ## Workflows
 
-All reusable workflows live in `sbaerlocher/.github/.github/workflows/`. Reference with a
-date-based version tag for reproducibility:
+All reusable workflows live in `sbaerlocher/.github/.github/workflows/`.
+
+**Versioning model:** rolling release with date-based tags (`YYYY-MM-DD`).
+Consumer repositories MUST reference workflows by date tag — never `@main`,
+never `@v1` (those tags do not exist). Renovate updates these tags
+automatically via the shared `renovate-base` custom manager.
 
 ```yaml
-uses: sbaerlocher/.github/.github/workflows/ci-terraform.yml@2026-02-14
+uses: sbaerlocher/.github/.github/workflows/ci-terraform.yml@2026-04-25
 ```
+
+The current set of tags is visible at
+<https://github.com/sbaerlocher/.github/tags>.
 
 ### Required Workflows by Repo Type
 
@@ -183,16 +190,21 @@ not on PRs, and would block every merge.
 
 Shared presets in `sbaerlocher/.github`. Each repo extends exactly one:
 
-| Repo type       | Preset               |
-| --------------- | -------------------- |
-| JS/TS           | `renovate-js`        |
-| Terraform/IaC   | `renovate-terraform` |
-| GitOps/Helm     | `renovate-gitops`    |
-| Everything else | `renovate-base`      |
+| Repo type       | Preset                |
+| --------------- | --------------------- |
+| JS/TS           | `renovate-js`         |
+| Terraform/IaC   | `renovate-terraform`  |
+| GitOps/Helm     | `renovate-kubernetes` |
+| Everything else | `renovate-base`       |
 
 ```json
-{ "extends": ["github>sbaerlocher/.github:renovate/renovate-base"] }
+{ "extends": ["github>sbaerlocher/.github:renovate-base"] }
 ```
+
+The preset name is the JSON file basename without `.json` (e.g. `renovate-base.json`
+→ `renovate-base`). No slash between repo and preset name. Append `#main` only when
+the preset references *itself* (see `renovate.json` in this repo) — consumer repos
+should omit the suffix to use Renovate's default resolution.
 
 Project-specific rules go in `packageRules` — never duplicate base config inline.
 

--- a/renovate-base.json
+++ b/renovate-base.json
@@ -46,7 +46,7 @@
       "minimumReleaseAge": "7 days"
     },
     {
-      "description": "Pre-1.0 packages: minor bumps may be breaking, require review for major/minor only",
+      "description": "Pre-1.0 packages: SemVer does not guarantee backward compatibility; treat any non-patch bump as potentially breaking and require manual review.",
       "matchCurrentVersion": "/^0\\./",
       "matchUpdateTypes": ["major", "minor"],
       "automerge": false

--- a/renovate-base.json
+++ b/renovate-base.json
@@ -8,7 +8,8 @@
   "assigneesFromCodeOwners": true,
   "reviewersFromCodeOwners": true,
   "prConcurrentLimit": 5,
-  "prHourlyLimit": 0,
+  "prHourlyLimit": 4,
+  "osvVulnerabilityAlerts": true,
   "platformAutomerge": true,
   "automergeType": "pr",
   "automergeStrategy": "squash",
@@ -45,8 +46,9 @@
       "minimumReleaseAge": "7 days"
     },
     {
-      "description": "Pre-release versions require manual review",
+      "description": "Pre-1.0 packages: minor bumps may be breaking, require review for major/minor only",
       "matchCurrentVersion": "/^0\\./",
+      "matchUpdateTypes": ["major", "minor"],
       "automerge": false
     },
     {

--- a/renovate-js.json
+++ b/renovate-js.json
@@ -167,27 +167,43 @@
       "enabled": false
     },
     {
-      "description": "Major framework updates - extra stability",
+      "description": "Major Astro updates - extra stability",
       "matchUpdateTypes": ["major"],
+      "groupName": "Astro packages (major)",
       "minimumReleaseAge": "14 days",
       "labels": ["framework", "major-update"],
-      "matchPackageNames": [
-        "/^astro$/",
-        "/^astro-/",
-        "/^@astrojs\\//",
-        "/^vue$/",
-        "/^vue-/",
-        "/^@vue\\//",
-        "/^pinia$/",
-        "/^svelte$/",
-        "/^svelte-/",
-        "/^@sveltejs\\//"
-      ]
+      "matchPackageNames": ["/^astro$/", "/^astro-/", "/^@astrojs\\//"]
+    },
+    {
+      "description": "Major Vue updates - extra stability",
+      "matchUpdateTypes": ["major"],
+      "groupName": "Vue packages (major)",
+      "minimumReleaseAge": "14 days",
+      "labels": ["framework", "major-update"],
+      "matchPackageNames": ["/^vue$/", "/^vue-/", "/^@vue\\//", "/^pinia$/"]
+    },
+    {
+      "description": "Major Svelte updates - extra stability",
+      "matchUpdateTypes": ["major"],
+      "groupName": "Svelte packages (major)",
+      "minimumReleaseAge": "14 days",
+      "labels": ["framework", "major-update"],
+      "matchPackageNames": ["/^svelte$/", "/^svelte-/", "/^@sveltejs\\//"]
+    },
+    {
+      "description": "Major TailwindCSS updates - breaking config changes (v3 -> v4)",
+      "matchUpdateTypes": ["major"],
+      "groupName": "TailwindCSS packages (major)",
+      "minimumReleaseAge": "14 days",
+      "labels": ["framework", "major-update"],
+      "matchPackageNames": ["/^tailwindcss$/", "/^tailwindcss-/", "/^@tailwindcss\\//"]
     },
     {
       "description": "Major build tooling updates - extra stability (Vite, Vitest, Rollup, Webpack)",
       "matchUpdateTypes": ["major"],
+      "groupName": "Build tooling (major)",
       "minimumReleaseAge": "14 days",
+      "labels": ["build-tooling", "major-update"],
       "matchPackageNames": [
         "/^vite$/",
         "/^vitest$/",

--- a/renovate-kubernetes.json
+++ b/renovate-kubernetes.json
@@ -11,7 +11,12 @@
     "github-actions"
   ],
   "kubernetes": {
-    "managerFilePatterns": ["/\\.ya?ml$/", "/^kustomization\\.ya?ml$/"]
+    "managerFilePatterns": [
+      "/(^|/)(deployment|statefulset|daemonset|cronjob|job|pod|service|configmap|secret|ingress|hpa|networkpolicy|serviceaccount|role|rolebinding|clusterrole|clusterrolebinding)[^/]*\\.ya?ml$/",
+      "/(^|/)manifests/[^/]+\\.ya?ml$/",
+      "/(^|/)k8s/[^/]+\\.ya?ml$/",
+      "/(^|/)kustomization\\.ya?ml$/"
+    ]
   },
   "helm-values": {
     "managerFilePatterns": ["/values\\.ya?ml$/", "/values-.+\\.ya?ml$/"]

--- a/renovate-kubernetes.json
+++ b/renovate-kubernetes.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "GitOps Renovate configuration for Fleet, Helm, Kubernetes and Kustomize",
+  "description": "GitOps Renovate configuration for Fleet, Helm, Kubernetes and Kustomize. Helm templates under */templates/* are deliberately NOT matched by the kubernetes manager — they go through helm-values / helmv3 instead, which would otherwise double-process them.",
   "extends": ["github>sbaerlocher/.github:renovate-base#main"],
   "enabledManagers": [
     "kubernetes",
@@ -12,9 +12,9 @@
   ],
   "kubernetes": {
     "managerFilePatterns": [
-      "/(^|/)(deployment|statefulset|daemonset|cronjob|job|pod|service|configmap|secret|ingress|hpa|networkpolicy|serviceaccount|role|rolebinding|clusterrole|clusterrolebinding)[^/]*\\.ya?ml$/",
-      "/(^|/)manifests/[^/]+\\.ya?ml$/",
-      "/(^|/)k8s/[^/]+\\.ya?ml$/",
+      "/(^|/)(deployment|statefulset|daemonset|cronjob|job|pod|service|configmap|secret|ingress|hpa|networkpolicy|serviceaccount|role|rolebinding|clusterrole|clusterrolebinding|persistentvolume|persistentvolumeclaim|replicaset|endpoints|poddisruptionbudget|customresourcedefinition|gateway|httproute|virtualservice)[^/]*\\.ya?ml$/",
+      "/(^|/)manifests/.+\\.ya?ml$/",
+      "/(^|/)k8s/.+\\.ya?ml$/",
       "/(^|/)kustomization\\.ya?ml$/"
     ]
   },


### PR DESCRIPTION
## Summary

Cross-cutting fixes from a full audit of this repo. Four thematic
commits, ~30 files touched. Each commit stands on its own and can be
reviewed independently.

| Commit | Theme | Files |
| --- | --- | --- |
| `cfd631f` | reusable workflows hardening | 21 |
| `dafbb69` | renovate presets | 3 |
| `4a46e0a` | org-default issue templates + security policy | 5 |
| `19705df` | standards docs alignment | 3 |

## Highlights per commit

### `ci:` workflow hardening (21 files)
- **Concurrency** added to 17 workflows that lacked one (CI/security/E2E cancel-in-progress, deploy/release/ops keep running)
- **Tool pinning** of every `@latest` install (staticcheck, gosec, govulncheck, tflint, kubeconform, license-checker, safety, pip-licenses, cyclonedx-*, trivy/kubesec docker images, ansible/yamllint) with `# renovate:` markers
- **Permissions**: drop unjustified `pull-requests: write` from `ci-terraform`, add missing top-level permissions to `ops-terraform-orchestration`
- **Shell-injection fix** in `ops-terraform-orchestration`: route input regexes through `env:` instead of inlining into `grep -E`
- **Cross-repo bug fix** in `release-npm`: relative `uses: ./.github/workflows/security-sbom.yml` only resolved inside this repo. Replaced with self-contained inline CycloneDX SBOM job
- **Strict toggles** for `ci-ansible` (yamllint) and `ci-gitops` (yamllint, kubeconform) so lint actually fails the job
- **govulncheck false positive**: `[ -s file.json ]` always triggered. Now greps for `"finding"`
- **Version comment drift**: 24 action refs normalized from `# v3` style to precise SemVer

### `chore(renovate):` preset cleanup
- `renovate-base`: `prHourlyLimit: 4` (was unlimited), `osvVulnerabilityAlerts: true`, pre-1.0 rule scoped to major+minor
- `renovate-js`: split single major-framework rule into per-framework groups (Astro, Vue, Svelte, Tailwind, build tooling)
- `renovate-kubernetes`: file pattern `/\\.ya?ml$/` → restricted to typical K8s paths so workflow YAMLs aren't parsed as manifests

### `chore(repo):` org-default community files
- `ISSUE_TEMPLATE/config.yml` (new): closes the blank-issue bypass, adds Security/Discussions/Standards contact links
- `bug_report.yml`: required `Affected repository` + severity dropdown + secrets-redaction warnings + checklist
- `feature_request.yml`: required `Affected repository` and `Acceptance criteria`
- `pull_request_template.md`: Conventional Commits hint, deduped sections
- `SECURITY.md` (new): org-wide default security policy
- Labels reduced to GitHub defaults (`bug`/`enhancement`) — `triage` was not guaranteed in consumer repos
- All of these auto-propagate to every `sbaerlocher/*` repo without its own version

### `docs:` standards alignment
- README rewritten: was 71 days stale, claimed 27 workflows, listed 8 dead ones. Now matches the actual 21
- Versioning collapsed to one canonical story: rolling date tags, no `@v1` (never existed), no `@main` for consumers
- Schedule unified at Mon 06:00 UTC (was three different values across docs)
- Fixed `renovate-gitops` → `renovate-kubernetes` and the stray slash in the `extends` example

## Test plan

- [ ] CI passes on this PR
- [ ] Spot-check one consumer repo can still call workflows by date tag (e.g. `ci-js.yml@2026-04-25`)
- [ ] After merge, cut a new dated tag so consumers can pick up the fixes
- [ ] After merge, verify a fresh issue on a `sbaerlocher/*` repo without local templates shows the new forms