### PR TITLE
fix(security-config): trivy report via trivy-action; renovate-base disables custom-regex digest pinning

### DIFF
--- a/.github/workflows/security-config.yml
+++ b/.github/workflows/security-config.yml
@@ -92,17 +92,14 @@ jobs:
 
       - name: Generate Trivy report
         if: always()
-        env:
-          # renovate: datasource=docker depName=aquasec/trivy
-          TRIVY_IMAGE_VERSION: '0.70.0'
-          SEVERITY: ${{ inputs.severity-threshold }}
-        run: |
-          echo "Generating detailed Trivy report..."
-          docker run --rm -v "$(pwd):/workspace" \
-            "aquasec/trivy:${TRIVY_IMAGE_VERSION}" config /workspace \
-            --severity "${SEVERITY},HIGH,CRITICAL" \
-            --format table \
-            | tee trivy-config-report.txt
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: 'config'
+          scan-ref: '.'
+          severity: ${{ inputs.severity-threshold }},HIGH,CRITICAL
+          format: 'table'
+          output: 'trivy-config-report.txt'
+          exit-code: '0'
 
       - name: Upload Trivy artifacts
         if: always()

--- a/renovate-base.json
+++ b/renovate-base.json
@@ -68,6 +68,12 @@
       "allowedVersions": "/^\\d{4}-\\d{2}-\\d{2}$/",
       "minimumReleaseAge": "1 day",
       "automerge": true
+    },
+    {
+      "description": "Custom regex managers tracking Docker images via env-var markers (e.g. `# renovate: datasource=docker depName=foo` over `IMAGE_VERSION: '1.2.3'`) cannot accept a digest — the regex captures only the version. Disable digest pinning to avoid 'Digest is not updated' branch failures.",
+      "matchManagers": ["custom.regex"],
+      "matchDatasources": ["docker"],
+      "pinDigests": false
     }
   ],
   "lockFileMaintenance": {

--- a/renovate-kubernetes.json
+++ b/renovate-kubernetes.json
@@ -63,12 +63,6 @@
       "automerge": false,
       "prPriority": 5,
       "labels": ["platform", "critical"]
-    },
-    {
-      "description": "Disable auto digest pinning for custom regex manager - Fleet/Helm stack does not universally support image@sha256: format. Manually add digests where supported; Renovate will track existing digests via currentDigest capture group.",
-      "matchManagers": ["custom.regex"],
-      "matchDatasources": ["docker"],
-      "pinDigests": false
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary

Renovate's pin-dependencies branch failed today with:

> Error updating branch: update failure

Root cause: the third Trivy invocation in `security-config.yml` was a `docker run aquasec/trivy:<TRIVY_IMAGE_VERSION>` shell call, with the version tracked through a `# renovate: datasource=docker depName=aquasec/trivy` env-var marker. The custom-regex manager captures only the version string — not a digest — but `config:best-practices` in the base preset sets `pinDigests: true` for Docker. Renovate tried to write the digest, had nowhere to put it, and aborted the whole branch update. Kubesec on the same branch was collateral damage.

## Fix

**Trivy:** migrate the third invocation to the existing `aquasecurity/trivy-action` (the same workflow already uses it twice for SARIF + JSON; this brings the `format: table` step in line). Side effects:

- The custom-regex marker for Trivy is gone — the github-actions manager now tracks Trivy through the `uses:` reference and pins the digest automatically.
- One env-var permutation removed from the run step.

**Kubesec:** stays on env-var + custom-regex because there's no maintained official action. To keep Renovate from running into the same digest-pinning trap, add a rule to `renovate-base.json` that disables `pinDigests` when the manager is `custom.regex` and the datasource is `docker`. The kubernetes preset has had the same rule for the same reason; lifting it into base means every consumer of every preset is covered.

## Test plan

- [ ] CI passes
- [ ] Open Renovate Dependency Dashboard after merge → no more "update failure" warning
- [ ] When the next aquasec/trivy / kubesec release lands, Renovate should propose the bump cleanly without trying to pin a digest