### PR TITLE
fix(dde): drop sudo wrapper around dde system:install

### DIFF
--- a/.github/actions/project-up/README.md
+++ b/.github/actions/project-up/README.md
@@ -89,7 +89,8 @@ not supported.
 ## What runs under the hood
 
 1. **`uses: setup-dde` with `system-install: 'true'`** — install + verify
-   the binary, install `mkcert`, and run `sudo dde system:install`. See
+   the binary, install `mkcert`, and run `dde system:install` as the
+   runner user (dde escalates internally for steps that need root). See
    [`setup-dde`](../setup-dde/) for the underlying steps.
 2. `cd $working-directory && dde project:up` — fails fast if
    `.dde/config.yml` is missing.

--- a/.github/actions/setup-dde/README.md
+++ b/.github/actions/setup-dde/README.md
@@ -48,7 +48,7 @@ sibling [`project-up`](../project-up/) action instead.
 |------------------|----------------|--------------------------------------------------------------------------|
 | `version`        | `latest`       | Tag to install (`v2.0.0-alpha.5`, `2.0.0-alpha.5`, or `latest`).         |
 | `install-mkcert` | `true`         | Install `mkcert` (and `libnss3-tools` on Linux) for local TLS certs.     |
-| `system-install` | `false`        | Run `sudo dde system:install` (required for `dde project:up`).           |
+| `system-install` | `false`        | Run `dde system:install` (required for `dde project:up`).                |
 | `github-token`   | `github.token` | Token for the GitHub API call that resolves `latest`.                    |
 | `repository`     | `whatwedo/dde` | Source repository. Override for forks or staging mirrors.                |
 
@@ -90,15 +90,14 @@ fail to update the system NSS database. If that applies, install
 `dde system:install` performs host-level configuration (writes
 `/etc/systemd/resolved.conf.d/dde-test.conf` on Linux, restarts
 `systemd-resolved`) and starts the global Traefik, dnsmasq and SSH-Agent
-containers. The action invokes it via:
+containers. The action invokes it as the runner user — dde escalates
+internally (passwordless sudo, which GitHub-hosted runners provide) for
+the individual steps that need root. Wrapping the whole call in `sudo`
+would leave dde's state files (`~/.dde/data/...`) root-owned and break
+the subsequent unprivileged `dde project:*` calls.
 
-```bash
-sudo --preserve-env=HOME,USER,DDE_CONFIG_DIR,DDE_DATA_DIR dde system:install
-```
-
-`HOME` is preserved so `mkcert` installs its local CA into the runner
-user's trust store rather than `/root`. `DDE_CONFIG_DIR` / `DDE_DATA_DIR`
-are forwarded so the caller can isolate dde state into a temp directory:
+`DDE_CONFIG_DIR` / `DDE_DATA_DIR` propagate naturally, so the caller
+can isolate dde state into a temp directory:
 
 ```yaml
 - uses: sbaerlocher/.github/.github/actions/setup-dde@2026-04-28

--- a/.github/actions/setup-dde/action.yml
+++ b/.github/actions/setup-dde/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: false
     default: 'true'
   system-install:
-    description: 'Run `dde system:install` after installing the binary. Requires sudo and Docker.'
+    description: 'Run `dde system:install` after installing the binary. Requires Docker; dde escalates internally (passwordless sudo) for steps that need root.'
     required: false
     default: 'false'
   github-token:
@@ -164,10 +164,10 @@ runs:
         BINARY: ${{ steps.install.outputs.binary-path }}
       run: |
         set -euo pipefail
-        # Preserve HOME so mkcert installs the local CA into the runner
-        # user's trust store (otherwise sudo resets HOME to /root and the
-        # CA ends up where dde-as-runner-user can't find it).
-        # DDE_CONFIG_DIR / DDE_DATA_DIR are forwarded so callers can
-        # isolate state into a temp directory if they wish.
-        sudo --preserve-env=HOME,USER,DDE_CONFIG_DIR,DDE_DATA_DIR \
-          "$BINARY" system:install
+        # Run as the runner user, not under sudo. dde escalates internally
+        # for the steps that need root (mkcert CA, DNS resolver), and that
+        # path relies on passwordless sudo, which GitHub-hosted runners
+        # provide. Wrapping the whole command in `sudo` would leave dde's
+        # state files (~/.dde/data/...) root-owned, breaking the
+        # subsequent unprivileged `dde project:*` calls.
+        "$BINARY" system:install

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,9 +228,11 @@ workflow via `sbaerlocher/.github/.github/actions/<name>@<DATE-TAG>`.
 `setup-dde` downloads the dde binary from
 [`whatwedo/dde`](https://github.com/whatwedo/dde) GitHub releases, verifies
 SHA256 against `checksums.txt`, places it on `PATH`, and optionally installs
-`mkcert` and runs `sudo --preserve-env=HOME,USER,DDE_CONFIG_DIR,DDE_DATA_DIR dde
-system:install` (HOME preserved so mkcert installs the CA into the runner
-user's trust store, not `/root`).
+`mkcert` and runs `dde system:install` as the runner user. dde escalates
+internally (passwordless sudo, which GitHub-hosted runners provide) for the
+individual steps that need root — wrapping the whole call in `sudo` would
+leave the state files in `~/.dde/data/` root-owned and break the subsequent
+unprivileged `dde project:*` calls.
 
 `project-up` is a thin wrapper: it calls `setup-dde` with
 `system-install: 'true'`, then runs `dde project:up` in the supplied

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ This is a rolling release - changes are deployed continuously to `main`.
 
 ---
 
+## 2026-04-30
+
+### Fixed
+
+- **`setup-dde`**: Drop the `sudo --preserve-env=...` wrapper around
+  `dde system:install`. dde escalates internally (passwordless sudo) for
+  the individual steps that need root, so wrapping the whole call left
+  `~/.dde/data/...` files root-owned and broke subsequent unprivileged
+  `dde project:*` calls. Surfaced once the action-resolution bug fixed
+  in #93 stopped masking it. Caller-visible changes: none for the happy
+  path; the `system-install` input description and the `setup-dde` /
+  `project-up` / AGENTS.md notes were aligned with the new behavior.
+
+---
+
 ## 2026-04-28
 
 ### Added


### PR DESCRIPTION
## Summary

Remove the `sudo --preserve-env=...` wrapper around `dde system:install`
in `setup-dde`. The upstream README runs the command unprivileged; dde
escalates internally (passwordless sudo) for the steps that actually
need root (mkcert CA, DNS resolver tweak).

## Why

Wrapping the whole command in `sudo` had two side effects:

1. **State files end up root-owned.** The next unprivileged
   `dde project:up` then fails with `Permission denied` when trying to
   overwrite the generated dnsmasq config:

   ```
   [ERROR] Cannot rename "/tmp/dnsmasq.conf..." to
           "/home/runner/.dde/data/dnsmasq/dnsmasq.conf":
           Permission denied
   ```

   Observed in [sbaerlocher/savvy#102](https://github.com/sbaerlocher/savvy/actions/runs/25138709404/job/73683744817)
   once the action-resolution bug fixed in #93 stopped masking it.
2. The `--preserve-env=HOME,USER,DDE_CONFIG_DIR,DDE_DATA_DIR` workaround
   exists only because of the sudo wrap; dropping the wrap drops the
   workaround.

## Test plan

- [ ] CI passes on this PR (note: `test-actions-dde.yml` runs
      `system-install: 'false'`, so this code path is not directly
      covered — see follow-up below).
- [ ] After merge + `2026-04-28` tag-move: re-run the failing
      [savvy E2E job](https://github.com/sbaerlocher/savvy/actions/runs/25138709404)
      and confirm `dde project:up` proceeds past the dnsmasq config step.

## Follow-ups

- The self-test workflow uses `system-install: 'false'`, so this code
  path is not exercised in this repo's CI. Adding a smoke job that
  runs `system:install` on `ubuntu-latest` would close the gap.