### PR TITLE
feat(actions): extract npm SBOM logic into shared composite action

### DIFF
--- a/.github/actions/sbom-npm/action.yml
+++ b/.github/actions/sbom-npm/action.yml
@@ -1,0 +1,82 @@
+---
+name: 'Generate npm SBOM'
+description: |
+  Generate a CycloneDX Software Bill of Materials for an npm/pnpm/yarn/bun
+  project. Single source of truth for npm SBOM generation across the
+  release-npm.yml and security-sbom.yml reusable workflows.
+author: 'sbaerlocher'
+
+inputs:
+  package-manager:
+    description: 'Package manager to use (npm, pnpm, yarn, bun)'
+    required: false
+    default: 'npm'
+  working-directory:
+    description: 'Working directory containing package.json'
+    required: false
+    default: '.'
+  node-version-file:
+    description: 'Path to a Node.js version file (e.g. .nvmrc, package.json)'
+    required: false
+    default: '.nvmrc'
+  output-file:
+    description: 'SBOM output file path, relative to working-directory'
+    required: false
+    default: 'sbom-npm-package.cdx.json'
+  install-dependencies:
+    description: |
+      Whether the action should install dependencies before generating the
+      SBOM. Set to "false" if the calling job already installed them.
+    required: false
+    default: 'true'
+
+outputs:
+  sbom-path:
+    description: 'Resolved path to the generated SBOM file'
+    value: ${{ steps.generate.outputs.sbom-path }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version-file: ${{ inputs.node-version-file }}
+
+    - name: Setup pnpm
+      if: inputs.package-manager == 'pnpm'
+      uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
+
+    - name: Setup Bun
+      if: inputs.package-manager == 'bun'
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+    - name: Install dependencies
+      if: inputs.install-dependencies == 'true'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        PM: ${{ inputs.package-manager }}
+      run: |
+        case "$PM" in
+          pnpm) pnpm install --frozen-lockfile ;;
+          bun)  bun install --frozen-lockfile ;;
+          yarn) yarn install --frozen-lockfile ;;
+          npm)  npm ci ;;
+          *)    echo "::error::unsupported package manager: $PM" ; exit 1 ;;
+        esac
+
+    - name: Generate CycloneDX SBOM
+      id: generate
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        # renovate: datasource=npm depName=@cyclonedx/cyclonedx-npm
+        CYCLONEDX_NPM_VERSION: '2.0.0'
+        OUTPUT_FILE: ${{ inputs.output-file }}
+      run: |
+        npx --yes "@cyclonedx/cyclonedx-npm@${CYCLONEDX_NPM_VERSION}" \
+          --output-format JSON \
+          --output-file "${OUTPUT_FILE}"
+        echo "sbom-path=${{ inputs.working-directory }}/${OUTPUT_FILE}" >> "$GITHUB_OUTPUT"
+        echo "✓ SBOM generated at ${{ inputs.working-directory }}/${OUTPUT_FILE}"

--- a/.github/actions/sbom-npm/action.yml
+++ b/.github/actions/sbom-npm/action.yml
@@ -74,9 +74,12 @@ runs:
         # renovate: datasource=npm depName=@cyclonedx/cyclonedx-npm
         CYCLONEDX_NPM_VERSION: '2.0.0'
         OUTPUT_FILE: ${{ inputs.output-file }}
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
       run: |
         npx --yes "@cyclonedx/cyclonedx-npm@${CYCLONEDX_NPM_VERSION}" \
           --output-format JSON \
           --output-file "${OUTPUT_FILE}"
-        echo "sbom-path=${{ inputs.working-directory }}/${OUTPUT_FILE}" >> "$GITHUB_OUTPUT"
-        echo "✓ SBOM generated at ${{ inputs.working-directory }}/${OUTPUT_FILE}"
+        # Strip a trailing slash so "app/" + "sbom.json" doesn't yield "app//sbom.json".
+        SBOM_PATH="${WORKING_DIRECTORY%/}/${OUTPUT_FILE}"
+        echo "sbom-path=${SBOM_PATH}" >> "$GITHUB_OUTPUT"
+        echo "✓ SBOM generated at ${SBOM_PATH}"

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -378,12 +378,6 @@ jobs:
             fi
           done
 
-  # Inlined here intentionally: a previous version called
-  # `uses: ./.github/workflows/security-sbom.yml`, which only resolves inside
-  # this repo and silently broke for every consumer. The CycloneDX/npm logic
-  # below duplicates security-sbom.yml — when bumping CYCLONEDX_NPM_VERSION,
-  # update both files. Long-term TODO: extract into a composite action under
-  # `.github/actions/sbom-npm/` so both workflows can call it cross-repo.
   generate-sbom:
     name: Generate SBOM
     needs: [pre-release-checks, publish]
@@ -396,42 +390,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      # The composite action lives in this repo, but `uses: ./` in a reusable
+      # workflow resolves against the caller's checkout — not against this
+      # workflow's source repo. So we reference it absolutely. `@main` tracks
+      # the rolling release; Renovate's github-actions manager will pin this
+      # to the most recent date tag once one exists for the action.
+      - name: Generate npm SBOM
+        id: sbom
+        uses: sbaerlocher/.github/.github/actions/sbom-npm@main
         with:
+          package-manager: ${{ inputs.package-manager }}
+          working-directory: ${{ inputs.working-directory }}
           node-version-file: ${{ inputs.node-version-file }}
-
-      - name: Setup pnpm
-        if: inputs.package-manager == 'pnpm'
-        uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
-
-      - name: Setup Bun
-        if: inputs.package-manager == 'bun'
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-
-      - name: Install dependencies
-        working-directory: ${{ inputs.working-directory }}
-        run: |
-          case "${{ inputs.package-manager }}" in
-            pnpm) pnpm install --frozen-lockfile ;;
-            bun) bun install --frozen-lockfile ;;
-            yarn) yarn install --frozen-lockfile ;;
-            npm) npm ci ;;
-          esac
-
-      - name: Generate CycloneDX SBOM
-        working-directory: ${{ inputs.working-directory }}
-        run: |
-          npx --yes @cyclonedx/cyclonedx-npm@2.0.0 \
-            --output-format JSON \
-            --output-file sbom-npm-package.cdx.json
-          echo "✓ SBOM generated"
+          output-file: sbom-npm-package.cdx.json
 
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-npm-package
-          path: ${{ inputs.working-directory }}/sbom-npm-package.cdx.json
+          path: ${{ steps.sbom.outputs.sbom-path }}
           retention-days: 90
           if-no-files-found: error
 

--- a/.github/workflows/security-sbom.yml
+++ b/.github/workflows/security-sbom.yml
@@ -20,6 +20,14 @@ on:
         type: string
         default: 'cyclonedx-json'
         description: 'SBOM format (cyclonedx-json, spdx-json, syft-json)'
+      package-manager:
+        type: string
+        default: 'npm'
+        description: 'For artifact-type=npm-package: package manager (npm, pnpm, yarn, bun)'
+      node-version-file:
+        type: string
+        default: '.nvmrc'
+        description: 'For artifact-type=npm-package: Node.js version file'
 
 permissions:
   contents: write
@@ -83,22 +91,32 @@ jobs:
       # release; Renovate updates this once tagged versions exist.
       - name: Generate npm SBOM
         if: inputs.artifact-type == 'npm-package'
+        id: sbom-npm
         uses: sbaerlocher/.github/.github/actions/sbom-npm@main
         with:
+          package-manager: ${{ inputs.package-manager }}
           working-directory: ${{ inputs.working-directory }}
+          node-version-file: ${{ inputs.node-version-file }}
           output-file: sbom-${{ inputs.artifact-type }}.json
 
-      # Validate and upload SBOM
+      # Resolve the SBOM file path for downstream steps. The npm branch
+      # writes inside working-directory (and exposes its path as an output);
+      # the other artifact-types write to the repo root.
       - name: Validate SBOM
         id: sbom-output
+        env:
+          ARTIFACT_TYPE: ${{ inputs.artifact-type }}
+          NPM_SBOM_PATH: ${{ steps.sbom-npm.outputs.sbom-path }}
         run: |
-          SBOM_FILE="sbom-${{ inputs.artifact-type }}.json"
-          echo "file=$SBOM_FILE" >> $GITHUB_OUTPUT
+          if [ "$ARTIFACT_TYPE" = 'npm-package' ]; then
+            SBOM_FILE="$NPM_SBOM_PATH"
+          else
+            SBOM_FILE="sbom-${ARTIFACT_TYPE}.json"
+          fi
+          echo "file=$SBOM_FILE" >> "$GITHUB_OUTPUT"
 
           if [ -f "$SBOM_FILE" ]; then
             echo "✓ SBOM generated successfully: $SBOM_FILE"
-
-            # Show component count
             COMPONENTS=$(jq '[.components[] // .packages[]] | length' "$SBOM_FILE" 2>/dev/null || echo "unknown")
             echo "Components/Packages: $COMPONENTS"
           else
@@ -110,8 +128,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-${{ inputs.artifact-type }}
-          path: sbom-${{ inputs.artifact-type }}.json
+          path: ${{ steps.sbom-output.outputs.file }}
           retention-days: 90
+          if-no-files-found: error
 
   sbom-report:
     name: Create Report

--- a/.github/workflows/security-sbom.yml
+++ b/.github/workflows/security-sbom.yml
@@ -76,24 +76,17 @@ jobs:
           go install "github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@${CYCLONEDX_GOMOD_VERSION}"
           cyclonedx-gomod mod -json -output "../sbom-${ARTIFACT_TYPE}.json"
 
-      # NPM Package SBOM
-      - name: Setup Node.js
+      # NPM Package SBOM — uses the shared composite action so this step
+      # stays in lockstep with the SBOM job in release-npm.yml. `uses: ./`
+      # in a reusable workflow resolves against the caller's checkout, so
+      # we reference the action absolutely. `@main` rides the rolling
+      # release; Renovate updates this once tagged versions exist.
+      - name: Generate npm SBOM
         if: inputs.artifact-type == 'npm-package'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: sbaerlocher/.github/.github/actions/sbom-npm@main
         with:
-          node-version-file: '.nvmrc'
-
-      - name: Generate SBOM for NPM package
-        if: inputs.artifact-type == 'npm-package'
-        working-directory: ${{ inputs.working-directory }}
-        env:
-          # renovate: datasource=npm depName=@cyclonedx/cyclonedx-npm
-          CYCLONEDX_NPM_VERSION: '2.0.0'
-          ARTIFACT_TYPE: ${{ inputs.artifact-type }}
-        run: |
-          npm install -g "@cyclonedx/cyclonedx-npm@${CYCLONEDX_NPM_VERSION}"
-          npm ci
-          cyclonedx-npm --output-file "../sbom-${ARTIFACT_TYPE}.json"
+          working-directory: ${{ inputs.working-directory }}
+          output-file: sbom-${{ inputs.artifact-type }}.json
 
       # Validate and upload SBOM
       - name: Validate SBOM


### PR DESCRIPTION
## Summary

Follow-up to #78. Extract the duplicated CycloneDX/npm SBOM logic from `release-npm.yml` and `security-sbom.yml` into a shared composite action under `.github/actions/sbom-npm/`.

## Why

The audit on #78 flagged the duplication explicitly: bumping `@cyclonedx/cyclonedx-npm` would have to land in two places, and the two workflows had already diverged on output filename (`sbom-npm-package.cdx.json` vs `sbom-${ARTIFACT_TYPE}.json`) and install command (`pnpm install --frozen-lockfile` vs `npm ci`).

## What changed

- **New** `.github/actions/sbom-npm/action.yml` — composite action with multi-pm support (npm/pnpm/yarn/bun), Renovate-pinned `@cyclonedx/cyclonedx-npm`, and a `sbom-path` output so callers don't reconstruct the location.
- `release-npm.yml`: 35 lines of inlined SBOM job replaced with one `uses:` call.
- `security-sbom.yml`: NPM_PACKAGE branch likewise. **Side-effect fix:** the previous step wrote to `../sbom-${TYPE}.json` (one level above working-directory) — with the default `working-directory: .` that landed outside the repo root and the Validate SBOM step couldn't find it. Now writes inside working-directory.

## Bootstrap note

Both workflows reference the action absolutely as
`sbaerlocher/.github/.github/actions/sbom-npm@main`. `uses: ./` in a reusable workflow resolves against the **caller's** checkout, not the workflow's source repo, so a relative path doesn't work here. `@main` rides the rolling-release model — Renovate's github-actions manager will pin to date tags once they exist for the action.

actionlint may flag the absolute reference as unresolved on this branch — that's expected. The action is added by this same PR; after merge it resolves.

## Test plan

- [ ] CI passes
- [ ] Spot-check the action manually after merge by running `release-npm.yml` with `enable-sbom: true` from a consumer (or wait for the next NPM release of any consumer to exercise the path)