### PR TITLE
fix(dde): reference setup-dde via full repo path in project-up

### DIFF
--- a/.github/actions/project-up/action.yml
+++ b/.github/actions/project-up/action.yml
@@ -52,12 +52,14 @@ runs:
   using: 'composite'
   steps:
     # `uses: ./...` from inside a composite action resolves against the
-    # action's own repository (not the caller's workspace), so this works
-    # both when project-up is consumed from another repo and when it runs
-    # from this repo's self-test workflow.
+    # caller's GITHUB_WORKSPACE, NOT against this action's own repo — see
+    # https://github.com/actions/runner/issues/2185. Reference setup-dde via
+    # the full repo path with a date tag so the action keeps working when
+    # consumed from any repository. Renovate keeps this ref in sync with new
+    # rolling-release tags via the github-actions manager.
     - name: Setup dde
       id: setup
-      uses: ./.github/actions/setup-dde
+      uses: sbaerlocher/.github/.github/actions/setup-dde@2026-04-28
       with:
         version: ${{ inputs.version }}
         install-mkcert: ${{ inputs.install-mkcert }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,16 +232,26 @@ SHA256 against `checksums.txt`, places it on `PATH`, and optionally installs
 system:install` (HOME preserved so mkcert installs the CA into the runner
 user's trust store, not `/root`).
 
-`project-up` is a thin wrapper: it `uses: ./.github/actions/setup-dde` with
+`project-up` is a thin wrapper: it calls `setup-dde` with
 `system-install: 'true'`, then runs `dde project:up` in the supplied
-`working-directory`, then optionally polls `wait-url`. The relative `uses:`
-inside a composite action resolves against the action's own repo, so this
-works both for cross-repo consumers and for this repo's self-test workflow.
+`working-directory`, then optionally polls `wait-url`. Both reusable
+workflows (`e2e-dde.yml`) and composite actions (`project-up`) must
+reference sibling actions via the full versioned path
+(`sbaerlocher/.github/.github/actions/<name>@<DATE-TAG>`), because
+`uses: ./...` always resolves against the caller's `GITHUB_WORKSPACE`,
+never against the action/workflow's own repo
+(see [actions/runner#2185](https://github.com/actions/runner/issues/2185)).
+Renovate keeps the inner ref in `project-up/action.yml` aligned with new
+date tags via the standard github-actions manager.
 
-Reusable workflows (`e2e-dde.yml`) reference the actions via the full
-versioned path (`sbaerlocher/.github/.github/actions/project-up@<DATE-TAG>`)
-because a reusable workflow's `uses: ./...` resolves against the caller's
-workspace, not the workflow's repo.
+The self-test workflow (`test-actions-dde.yml`) is the one place `./...`
+is safe — it's a normal workflow that runs `actions/checkout` first, so
+the workspace coincidentally matches the action's repo. Side-effect of
+the full-path pin: the `smoke-project-up-*` jobs exercise the *tagged*
+`setup-dde`, not the in-PR copy, so changes to `setup-dde/action.yml`
+are only validated end-to-end through `project-up` once a new date tag
+has been cut. Direct changes to `setup-dde` are still covered by the
+`smoke-setup-dde` matrix in the same workflow.
 
 Composite actions have no `post:` hook, so cleanup is always an explicit
 `if: always() run: dde project:down` step in the consumer workflow.

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>sbaerlocher/.github:renovate-base#main"],
   "github-actions": {
-    "managerFilePatterns": ["/(^|/)workflows/[^/]+\\.ya?ml$/"]
+    "managerFilePatterns": [
+      "/(^|/)workflows/[^/]+\\.ya?ml$/",
+      "/(^|/)actions/[^/]+/action\\.ya?ml$/"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- `project-up` composite action now references `setup-dde` via the full
  versioned path `sbaerlocher/.github/.github/actions/setup-dde@2026-04-28`
  instead of the relative `./.github/actions/setup-dde`.
- AGENTS.md updated to reflect that `uses: ./...` always resolves against
  the caller's `GITHUB_WORKSPACE`, both inside reusable workflows and
  composite actions (the previous claim that composite actions were
  different was wrong — see [actions/runner#2185](https://github.com/actions/runner/issues/2185)).

## Why

Consumer repositories like [`sbaerlocher/savvy`](https://github.com/sbaerlocher/savvy/actions/runs/25137610221/job/73680184474?pr=102)
were failing with:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
'/home/runner/work/savvy/savvy/.github/actions/setup-dde'.
Did you forget to run actions/checkout before running your local action?
```

The relative `./...` was being resolved against the caller's workspace
(`savvy`), not against the action's own repo. The self-test
(`test-actions-dde.yml`) didn't catch this because it's a regular
workflow that does `actions/checkout` of `sbaerlocher/.github` first,
so the workspace coincidentally contains the `setup-dde` directory.

## Follow-ups

- After merge, cut a new rolling-release date tag so consumers' pinned
  refs (`@2026-04-28`) point at a working `project-up`.
- Renovate will then bump consumer pins automatically via the existing
  `sbaerlocher/.github` package rule.

## Test plan

- [ ] CI passes on this PR (self-test workflow exercises `setup-dde` and
      `project-up` smoke jobs in the same workflow run).
- [ ] After merge + new date tag: re-run the failing
      [savvy E2E job](https://github.com/sbaerlocher/savvy/actions/runs/25137610221)
      and confirm `setup-dde` resolves.