### PR TITLE
feat(dde): add reusable e2e workflow and composite actions for whatwedo dde

### DIFF
--- a/.github/actions/project-up/README.md
+++ b/.github/actions/project-up/README.md
@@ -94,7 +94,11 @@ not supported.
 2. `cd $working-directory && dde project:up` — fails fast if
    `.dde/config.yml` is missing.
 3. If `wait-url` is set: `curl -k` poll loop with 2s interval and 5s
-   per-request timeout, until 2xx/3xx or `wait-timeout` expires.
+   per-request timeout, until 2xx/3xx or `wait-timeout` expires. The
+   `sleep 2` is a hard floor between attempts, so a slow first request
+   plus the sleep yields ~25 attempts in 180s. The deadline check happens
+   after each sleep, so wall-clock can overshoot `wait-timeout` by up to
+   2 seconds before the action errors out.
 
 The relative `uses: ./.github/actions/setup-dde` from inside this composite
 action resolves against the action's own repository (not the caller's

--- a/.github/actions/project-up/README.md
+++ b/.github/actions/project-up/README.md
@@ -1,0 +1,103 @@
+# `sbaerlocher/.github/.github/actions/project-up`
+
+Bring a [whatwedo dde](https://github.com/whatwedo/dde) project up on a
+GitHub Actions runner in one step. Installs the dde CLI, runs
+`dde system:install`, executes `dde project:up` in your project directory,
+and (optionally) waits for an HTTP endpoint to respond before handing
+control back to your workflow.
+
+For setup-only (no `system:install`, no `project:up`) use the sibling
+[`setup-dde`](../setup-dde/) action.
+
+## Usage
+
+Pick the most recent date tag from
+<https://github.com/sbaerlocher/.github/tags> (used as `<TAG>` below).
+
+### Minimal — bring the project at the repo root up
+
+```yaml
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+- uses: sbaerlocher/.github/.github/actions/project-up@2026-04-28
+- run: dde project:exec composer test:e2e
+- if: always()
+  run: dde project:down
+```
+
+### With a wait-for-ready URL
+
+```yaml
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+- uses: sbaerlocher/.github/.github/actions/project-up@2026-04-28
+  with:
+    wait-url: https://myproject.test/healthz
+    wait-timeout: '180'
+- run: npm run test:e2e
+- if: always()
+  run: dde project:down
+```
+
+### Project lives in a subdirectory
+
+```yaml
+- uses: sbaerlocher/.github/.github/actions/project-up@2026-04-28
+  with:
+    working-directory: ./apps/web
+```
+
+## Inputs
+
+| Input               | Default        | Description                                                              |
+|---------------------|----------------|--------------------------------------------------------------------------|
+| `version`           | `latest`       | dde version (`v2.0.0-alpha.5`, `2.0.0-alpha.5`, or `latest`).            |
+| `working-directory` | `.`            | Directory with `.dde/config.yml`. Fails fast if missing.                 |
+| `install-mkcert`    | `true`         | Install `mkcert` (+ `libnss3-tools` on Linux) for local TLS certs.       |
+| `system-install`    | `true`         | Run `dde system:install` (host setup). `'false'` skips it.               |
+| `wait-url`          | `""`           | Poll this URL until 2xx/3xx (TLS errors ignored). Empty disables.        |
+| `wait-timeout`      | `180`          | Maximum seconds to wait for `wait-url` to respond.                       |
+| `github-token`      | `github.token` | Token for the GitHub API call that resolves `latest`.                    |
+| `repository`        | `whatwedo/dde` | Source repository. Override for forks or staging mirrors.                |
+
+## Outputs
+
+| Output        | Description                                              |
+|---------------|----------------------------------------------------------|
+| `version`     | Resolved tag that was installed (e.g. `v2.0.0-alpha.5`). |
+| `binary-path` | Absolute path to the installed `dde` binary.             |
+
+## Teardown
+
+Composite GitHub Actions cannot register post-steps, so cleanup must be an
+explicit workflow step:
+
+```yaml
+- if: always()
+  working-directory: ./apps/web   # match the project-up working-directory
+  run: dde project:down
+```
+
+For longer-lived runners (self-hosted) you may also want
+`dde system:down` once all jobs in the matrix have finished.
+
+## Supported runners
+
+Same matrix as
+[`setup-dde`](../setup-dde/README.md#supported-runners):
+`ubuntu-latest`, `ubuntu-24.04-arm`, `macos-latest`, `macos-13`. Windows is
+not supported.
+
+## What runs under the hood
+
+1. **`uses: setup-dde` with `system-install: 'true'`** — install + verify
+   the binary, install `mkcert`, and run `sudo dde system:install`. See
+   [`setup-dde`](../setup-dde/) for the underlying steps.
+2. `cd $working-directory && dde project:up` — fails fast if
+   `.dde/config.yml` is missing.
+3. If `wait-url` is set: `curl -k` poll loop with 2s interval and 5s
+   per-request timeout, until 2xx/3xx or `wait-timeout` expires.
+
+The relative `uses: ./.github/actions/setup-dde` from inside this composite
+action resolves against the action's own repository (not the caller's
+workspace, which is how reusable workflows behave), so the same source
+file works whether `project-up` is consumed cross-repo or from this repo's
+self-test workflow.

--- a/.github/actions/project-up/action.yml
+++ b/.github/actions/project-up/action.yml
@@ -65,13 +65,21 @@ runs:
         github-token: ${{ inputs.github-token }}
         repository: ${{ inputs.repository }}
 
+    # cd is done inside the script (not via working-directory:) so that a
+    # missing/typo'd working-directory produces our friendly ::error::
+    # instead of the runner's generic ENOENT before the script runs.
     - name: Bring project up
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
       env:
         BINARY: ${{ steps.setup.outputs.binary-path }}
+        WD: ${{ inputs.working-directory }}
       run: |
         set -euo pipefail
+        if [ ! -d "$WD" ]; then
+          echo "::error::working-directory '$WD' does not exist."
+          exit 1
+        fi
+        cd "$WD"
         if [ ! -f .dde/config.yml ]; then
           echo "::error::No .dde/config.yml found in $(pwd). Set 'working-directory' to the project root."
           exit 1

--- a/.github/actions/project-up/action.yml
+++ b/.github/actions/project-up/action.yml
@@ -1,0 +1,112 @@
+name: 'dde project:up'
+description: 'Install dde, run system:install, and bring a project up. Designed for E2E test pipelines.'
+author: 'sbaerlocher'
+
+branding:
+  icon: 'play'
+  color: 'orange'
+
+inputs:
+  version:
+    description: 'dde version to install (e.g. v2.0.0-alpha.5) or "latest"'
+    required: false
+    default: 'latest'
+  working-directory:
+    description: 'Directory containing .dde/config.yml. Defaults to the repository root.'
+    required: false
+    default: '.'
+  install-mkcert:
+    description: 'Install mkcert (and libnss3-tools on Linux) — required for TLS certs'
+    required: false
+    default: 'true'
+  system-install:
+    description: 'Run `dde system:install` to set up host (Traefik, mkcert CA, dnsmasq). Disable for unit-style tests that exercise project commands without provisioning the host.'
+    required: false
+    default: 'true'
+  wait-url:
+    description: 'If set, the action polls this URL until it returns 2xx/3xx (or wait-timeout expires). TLS errors are ignored.'
+    required: false
+    default: ''
+  wait-timeout:
+    description: 'Maximum seconds to wait for wait-url to respond'
+    required: false
+    default: '180'
+  github-token:
+    description: 'Token used to query the GitHub API when resolving "latest"'
+    required: false
+    default: ${{ github.token }}
+  repository:
+    description: 'GitHub repository slug to download dde releases from'
+    required: false
+    default: 'whatwedo/dde'
+
+outputs:
+  version:
+    description: 'Resolved dde version that was installed'
+    value: ${{ steps.setup.outputs.version }}
+  binary-path:
+    description: 'Absolute path to the installed dde binary'
+    value: ${{ steps.setup.outputs.binary-path }}
+
+runs:
+  using: 'composite'
+  steps:
+    # `uses: ./...` from inside a composite action resolves against the
+    # action's own repository (not the caller's workspace), so this works
+    # both when project-up is consumed from another repo and when it runs
+    # from this repo's self-test workflow.
+    - name: Setup dde
+      id: setup
+      uses: ./.github/actions/setup-dde
+      with:
+        version: ${{ inputs.version }}
+        install-mkcert: ${{ inputs.install-mkcert }}
+        system-install: ${{ inputs.system-install }}
+        github-token: ${{ inputs.github-token }}
+        repository: ${{ inputs.repository }}
+
+    - name: Bring project up
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        BINARY: ${{ steps.setup.outputs.binary-path }}
+      run: |
+        set -euo pipefail
+        if [ ! -f .dde/config.yml ]; then
+          echo "::error::No .dde/config.yml found in $(pwd). Set 'working-directory' to the project root."
+          exit 1
+        fi
+        "$BINARY" project:up
+
+    - name: Wait for URL
+      if: inputs.wait-url != ''
+      shell: bash
+      env:
+        URL: ${{ inputs.wait-url }}
+        TIMEOUT: ${{ inputs.wait-timeout }}
+      run: |
+        # `-e` is intentionally omitted: the loop below tolerates curl
+        # failures (DNS, TCP refused, timeout) and exits explicitly when the
+        # deadline is reached or a 2xx/3xx is observed.
+        set -uo pipefail
+        if ! [[ "$TIMEOUT" =~ ^[0-9]+$ ]] || [ "$TIMEOUT" -le 0 ]; then
+          echo "::error::wait-timeout must be a positive integer (got: '$TIMEOUT')"
+          exit 1
+        fi
+        deadline=$(( $(date +%s) + TIMEOUT ))
+        echo "Polling $URL until 2xx/3xx (timeout: ${TIMEOUT}s, ignoring TLS errors)"
+        attempt=0
+        status=""
+        while [ "$(date +%s)" -lt "$deadline" ]; do
+          attempt=$((attempt + 1))
+          status=$(curl -ksS -o /dev/null -w '%{http_code}' --max-time 5 "$URL" 2>/dev/null || true)
+          case "$status" in
+            2*|3*)
+              echo "Got HTTP $status after $attempt attempt(s) — ready"
+              exit 0
+              ;;
+          esac
+          sleep 2
+        done
+        echo "::error::Timed out after ${TIMEOUT}s waiting for $URL (last status: ${status:-no-response}, attempts: $attempt)"
+        exit 1

--- a/.github/actions/setup-dde/README.md
+++ b/.github/actions/setup-dde/README.md
@@ -73,6 +73,18 @@ unauthenticated rate limits.
 | `macos-13`         | Supported (`darwin-amd64`).                                  |
 | `windows-*`        | Not supported — dde does not ship a Windows binary.          |
 
+## Notes on `mkcert`
+
+If `mkcert` is already on `PATH` (e.g. preinstalled on the runner image),
+the action **skips** the apt/Homebrew install. On Linux, this means the
+action does not separately ensure that `libnss3-tools` is present — the
+package is only installed alongside `mkcert` via apt. On hosted GitHub
+runners this never matters (the apt path always runs because `mkcert` is
+not preinstalled), but on self-hosted Linux runners with a non-apt mkcert
+build, `mkcert -install` (called by `dde system:install`) may silently
+fail to update the system NSS database. If that applies, install
+`libnss3-tools` in your runner image.
+
 ## Notes for `system-install: true`
 
 `dde system:install` performs host-level configuration (writes

--- a/.github/actions/setup-dde/README.md
+++ b/.github/actions/setup-dde/README.md
@@ -1,0 +1,111 @@
+# `sbaerlocher/.github/.github/actions/setup-dde`
+
+Install the [whatwedo `dde`](https://github.com/whatwedo/dde) CLI on a
+GitHub Actions runner. Designed as a setup-style action — it puts the
+binary on `PATH` and, optionally, installs host dependencies (`mkcert`)
+and runs `dde system:install`.
+
+## Usage
+
+Pick the most recent date tag from
+<https://github.com/sbaerlocher/.github/tags> (used as `<TAG>` below).
+
+### Minimal — install the binary
+
+```yaml
+- uses: sbaerlocher/.github/.github/actions/setup-dde@2026-04-28
+- run: dde --version
+```
+
+### Pin a specific dde version
+
+```yaml
+- uses: sbaerlocher/.github/.github/actions/setup-dde@2026-04-28
+  with:
+    version: v2.0.0-alpha.5
+```
+
+### Full setup for E2E tests
+
+```yaml
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+- uses: sbaerlocher/.github/.github/actions/setup-dde@2026-04-28
+  with:
+    system-install: 'true'
+- run: |
+    dde project:up
+    dde project:exec composer test:e2e
+- if: always()
+  run: dde project:down
+```
+
+For the higher-level "install + system:install + project:up" flow, use the
+sibling [`project-up`](../project-up/) action instead.
+
+## Inputs
+
+| Input            | Default        | Description                                                              |
+|------------------|----------------|--------------------------------------------------------------------------|
+| `version`        | `latest`       | Tag to install (`v2.0.0-alpha.5`, `2.0.0-alpha.5`, or `latest`).         |
+| `install-mkcert` | `true`         | Install `mkcert` (and `libnss3-tools` on Linux) for local TLS certs.     |
+| `system-install` | `false`        | Run `sudo dde system:install` (required for `dde project:up`).           |
+| `github-token`   | `github.token` | Token for the GitHub API call that resolves `latest`.                    |
+| `repository`     | `whatwedo/dde` | Source repository. Override for forks or staging mirrors.                |
+
+`latest` resolves the most recent published release, including
+pre-releases. The default `github-token` works for public repos and avoids
+unauthenticated rate limits.
+
+## Outputs
+
+| Output        | Description                                              |
+|---------------|----------------------------------------------------------|
+| `version`     | Resolved tag that was installed (e.g. `v2.0.0-alpha.5`). |
+| `binary-path` | Absolute path to the installed `dde` binary.             |
+
+## Supported runners
+
+| Runner             | Status                                                       |
+|--------------------|--------------------------------------------------------------|
+| `ubuntu-latest`    | Supported (`linux-amd64`).                                   |
+| `ubuntu-24.04-arm` | Supported (`linux-arm64`).                                   |
+| `macos-latest`     | Supported (`darwin-arm64`). `mkcert` installed via Homebrew. |
+| `macos-13`         | Supported (`darwin-amd64`).                                  |
+| `windows-*`        | Not supported — dde does not ship a Windows binary.          |
+
+## Notes for `system-install: true`
+
+`dde system:install` performs host-level configuration (writes
+`/etc/systemd/resolved.conf.d/dde-test.conf` on Linux, restarts
+`systemd-resolved`) and starts the global Traefik, dnsmasq and SSH-Agent
+containers. The action invokes it via:
+
+```bash
+sudo --preserve-env=HOME,USER,DDE_CONFIG_DIR,DDE_DATA_DIR dde system:install
+```
+
+`HOME` is preserved so `mkcert` installs its local CA into the runner
+user's trust store rather than `/root`. `DDE_CONFIG_DIR` / `DDE_DATA_DIR`
+are forwarded so the caller can isolate dde state into a temp directory:
+
+```yaml
+- uses: sbaerlocher/.github/.github/actions/setup-dde@2026-04-28
+  with:
+    system-install: 'true'
+  env:
+    DDE_CONFIG_DIR: ${{ runner.temp }}/dde-config
+    DDE_DATA_DIR:   ${{ runner.temp }}/dde-data
+```
+
+## Security
+
+Each dde release ships a `checksums.txt` SHA256 manifest alongside the
+binaries. The action downloads it from the same release and verifies the
+binary against it before placing it on `PATH`. Verification is fail-closed:
+a missing asset, a missing checksum file, or a hash mismatch aborts the
+step.
+
+Note that `checksums.txt` is fetched over HTTPS from the same GitHub
+release as the binary; it is not signed. Trust is anchored on
+`whatwedo/dde`'s release pipeline. If you need a stronger trust root, pin
+`version` to an exact tag rather than `latest` and audit it out-of-band.

--- a/.github/actions/setup-dde/action.yml
+++ b/.github/actions/setup-dde/action.yml
@@ -1,0 +1,169 @@
+name: 'Setup dde'
+description: 'Install the whatwedo dde CLI on a GitHub Actions runner'
+author: 'sbaerlocher'
+
+branding:
+  icon: 'box'
+  color: 'orange'
+
+inputs:
+  version:
+    description: 'dde version to install (e.g. v2.0.0-alpha.5) or "latest"'
+    required: false
+    default: 'latest'
+  install-mkcert:
+    description: 'Install mkcert (and libnss3-tools on Linux) so dde can issue local TLS certs'
+    required: false
+    default: 'true'
+  system-install:
+    description: 'Run `dde system:install` after installing the binary. Requires sudo and Docker.'
+    required: false
+    default: 'false'
+  github-token:
+    description: 'Token used to query the GitHub API (avoids unauthenticated rate limits when resolving "latest")'
+    required: false
+    default: ${{ github.token }}
+  repository:
+    description: 'GitHub repository slug to download dde releases from. Override for forks or staging mirrors.'
+    required: false
+    default: 'whatwedo/dde'
+
+outputs:
+  version:
+    description: 'Resolved version that was installed (e.g. v2.0.0-alpha.5)'
+    value: ${{ steps.resolve.outputs.version }}
+  binary-path:
+    description: 'Absolute path to the installed dde binary'
+    value: ${{ steps.install.outputs.binary-path }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Detect platform
+      id: platform
+      shell: bash
+      run: |
+        set -euo pipefail
+        case "$RUNNER_OS" in
+          Linux) os=linux ;;
+          macOS) os=darwin ;;
+          *)
+            echo "::error::dde does not ship a binary for $RUNNER_OS"
+            exit 1
+            ;;
+        esac
+        case "$RUNNER_ARCH" in
+          X64)   arch=amd64 ;;
+          ARM64) arch=arm64 ;;
+          *)
+            echo "::error::dde does not ship a binary for $RUNNER_ARCH"
+            exit 1
+            ;;
+        esac
+        echo "asset=dde-${os}-${arch}" >> "$GITHUB_OUTPUT"
+
+    - name: Resolve version
+      id: resolve
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ inputs.repository }}
+        REQUESTED: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        if [ "$REQUESTED" = "latest" ]; then
+          # Use /releases?per_page=1 (not /releases/latest) so this works
+          # while the project only ships pre-releases — /releases/latest
+          # excludes pre-releases and would 404.
+          auth_args=()
+          if [ -n "${GH_TOKEN:-}" ]; then
+            auth_args=(-H "Authorization: Bearer $GH_TOKEN")
+          fi
+          version=$(curl -fsSL \
+            "${auth_args[@]}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${REPO}/releases?per_page=1" \
+            | jq -r '.[0].tag_name // empty')
+        else
+          case "$REQUESTED" in
+            v*) version="$REQUESTED" ;;
+            *)  version="v$REQUESTED" ;;
+          esac
+        fi
+        if [ -z "$version" ]; then
+          echo "::error::Could not resolve dde version (input: $REQUESTED, repo: $REPO)"
+          exit 1
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "Resolved dde version: $version"
+
+    - name: Install dde binary
+      id: install
+      shell: bash
+      env:
+        VERSION: ${{ steps.resolve.outputs.version }}
+        ASSET: ${{ steps.platform.outputs.asset }}
+        REPO: ${{ inputs.repository }}
+      run: |
+        set -euo pipefail
+        dl="$RUNNER_TEMP/dde-download"
+        bin_dir="$RUNNER_TEMP/dde-bin"
+        mkdir -p "$dl" "$bin_dir"
+
+        base="https://github.com/${REPO}/releases/download/${VERSION}"
+        echo "Downloading $base/$ASSET"
+        curl -fsSL --retry 3 "$base/$ASSET" -o "$dl/$ASSET"
+        curl -fsSL --retry 3 "$base/checksums.txt" -o "$dl/checksums.txt"
+
+        # GoReleaser writes "<sha>  <filename>" (two spaces). Match any
+        # whitespace run so we don't break if the format ever switches to a
+        # tab. Extract the line first, fail with a clear message if missing,
+        # then pipe to shasum so the verification error path stays clean.
+        echo "Verifying SHA256 for $ASSET"
+        if ! grep -E "[[:space:]]+${ASSET}\$" "$dl/checksums.txt" > "$dl/expected.sum"; then
+          echo "::error::Asset '${ASSET}' not listed in checksums.txt for ${VERSION}"
+          echo "checksums.txt contents:" && cat "$dl/checksums.txt"
+          exit 1
+        fi
+        ( cd "$dl" && shasum -a 256 -c expected.sum )
+
+        install -m 0755 "$dl/$ASSET" "$bin_dir/dde"
+        echo "$bin_dir" >> "$GITHUB_PATH"
+        echo "binary-path=$bin_dir/dde" >> "$GITHUB_OUTPUT"
+
+        "$bin_dir/dde" --version
+
+    - name: Install mkcert
+      if: inputs.install-mkcert == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if command -v mkcert >/dev/null 2>&1; then
+          echo "mkcert already installed: $(mkcert -version 2>&1 || true)"
+          exit 0
+        fi
+        case "$RUNNER_OS" in
+          Linux)
+            sudo apt-get update -y
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends mkcert libnss3-tools
+            ;;
+          macOS)
+            brew install mkcert nss
+            ;;
+        esac
+        mkcert -version
+
+    - name: Run dde system:install
+      if: inputs.system-install == 'true'
+      shell: bash
+      env:
+        BINARY: ${{ steps.install.outputs.binary-path }}
+      run: |
+        set -euo pipefail
+        # Preserve HOME so mkcert installs the local CA into the runner
+        # user's trust store (otherwise sudo resets HOME to /root and the
+        # CA ends up where dde-as-runner-user can't find it).
+        # DDE_CONFIG_DIR / DDE_DATA_DIR are forwarded so callers can
+        # isolate state into a temp directory if they wish.
+        sudo --preserve-env=HOME,USER,DDE_CONFIG_DIR,DDE_DATA_DIR \
+          "$BINARY" system:install

--- a/.github/actions/setup-dde/action.yml
+++ b/.github/actions/setup-dde/action.yml
@@ -72,9 +72,13 @@ runs:
       run: |
         set -euo pipefail
         if [ "$REQUESTED" = "latest" ]; then
-          # Use /releases?per_page=1 (not /releases/latest) so this works
-          # while the project only ships pre-releases — /releases/latest
-          # excludes pre-releases and would 404.
+          # Use /releases (not /releases/latest) so this works while the
+          # project only ships pre-releases — /releases/latest excludes
+          # pre-releases and would 404. /releases is sorted by `created_at`
+          # descending; we filter out drafts and take the first non-draft
+          # release. Pre-releases ARE included by design (whatwedo/dde is
+          # currently alpha). Pin `version` to an exact tag if you need a
+          # stronger contract than "newest non-draft tag".
           auth_args=()
           if [ -n "${GH_TOKEN:-}" ]; then
             auth_args=(-H "Authorization: Bearer $GH_TOKEN")
@@ -82,8 +86,8 @@ runs:
           version=$(curl -fsSL \
             "${auth_args[@]}" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${REPO}/releases?per_page=1" \
-            | jq -r '.[0].tag_name // empty')
+            "https://api.github.com/repos/${REPO}/releases?per_page=10" \
+            | jq -r '[.[] | select(.draft == false)][0].tag_name // empty')
         else
           case "$REQUESTED" in
             v*) version="$REQUESTED" ;;

--- a/.github/workflows/e2e-dde.yml
+++ b/.github/workflows/e2e-dde.yml
@@ -105,8 +105,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
-          cache: ${{ inputs.package-manager != 'bun' && inputs.package-manager || '' }}
-          cache-dependency-path: ${{ inputs.playwright-directory }}/${{ inputs.package-manager == 'pnpm' && 'pnpm-lock.yaml' || inputs.package-manager == 'yarn' && 'yarn.lock' || inputs.package-manager == 'bun' && 'bun.lockb' || 'package-lock.json' }}
+          cache: ${{ inputs.package-manager }}
+          cache-dependency-path: ${{ inputs.playwright-directory }}/${{ inputs.package-manager == 'pnpm' && 'pnpm-lock.yaml' || inputs.package-manager == 'yarn' && 'yarn.lock' || inputs.package-manager == 'bun' && 'bun.lock' || 'package-lock.json' }}
 
       - name: Setup pnpm
         if: inputs.package-manager == 'pnpm'
@@ -155,10 +155,22 @@ jobs:
       # ----- Failure diagnostics & teardown -----
       - name: Save dde logs
         if: failure() && inputs.upload-artifacts
-        working-directory: ${{ inputs.project-directory }}
+        env:
+          PROJECT_DIR: ${{ inputs.project-directory }}
         run: |
-          dde project:logs > "${{ runner.temp }}/dde-logs.txt" 2>&1 || true
-          dde project:ps > "${{ runner.temp }}/dde-ps.txt" 2>&1 || true
+          if ! command -v dde >/dev/null 2>&1; then
+            echo "dde was never installed — see project-up step output" \
+              | tee "$RUNNER_TEMP/dde-logs.txt" "$RUNNER_TEMP/dde-ps.txt"
+            exit 0
+          fi
+          if [ ! -d "$PROJECT_DIR" ]; then
+            echo "project-directory '$PROJECT_DIR' does not exist" \
+              | tee "$RUNNER_TEMP/dde-logs.txt" "$RUNNER_TEMP/dde-ps.txt"
+            exit 0
+          fi
+          cd "$PROJECT_DIR"
+          dde project:logs > "$RUNNER_TEMP/dde-logs.txt" 2>&1 || true
+          dde project:ps   > "$RUNNER_TEMP/dde-ps.txt"   2>&1 || true
 
       - name: Upload Playwright report
         if: inputs.upload-artifacts && always()
@@ -191,8 +203,19 @@ jobs:
 
       - name: Stop dde project
         if: always()
-        working-directory: ${{ inputs.project-directory }}
-        run: dde project:down || true
+        env:
+          PROJECT_DIR: ${{ inputs.project-directory }}
+        run: |
+          if ! command -v dde >/dev/null 2>&1; then
+            echo "dde was never installed — nothing to tear down"
+            exit 0
+          fi
+          if [ ! -d "$PROJECT_DIR" ] || [ ! -f "$PROJECT_DIR/.dde/config.yml" ]; then
+            echo "project-directory '$PROJECT_DIR' missing or not a dde project — skipping project:down"
+            exit 0
+          fi
+          cd "$PROJECT_DIR"
+          dde project:down || true
 
   # PR comment runs as a separate job so the test job stays at
   # contents:read. pull-requests:write is scoped to this job only.

--- a/.github/workflows/e2e-dde.yml
+++ b/.github/workflows/e2e-dde.yml
@@ -1,0 +1,246 @@
+---
+name: E2E Tests (dde)
+
+on:
+  workflow_call:
+    inputs:
+      # dde Configuration
+      dde-version:
+        type: string
+        required: false
+        default: 'latest'
+        description: 'dde version to install (e.g. v2.0.0-alpha.5) or "latest"'
+      project-directory:
+        type: string
+        required: false
+        default: '.'
+        description: 'Directory containing .dde/config.yml'
+      wait-url:
+        type: string
+        required: false
+        default: ''
+        description: 'If set, poll this URL until 2xx/3xx before running tests (TLS errors ignored)'
+      wait-timeout:
+        type: number
+        required: false
+        default: 180
+        description: 'Maximum seconds to wait for wait-url to respond'
+
+      # Playwright Configuration
+      node-version:
+        type: string
+        required: false
+        default: '20'
+        description: 'Node.js version for Playwright'
+      package-manager:
+        type: string
+        required: false
+        default: 'npm'
+        description: 'Package manager (npm, pnpm, yarn, bun)'
+      playwright-directory:
+        type: string
+        required: false
+        default: './client'
+        description: 'Directory containing Playwright tests'
+      test-command:
+        type: string
+        required: false
+        default: 'test:e2e'
+        description: 'Playwright test command'
+      playwright-browsers:
+        type: string
+        required: false
+        default: 'chromium'
+        description: 'Playwright browsers (chromium, firefox, webkit, all)'
+
+      # Artifact Configuration
+      upload-artifacts:
+        type: boolean
+        required: false
+        default: true
+        description: 'Upload test artifacts and logs'
+      artifact-retention-days:
+        type: number
+        required: false
+        default: 30
+        description: 'Artifact retention days'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-dde:
+    name: E2E (dde)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    outputs:
+      dde-version: ${{ steps.dde.outputs.version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Bring dde project up
+        id: dde
+        uses: sbaerlocher/.github/.github/actions/project-up@2026-04-28
+        with:
+          version: ${{ inputs.dde-version }}
+          working-directory: ${{ inputs.project-directory }}
+          wait-url: ${{ inputs.wait-url }}
+          wait-timeout: ${{ inputs.wait-timeout }}
+
+      - name: Show running services
+        working-directory: ${{ inputs.project-directory }}
+        continue-on-error: true
+        run: dde project:ps
+
+      # ----- Playwright -----
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager != 'bun' && inputs.package-manager || '' }}
+          cache-dependency-path: ${{ inputs.playwright-directory }}/${{ inputs.package-manager == 'pnpm' && 'pnpm-lock.yaml' || inputs.package-manager == 'yarn' && 'yarn.lock' || inputs.package-manager == 'bun' && 'bun.lockb' || 'package-lock.json' }}
+
+      - name: Setup pnpm
+        if: inputs.package-manager == 'pnpm'
+        uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
+
+      - name: Setup Bun
+        if: inputs.package-manager == 'bun'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Install dependencies
+        working-directory: ${{ inputs.playwright-directory }}
+        env:
+          PM: ${{ inputs.package-manager }}
+        run: |
+          case "$PM" in
+            pnpm) pnpm install --frozen-lockfile ;;
+            bun) bun install --frozen-lockfile ;;
+            yarn) yarn install --frozen-lockfile ;;
+            npm) npm ci ;;
+          esac
+
+      - name: Install Playwright browsers
+        working-directory: ${{ inputs.playwright-directory }}
+        env:
+          BROWSERS: ${{ inputs.playwright-browsers }}
+        run: |
+          if [ "$BROWSERS" = "all" ]; then
+            npx playwright install --with-deps
+          else
+            npx playwright install --with-deps "$BROWSERS"
+          fi
+
+      - name: Run Playwright tests
+        working-directory: ${{ inputs.playwright-directory }}
+        env:
+          PM: ${{ inputs.package-manager }}
+          TEST_CMD: ${{ inputs.test-command }}
+        run: |
+          case "$PM" in
+            pnpm) pnpm "$TEST_CMD" ;;
+            bun) bun run "$TEST_CMD" ;;
+            yarn) yarn "$TEST_CMD" ;;
+            npm) npm run "$TEST_CMD" ;;
+          esac
+
+      # ----- Failure diagnostics & teardown -----
+      - name: Save dde logs
+        if: failure() && inputs.upload-artifacts
+        working-directory: ${{ inputs.project-directory }}
+        run: |
+          dde project:logs > "${{ runner.temp }}/dde-logs.txt" 2>&1 || true
+          dde project:ps > "${{ runner.temp }}/dde-ps.txt" 2>&1 || true
+
+      - name: Upload Playwright report
+        if: inputs.upload-artifacts && always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-report
+          path: ${{ inputs.playwright-directory }}/playwright-report/
+          retention-days: ${{ inputs.artifact-retention-days }}
+          if-no-files-found: ignore
+
+      - name: Upload test results
+        if: inputs.upload-artifacts && always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results
+          path: ${{ inputs.playwright-directory }}/test-results/
+          retention-days: ${{ inputs.artifact-retention-days }}
+          if-no-files-found: ignore
+
+      - name: Upload dde logs
+        if: failure() && inputs.upload-artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dde-logs
+          path: |
+            ${{ runner.temp }}/dde-logs.txt
+            ${{ runner.temp }}/dde-ps.txt
+          retention-days: ${{ inputs.artifact-retention-days }}
+          if-no-files-found: ignore
+
+      - name: Stop dde project
+        if: always()
+        working-directory: ${{ inputs.project-directory }}
+        run: dde project:down || true
+
+  # PR comment runs as a separate job so the test job stays at
+  # contents:read. pull-requests:write is scoped to this job only.
+  # Skipped on fork PRs: GITHUB_TOKEN is read-only there, so createComment
+  # would 403 and fail the job.
+  comment:
+    name: Comment PR
+    needs: e2e-dde
+    runs-on: ubuntu-latest
+    if: >
+      always()
+      && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Comment PR with test results
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PROJECT_DIRECTORY: ${{ inputs.project-directory }}
+          DDE_VERSION: ${{ needs.e2e-dde.outputs.dde-version }}
+          JOB_STATUS: ${{ needs.e2e-dde.result }}
+        with:
+          script: |
+            const projectDir = process.env.PROJECT_DIRECTORY;
+            const ddeVersion = process.env.DDE_VERSION;
+            const jobStatus = process.env.JOB_STATUS;
+
+            let comment = '## 🎭 E2E Test Results (dde)\n\n';
+            comment += `**Project**: \`${projectDir}\`\n`;
+            comment += `**dde**: \`${ddeVersion}\`\n\n`;
+
+            const runUrl = `${context.payload.repository.html_url}/actions/runs/${context.runId}`;
+
+            if (jobStatus === 'success') {
+              comment += '✅ All tests passed!\n';
+            } else if (jobStatus === 'failure') {
+              comment += '❌ Tests failed!\n\n';
+              comment += `View the [Playwright report](${runUrl}) for details.\n`;
+            } else {
+              comment += `⚠️ Tests completed with status: ${jobStatus}\n\n`;
+              comment += `View the [test results](${runUrl}) for details.\n`;
+            }
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });

--- a/.github/workflows/test-actions-dde.yml
+++ b/.github/workflows/test-actions-dde.yml
@@ -32,7 +32,6 @@ jobs:
           - ubuntu-latest
           - ubuntu-24.04-arm
           - macos-latest
-          - macos-13
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -64,17 +63,17 @@ jobs:
         run: echo "Installed dde ${{ steps.dde.outputs.version }}"
 
   # project-up's full path requires Docker for `dde system:install`, which
-  # is only available on ubuntu-* hosted runners. The smoke test asserts
-  # the fail-fast path with `system-install: 'false'` so the runner host
-  # is not mutated (no Traefik containers, no systemd-resolved rewrite).
-  # A full E2E test belongs in a consuming repo with a real `.dde/config.yml`.
-  smoke-project-up-missing-config:
-    name: project-up fails fast without .dde/config.yml
+  # is only available on ubuntu-* hosted runners. Both smoke jobs use
+  # `system-install: 'false'` so the runner host is not mutated (no Traefik
+  # containers, no systemd-resolved rewrite). A full E2E test belongs in a
+  # consuming repo with a real `.dde/config.yml`.
+  smoke-project-up-missing-dir:
+    name: project-up fails fast on missing working-directory
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Run project-up in empty directory (expected to fail)
+      - name: Run project-up against non-existent dir (expected to fail)
         id: project-up
         continue-on-error: true
         uses: ./.github/actions/project-up
@@ -83,13 +82,7 @@ jobs:
           system-install: 'false'
           install-mkcert: 'false'
 
-      # Two-part assertion:
-      # 1. outcome must be `failure` (not `cancelled`/`skipped`)
-      # 2. dde must still be on PATH — proves the nested
-      #    `uses: ./.github/actions/setup-dde` resolved correctly and we
-      #    actually reached the `Bring project up` step (rather than failing
-      #    earlier in action resolution).
-      - name: Assert project-up failed at the right step
+      - name: Assert project-up failed at working-directory check
         shell: bash
         run: |
           set -euo pipefail
@@ -102,4 +95,37 @@ jobs:
             exit 1
           fi
           dde --version
-          echo "project-up correctly failed at the .dde/config.yml check (setup-dde nested action resolved)"
+          echo "project-up correctly failed at the working-directory existence check"
+
+  smoke-project-up-missing-config:
+    name: project-up fails fast without .dde/config.yml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Create empty project directory
+        run: mkdir -p empty-project
+
+      - name: Run project-up in empty directory (expected to fail)
+        id: project-up
+        continue-on-error: true
+        uses: ./.github/actions/project-up
+        with:
+          working-directory: ./empty-project
+          system-install: 'false'
+          install-mkcert: 'false'
+
+      - name: Assert project-up failed at .dde/config.yml check
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.project-up.outcome }}" != "failure" ]; then
+            echo "::error::project-up should have failed but reported '${{ steps.project-up.outcome }}'"
+            exit 1
+          fi
+          if ! command -v dde >/dev/null 2>&1; then
+            echo "::error::dde is not on PATH — setup-dde did not run"
+            exit 1
+          fi
+          dde --version
+          echo "project-up correctly failed at the .dde/config.yml check"

--- a/.github/workflows/test-actions-dde.yml
+++ b/.github/workflows/test-actions-dde.yml
@@ -1,0 +1,105 @@
+# Self-test workflow for the dde-related actions in this repo
+# (.github/actions/setup-dde, .github/actions/project-up).
+# Not a reusable workflow — runs only when the dde action sources change.
+
+name: Test dde actions
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/actions/setup-dde/**'
+      - '.github/actions/project-up/**'
+      - '.github/workflows/test-actions-dde.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/actions/setup-dde/**'
+      - '.github/actions/project-up/**'
+      - '.github/workflows/test-actions-dde.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-setup-dde:
+    name: setup-dde on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-latest
+          - macos-13
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install dde via setup-dde
+        id: dde
+        uses: ./.github/actions/setup-dde
+        with:
+          version: latest
+          install-mkcert: 'true'
+          system-install: 'false'
+
+      - name: Verify dde is on PATH
+        shell: bash
+        run: |
+          set -euo pipefail
+          which dde
+          dde --version
+          test "$(command -v dde)" = "${{ steps.dde.outputs.binary-path }}"
+
+      - name: Verify mkcert is on PATH
+        shell: bash
+        run: |
+          set -euo pipefail
+          which mkcert
+          mkcert -version
+
+      - name: Echo resolved version
+        shell: bash
+        run: echo "Installed dde ${{ steps.dde.outputs.version }}"
+
+  # project-up's full path requires Docker for `dde system:install`, which
+  # is only available on ubuntu-* hosted runners. The smoke test asserts
+  # the fail-fast path with `system-install: 'false'` so the runner host
+  # is not mutated (no Traefik containers, no systemd-resolved rewrite).
+  # A full E2E test belongs in a consuming repo with a real `.dde/config.yml`.
+  smoke-project-up-missing-config:
+    name: project-up fails fast without .dde/config.yml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run project-up in empty directory (expected to fail)
+        id: project-up
+        continue-on-error: true
+        uses: ./.github/actions/project-up
+        with:
+          working-directory: ./does-not-exist
+          system-install: 'false'
+          install-mkcert: 'false'
+
+      # Two-part assertion:
+      # 1. outcome must be `failure` (not `cancelled`/`skipped`)
+      # 2. dde must still be on PATH — proves the nested
+      #    `uses: ./.github/actions/setup-dde` resolved correctly and we
+      #    actually reached the `Bring project up` step (rather than failing
+      #    earlier in action resolution).
+      - name: Assert project-up failed at the right step
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.project-up.outcome }}" != "failure" ]; then
+            echo "::error::project-up should have failed but reported '${{ steps.project-up.outcome }}'"
+            exit 1
+          fi
+          if ! command -v dde >/dev/null 2>&1; then
+            echo "::error::dde is not on PATH — setup-dde did not run, suggesting nested 'uses:' resolution broke"
+            exit 1
+          fi
+          dde --version
+          echo "project-up correctly failed at the .dde/config.yml check (setup-dde nested action resolved)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 **Repository Type**: Centralized Workflow Repository
 **Purpose**: Provide reusable GitHub Actions workflows for all sbaerlocher projects
 **Visibility**: Public
-**Last Updated**: 2026-04-26
+**Last Updated**: 2026-04-28
 
 ---
 
@@ -24,8 +24,8 @@ directly impacting the CI/CD pipelines of multiple projects.
 
 **Current Statistics**:
 
-- **Total Workflows**: 21 reusable workflows (see [.github/workflows/](./.github/workflows/))
-- **Categories**: CI (5), Security (6), Deploy (2), Release (4), Operations (1), AI (2), E2E (1)
+- **Total Workflows**: 22 reusable workflows (see [.github/workflows/](./.github/workflows/))
+- **Categories**: CI (5), Security (6), Deploy (2), Release (4), Operations (1), AI (2), E2E (2)
 - **Consumers**: applications, infrastructure, authentication, observability, functions,
   sbaerlocher.ch, tsmetrics, and more
 
@@ -44,6 +44,8 @@ directly impacting the CI/CD pipelines of multiple projects.
 - `ops-*.yml` - Operational workflows
 - `ai-*.yml` - AI-assisted workflows
 - `e2e-*.yml` - End-to-end test workflows
+- `test-*.yml` - **Internal self-test workflows for actions in this repo
+  (NOT reusable — `paths:` filtered to a specific action's source files)**
 
 **Workflow Names** (`name:` field):
 
@@ -184,13 +186,71 @@ uses: sbaerlocher/.github/.github/workflows/ci-js.yml@2026-04-25
 | Code Review | `ai-claude-review.yml` | Auto code review (reads REVIEW.md) |
 | On-demand   | `ai-claude.yml`        | On-demand @claude mentions         |
 
-### E2E - End-to-End Tests (1)
+### E2E - End-to-End Tests (2)
 
-**Purpose**: End-to-end testing with Docker Compose
+**Purpose**: End-to-end testing with Docker Compose or whatwedo dde
 
-| Workflow   | File             | Description                  |
-| ---------- | ---------------- | ---------------------------- |
-| E2E Docker | `e2e-docker.yml` | E2E tests via Docker Compose |
+| Workflow   | File             | Description                                                     |
+| ---------- | ---------------- | --------------------------------------------------------------- |
+| E2E Docker | `e2e-docker.yml` | E2E tests via Docker Compose + Playwright                       |
+| E2E dde    | `e2e-dde.yml`    | E2E tests via whatwedo `dde project:up` + Playwright (Linux)    |
+
+`e2e-dde.yml` is the dde-native counterpart to `e2e-docker.yml`. Inputs
+overlap (Playwright/Node setup is identical); the stack-management surface
+swaps `compose-file` / `compose-profile` for `project-directory` /
+`wait-url`. Linux-only (`dde system:install` requires Docker, which hosted
+macOS runners don't ship).
+
+### Internal Self-Tests (1)
+
+**Purpose**: Smoke-test composite actions in this repo when their sources
+change. Not reusable from consumer repos.
+
+| Workflow         | File                     | Description                            |
+| ---------------- | ------------------------ | -------------------------------------- |
+| Test dde actions | `test-actions-dde.yml`   | Smoke-test `setup-dde` on Linux/macOS  |
+
+---
+
+## Composite Actions
+
+Located under [`.github/actions/`](./.github/actions/). Consume from any
+workflow via `sbaerlocher/.github/.github/actions/<name>@<DATE-TAG>`.
+
+| Action       | File                            | Purpose                                                       |
+| ------------ | ------------------------------- | ------------------------------------------------------------- |
+| `setup-dde`  | `.github/actions/setup-dde/`    | Install whatwedo dde CLI; optional mkcert + `system:install`  |
+| `project-up` | `.github/actions/project-up/`   | Install dde + `system:install` + `dde project:up` for E2E     |
+| `sbom-npm`   | `.github/actions/sbom-npm/`     | CycloneDX SBOM for npm/pnpm/yarn/bun (internal helper)        |
+
+### dde actions (`setup-dde`, `project-up`)
+
+`setup-dde` downloads the dde binary from
+[`whatwedo/dde`](https://github.com/whatwedo/dde) GitHub releases, verifies
+SHA256 against `checksums.txt`, places it on `PATH`, and optionally installs
+`mkcert` and runs `sudo --preserve-env=HOME,USER,DDE_CONFIG_DIR,DDE_DATA_DIR dde
+system:install` (HOME preserved so mkcert installs the CA into the runner
+user's trust store, not `/root`).
+
+`project-up` is a thin wrapper: it `uses: ./.github/actions/setup-dde` with
+`system-install: 'true'`, then runs `dde project:up` in the supplied
+`working-directory`, then optionally polls `wait-url`. The relative `uses:`
+inside a composite action resolves against the action's own repo, so this
+works both for cross-repo consumers and for this repo's self-test workflow.
+
+Reusable workflows (`e2e-dde.yml`) reference the actions via the full
+versioned path (`sbaerlocher/.github/.github/actions/project-up@<DATE-TAG>`)
+because a reusable workflow's `uses: ./...` resolves against the caller's
+workspace, not the workflow's repo.
+
+Composite actions have no `post:` hook, so cleanup is always an explicit
+`if: always() run: dde project:down` step in the consumer workflow.
+
+### sbom-npm
+
+Generates a CycloneDX SBOM for JavaScript/TypeScript projects. Consumed by
+`release-npm.yml` and `security-sbom.yml`; not intended as a standalone
+public action.
 
 ---
 
@@ -382,14 +442,15 @@ Ensure lock files are committed:
 ```text
 .github/
 ├── .github/
-│   ├── workflows/           # 21 reusable workflows
+│   ├── workflows/           # 22 reusable workflows + 1 internal self-test
 │   │   ├── ai-*.yml        # AI workflows
 │   │   ├── ci-*.yml        # CI workflows
 │   │   ├── deploy-*.yml    # Deploy workflows
 │   │   ├── e2e-*.yml       # End-to-end test workflows
 │   │   ├── ops-*.yml       # Operations workflows
 │   │   ├── release-*.yml   # Release workflows
-│   │   └── security-*.yml  # Security workflows
+│   │   ├── security-*.yml  # Security workflows
+│   │   └── test-*.yml      # Internal self-tests (NOT reusable)
 │   ├── ISSUE_TEMPLATE/     # Org-default issue forms
 │   ├── CODEOWNERS          # Repository owners
 │   ├── pull_request_template.md
@@ -515,5 +576,5 @@ Ensure lock files are committed:
 
 ---
 
-**Last Updated**: 2026-04-26
-**Version**: 1.2.0
+**Last Updated**: 2026-04-28
+**Version**: 1.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ This is a rolling release - changes are deployed continuously to `main`.
 
 ---
 
+## 2026-04-28
+
+### Added
+
+- **`e2e-dde.yml`**: Reusable E2E workflow using whatwedo `dde` for stack
+  management instead of Docker Compose. Mirrors the Playwright/Node setup
+  surface of `e2e-docker.yml`; replaces `compose-file` / `compose-profile`
+  with `project-directory` / `wait-url`. Linux-only (Docker is required by
+  `dde system:install`). PR-comment step is split into a separate job so
+  the test job runs at `contents: read` only; `pull-requests: write` is
+  scoped to the comment job. `cache-dependency-path` is selected based on
+  the `package-manager` input (npm / pnpm / yarn / bun), and
+  `playwright-browsers` / `test-command` flow through `env:` to prevent
+  shell injection from caller-supplied input. Migration: consumers running
+  `e2e-docker.yml` against a dde-compatible project can switch by
+  replacing the workflow reference and renaming inputs accordingly.
+- **`.github/actions/setup-dde/`**: Composite action that installs the
+  [whatwedo dde](https://github.com/whatwedo/dde) CLI, verifies the binary
+  against the release `checksums.txt`, and places it on `PATH`. Optional
+  `mkcert` install and `dde system:install`.
+- **`.github/actions/project-up/`**: Composite action that wraps
+  `setup-dde` + `system:install` + `dde project:up` plus an optional
+  `wait-url` poll loop. Intended for ad-hoc E2E pipelines that don't use
+  `e2e-dde.yml`. New `system-install` input (default `true`) lets unit-style
+  tests skip host provisioning. `wait-timeout` default is `180` (matches
+  `e2e-dde.yml`).
+- **`test-actions-dde.yml`**: Internal self-test workflow for the dde
+  composite actions. Not reusable. Smoke test for `setup-dde` covers
+  `ubuntu-latest`, `ubuntu-24.04-arm`, `macos-latest`, and `macos-13`
+  (darwin-amd64 coverage). The `project-up` smoke test uses
+  `system-install: 'false'` so it does not mutate the runner host.
+
+### Changed
+
+- **README.md / AGENTS.md**: Document the `Composite Actions` surface;
+  introduce `test-*.yml` as the filename prefix for internal self-test
+  workflows that are not consumer-callable.
+- **STANDARDS.md**: Annotate `setup-dde` and `project-up` as whatwedo-only;
+  clarify `sbom-npm` is an internal helper for `release-npm.yml` and
+  `security-sbom.yml`.
+
+---
+
 ## 2026-04-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Centralized CI/CD building blocks for all repositories under
 each workflow by date tag and let Renovate keep them current.
 
 - **Model:** rolling release with date tags (`YYYY-MM-DD`)
-- **Total workflows:** 21
-- **Last updated:** 2026-04-26
+- **Total workflows:** 22
+- **Last updated:** 2026-04-28
 
 See [STANDARDS.md](./STANDARDS.md) for repository conventions and
 [AGENTS.md](./AGENTS.md) for AI-agent context.
@@ -124,11 +124,40 @@ All files live in [.github/workflows/](./.github/workflows/).
 - [`ai-claude-review.yml`](./.github/workflows/ai-claude-review.yml)
   — Automatic code review on PRs (uses REVIEW.md as context)
 
-### E2E (1)
+### E2E (2)
 
-| File                                                   | Purpose                             |
-| ------------------------------------------------------ | ----------------------------------- |
-| [`e2e-docker.yml`](./.github/workflows/e2e-docker.yml) | End-to-end tests via Docker Compose |
+| File                                                   | Purpose                                              |
+| ------------------------------------------------------ | ---------------------------------------------------- |
+| [`e2e-docker.yml`](./.github/workflows/e2e-docker.yml) | End-to-end tests via Docker Compose + Playwright     |
+| [`e2e-dde.yml`](./.github/workflows/e2e-dde.yml)       | End-to-end tests via whatwedo dde + Playwright       |
+
+---
+
+## Composite Actions
+
+In addition to reusable workflows, this repo ships composite actions under
+[.github/actions/](./.github/actions/) for use from any consumer workflow.
+
+| Action                                            | Purpose                                                          |
+| ------------------------------------------------- | ---------------------------------------------------------------- |
+| [`setup-dde`](./.github/actions/setup-dde/)       | Install the [whatwedo dde](https://github.com/whatwedo/dde) CLI  |
+| [`project-up`](./.github/actions/project-up/)     | Install dde + `system:install` + `dde project:up` for E2E in CI  |
+| [`sbom-npm`](./.github/actions/sbom-npm/)         | CycloneDX SBOM for npm/pnpm/yarn/bun projects (internal)         |
+
+For a complete Playwright + dde E2E job, use the
+[`e2e-dde.yml`](./.github/workflows/e2e-dde.yml) reusable workflow — it
+wires `project-up` together with Node, browser install, artifacts, and PR
+commenting. Reach for the composite actions directly only when you need a
+custom test surface that the workflow doesn't cover.
+
+Reference an action from a consumer repository (Renovate keeps the date
+tag up to date):
+
+```yaml
+- uses: sbaerlocher/.github/.github/actions/project-up@2026-04-28
+  with:
+    wait-url: https://myproject.test/healthz
+```
 
 ---
 

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -137,6 +137,22 @@ The current set of tags is visible at
 | AI       | `ai-claude-review.yml`            | Auto code review (reads REVIEW.md) |
 | AI       | `ai-claude.yml`                   | On-demand @claude mentions         |
 | E2E      | `e2e-docker.yml`                  | E2E tests via Docker Compose       |
+| E2E      | `e2e-dde.yml`                     | E2E tests via whatwedo dde         |
+
+### Available Composite Actions
+
+Composite actions live in `sbaerlocher/.github/.github/actions/<name>/`
+and are referenced with the same date-tag scheme as reusable workflows:
+
+```yaml
+uses: sbaerlocher/.github/.github/actions/setup-dde@2026-04-28
+```
+
+| Action       | Description                                                                                        |
+| ------------ | -------------------------------------------------------------------------------------------------- |
+| `setup-dde`  | Install whatwedo dde CLI; optional mkcert + `system:install` *(whatwedo projects only)*            |
+| `project-up` | Install dde + `system:install` + `dde project:up` (E2E one-shot) *(whatwedo projects only)*        |
+| `sbom-npm`   | CycloneDX SBOM for npm/pnpm/yarn/bun (internal helper for `release-npm.yml` / `security-sbom.yml`) |
 
 ### Action SHA Pinning
 


### PR DESCRIPTION
## Summary

- New reusable workflow `e2e-dde.yml` — Playwright E2E against a whatwedo-`dde`-managed stack. Mirrors `e2e-docker.yml` but swaps `compose-file` / `compose-profile` for `project-directory` / `wait-url`. Linux-only.
- New composite actions: `setup-dde` (binary install + checksum verify + optional `mkcert` and `system:install`) and `project-up` (wraps `setup-dde` + `dde project:up` + optional URL poll). `project-up` exposes a `system-install` opt-out for unit-style tests.
- Internal self-test `test-actions-dde.yml` exercises `setup-dde` on `ubuntu-latest`, `ubuntu-24.04-arm`, `macos-latest`, and `macos-13` (darwin-amd64 coverage). The `project-up` smoke job uses `system-install: 'false'` so the runner host is not mutated.

## Security & correctness

- PR-comment runs in a separate job; the test job is `contents: read` only. `pull-requests: write` is scoped to the comment job.
- `playwright-browsers` and `test-command` flow through `env:` instead of direct `${{ }}` interpolation — no shell injection from caller input.
- `cache-dependency-path` switches on `package-manager` (npm / pnpm / yarn / bun); bun skips cache (setup-node has no bun support).
- `wait-timeout` default aligned to 180s across `project-up` and `e2e-dde.yml`.
- `setup-dde` checksum verification is fail-closed (missing asset / missing checksum file / hash mismatch all abort).

## Docs

- `STANDARDS.md`: `setup-dde` and `project-up` annotated as *whatwedo projects only*; `sbom-npm` clarified as internal helper.
- `AGENTS.md` + `README.md`: document the Composite Actions surface; introduce `test-*.yml` filename prefix for internal self-tests; counts and `Last Updated` metadata bumped to 2026-04-28.
- `CHANGELOG.md`: `2026-04-28` entry covering the additions and the security/correctness hardening.

## Test plan

- [ ] `test-actions-dde.yml` green on `ubuntu-latest`, `ubuntu-24.04-arm`, `macos-latest`, `macos-13`.
- [ ] `project-up` smoke job (`system-install: 'false'`) fails fast on missing `.dde/config.yml` without provisioning Traefik on the runner.
- [ ] Cut the `2026-04-28` date tag after merge so the `@2026-04-28` references in workflow and READMEs resolve.
- [ ] Smoke-consume `e2e-dde.yml` from a downstream sbaerlocher repo with a real `.dde/config.yml` before relying on it for required checks.