### PR TITLE
fix(templates): make org-default issue forms repo-aware

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,8 +9,9 @@ body:
         Thanks for taking the time to file a bug report.
 
         > **Security note:** if this is a security vulnerability, do **not**
-        > open a public issue. Use [GitHub Security Advisories](https://github.com/sbaerlocher/.github/security/advisories/new)
-        > or follow [SECURITY.md](https://github.com/sbaerlocher/.github/blob/main/SECURITY.md).
+        > open a public issue. Use the **"Report a vulnerability"** button on
+        > this repository's Security tab, or follow the steps in this
+        > repository's `SECURITY.md`.
         >
         > **Before pasting logs**, redact any secrets, API tokens, credentials,
         > or personal data. They cannot be removed once submitted.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,8 +10,8 @@ body:
 
         > **Security note:** if this is a security vulnerability, do **not**
         > open a public issue. Use the **"Report a vulnerability"** button on
-        > this repository's Security tab, or follow the steps in this
-        > repository's `SECURITY.md`.
+        > this repository's Security tab *(if Private Vulnerability Reporting
+        > is enabled)*, or follow the steps in this repository's `SECURITY.md`.
         >
         > **Before pasting logs**, redact any secrets, API tokens, credentials,
         > or personal data. They cannot be removed once submitted.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Security Vulnerability
-    url: https://github.com/sbaerlocher/.github/security/advisories/new
-    about: Report security issues privately via GitHub Security Advisories.
-  - name: Question or Discussion
-    url: https://github.com/sbaerlocher/.github/discussions
-    about: Ask a question or share an idea in Discussions.
   - name: Repository Standards
     url: https://github.com/sbaerlocher/.github/blob/main/STANDARDS.md
-    about: Conventions, required files, and workflow patterns.
+    about: Conventions, required files, and workflow patterns shared across all sbaerlocher repositories.

--- a/SETUP.md
+++ b/SETUP.md
@@ -39,6 +39,18 @@ permissions:
 
 ---
 
+## Private Vulnerability Reporting
+
+Enables the **"Report a vulnerability"** button on the repository's Security tab —
+the channel the org-default `bug_report.yml` form points reporters at. Without this,
+the button is hidden and reporters fall back to the SECURITY.md instructions.
+
+```bash
+gh api repos/{owner}/{repo}/private-vulnerability-reporting --method PUT
+```
+
+---
+
 ## Branch Ruleset (Personal Repo)
 
 ```bash
@@ -141,6 +153,8 @@ gh api "repos/$REPO" --method PATCH \
 gh api "repos/$REPO" --method PATCH \
   --field default_workflow_permissions=read \
   --field can_approve_pull_request_reviews=false
+
+gh api "repos/$REPO/private-vulnerability-reporting" --method PUT
 
 gh api "repos/$REPO/rulesets" --method POST --input - <<'EOF'
 {


### PR DESCRIPTION
## Summary

Two contact links in `config.yml` and the markdown intro of `bug_report.yml` pointed at hard-coded `https://github.com/sbaerlocher/.github/...` URLs. Because these forms propagate to every repo under `sbaerlocher/*` via default community health files, those URLs sent users to the wrong repo: someone reporting on `sbaerlocher/functions` clicking "Security Vulnerability" landed on `.github`'s advisory page instead of `functions`.

## Direction

Decision: security and discussions are **per repo**.

GitHub Issue Forms cannot interpolate the current repo into a URL, so we drop the per-repo links entirely and rely on:

- **Security:** GitHub auto-renders "Report a vulnerability" next to the issue picker when the current repo has `SECURITY.md` (which all sbaerlocher repos do via the org-default in this repo). The bug-report intro now points there in plain text.
- **Discussions:** repos that have Discussions enabled show them in the sidebar — no need for a contact link.

## What changed

**`config.yml`**
- Drop "Security Vulnerability" link
- Drop "Question or Discussion" link
- Keep "Repository Standards" (genuinely org-wide doc)
- Keep `blank_issues_enabled: false`

**`bug_report.yml`**
- Replace the two absolute URLs in the security note with text instructions ("use the **'Report a vulnerability'** button on this repository's Security tab, or follow this repository's `SECURITY.md`")

## Test plan

- [ ] After merge, open a draft issue on a `sbaerlocher/<other-repo>` → contact-link section shows only "Repository Standards"
- [ ] Bug-report markdown intro no longer has links pointing at `.github`