### PR TITLE
fix(ai-claude-review): harden review prompt and split cost by mode

### DIFF
--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -16,10 +16,21 @@ concurrency:
 
 jobs:
   claude-review:
+    # Skips:
+    # - draft PRs: not ready for review.
+    # - Renovate/Dependabot: predictable bot updates with deterministic diffs.
+    #   This is broader than REVIEW.md (which only sanctions skipping SHA-only Renovate
+    #   PRs), but in practice these bots' PRs are uniform enough that an AI review
+    #   adds little value relative to the Opus token cost.
+    # - fork PRs: `pull_request` from forks runs without secrets and with read-only
+    #   token, so the job would post zero comments and look broken. Skip cleanly
+    #   instead. (Switching to `pull_request_target` would re-enable this but trades
+    #   away the safety of running on the PR's own code.)
     if: |
       !github.event.pull_request.draft &&
       github.event.pull_request.user.login != 'renovate[bot]' &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -33,6 +44,39 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Determine review mode (first vs follow-up), the bot login under which
+      # prior reviews were posted, and the SHA of the last review. Done in shell
+      # so it's deterministic, doesn't burn Claude turns, and the model/max-turns
+      # below can be selected via expression instead of inside the prompt.
+      - id: mode
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          BOT=$(gh api "repos/$REPO/pulls/$PR/reviews" \
+            --jq '[.[] | select(.user.type=="Bot" and (.user.login|test("claude";"i")))][0].user.login // ""')
+          if [ -z "$BOT" ]; then
+            BOT=$(gh api "repos/$REPO/pulls/$PR/comments" \
+              --jq '[.[] | select(.user.type=="Bot" and (.user.login|test("claude";"i")))][0].user.login // ""')
+          fi
+          [ -z "$BOT" ] && BOT="claude[bot]"
+          echo "bot-login=$BOT" >> "$GITHUB_OUTPUT"
+
+          LAST=$(gh api "repos/$REPO/pulls/$PR/reviews" \
+            --jq "[.[] | select(.user.login==\"$BOT\")] | last")
+
+          if [ "$LAST" = "null" ] || [ -z "$LAST" ]; then
+            echo "mode=first" >> "$GITHUB_OUTPUT"
+            echo "last-review-sha=" >> "$GITHUB_OUTPUT"
+          else
+            SHA=$(printf '%s' "$LAST" | jq -r '.commit_id')
+            echo "mode=followup" >> "$GITHUB_OUTPUT"
+            echo "last-review-sha=$SHA" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -40,79 +84,113 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           claude_args: |
-            --max-turns 100
-            --model claude-opus-4-7
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Task,Agent,Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git log:*),Bash(gh api repos/*/pulls/*/comments*),Bash(gh api repos/*/pulls/comments*),Bash(gh api graphql:*)"
+            --max-turns ${{ steps.mode.outputs.mode == 'first' && '100' || '40' }}
+            --model ${{ steps.mode.outputs.mode == 'first' && 'claude-opus-4-7' || 'claude-sonnet-4-6' }}
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Agent,Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git log:*),Bash(gh api repos/*/pulls/*/comments*),Bash(gh api repos/*/pulls/comments*),Bash(gh api repos/*/pulls/*/comments/*/replies*),Bash(gh api repos/*/pulls/*/reviews*),Bash(gh api repos/*/compare/*),Bash(gh api graphql:*)"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
-            YOUR USERNAME: claude[bot]
+            HEAD SHA: ${{ github.event.pull_request.head.sha }}
+            MODE: ${{ steps.mode.outputs.mode }}
+            BOT_LOGIN: ${{ steps.mode.outputs.bot-login }}
+            LAST_REVIEW_SHA: ${{ steps.mode.outputs.last-review-sha }}
 
-            ## Step 1: Determine review mode
+            ## Repo-specific rules (always check first)
 
-            Check if you have already reviewed this PR:
-            `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments --jq '[.[] | select(.user.login == "claude[bot]")] | length'`
+            Try to Read these files at the repo root if they exist:
+            - `REVIEW.md` — explicit code-review rules. Takes precedence over generic best practices.
+            - `AGENTS.md` — repo-wide conventions for AI agents.
+            - `CLAUDE.md` — Claude-specific instructions (often just imports AGENTS.md).
+
+            If a rule in these files conflicts with a generic best practice, follow the file.
+            If none exist, proceed with generic best practices.
 
             ---
 
-            ## Step 2a: First review (result is 0 — no previous comments from you)
+            ## If MODE == first (no previous review by you on this PR)
 
             Perform a thorough, detailed code review:
-            - Run /code-review --comment
-            - Leave inline comments on every issue you find, no matter how small
+            - Run `/code-review --comment`
+            - Leave inline comments on every issue you find, no matter how small.
+            - At the end, submit a review with the appropriate verdict:
+              - Issues found:
+                ```
+                gh pr review ${{ github.event.pull_request.number }} --request-changes \
+                  --body "<short summary of the open issues>"
+                ```
+              - No issues:
+                ```
+                gh pr review ${{ github.event.pull_request.number }} --approve \
+                  --body "No issues found."
+                ```
 
             ---
 
-            ## Step 2b: Follow-up review (result > 0 — previous comments exist from you)
+            ## If MODE == followup (previous review by BOT_LOGIN exists)
 
-            Do NOT run a full review again. Act as a follow-up reviewer:
+            Do NOT run `/code-review` again. You have already reviewed this PR — only check the delta.
 
-            1. Fetch your previous comments:
-               `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments --jq '[.[] | select(.user.login == "claude[bot]")]'`
-
-            2. Look at what changed since your last review:
-               `gh pr diff ${{ github.event.pull_request.number }}`
-
-            3. For each of your previous inline comments, post a reply using the GitHub API directly
-               (the MCP inline comment tool does NOT support replies — use gh api instead):
+            1. Fetch your previous inline comments:
                ```
-               gh api repos/${{ github.repository }}/pulls/comments/<COMMENT_ID>/replies \
+               gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments \
+                 --jq '[.[] | select(.user.login=="${{ steps.mode.outputs.bot-login }}")]'
+               ```
+
+            2. Look at what actually changed since your last review (NOT the full PR diff):
+               ```
+               gh api repos/${{ github.repository }}/compare/${{ steps.mode.outputs.last-review-sha }}...${{ github.event.pull_request.head.sha }} \
+                 --jq '{files: [.files[] | {filename, status, patch}]}'
+               ```
+
+            3. For each of your previous inline comments, post a reply via the GitHub API
+               (the MCP inline comment tool does NOT support replies). The PR number is
+               part of the path — leaving it out returns 404:
+               ```
+               gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments/<COMMENT_ID>/replies \
                  -X POST -f body="<your reply text>"
                ```
-               - **Resolved** — the issue was fixed, briefly confirm what was done
-               - **Still open** — explain what is still missing or incorrect
+               - **Resolved** — confirm briefly what was done.
+               - **Still open** — explain what is still missing or incorrect.
 
-            4. Only add new inline comments (via the MCP tool) for issues not covered in your previous review
+            4. Add new inline comments (via the MCP tool) only for issues introduced
+               in the step 2 diff. Do not re-flag pre-existing code.
 
-            5. After replying to all previous comments, check whether all issues are now resolved:
-               - If ALL issues are resolved: approve the PR and resolve all review threads
-               - If ANY issue is still open: do NOT approve, leave the threads unresolved
+            5. Submit a review based on the outcome:
+               - All previous resolved AND no new issues:
+                 ```
+                 gh pr review ${{ github.event.pull_request.number }} --approve \
+                   --body "All raised issues have been addressed."
+                 ```
+                 Then resolve all review threads via GraphQL (below).
+               - Any open or new issues:
+                 ```
+                 gh pr review ${{ github.event.pull_request.number }} --request-changes \
+                   --body "<summary of remaining issues>"
+                 ```
+                 Leave threads unresolved.
 
-               Approve the PR:
-               ```
-               gh pr review ${{ github.event.pull_request.number }} --approve --body "All raised issues have been addressed."
-               ```
+            GraphQL — list thread IDs:
+            ```
+            gh api graphql -f query='
+              query {
+                repository(owner: "${{ github.repository_owner }}", name: "${{ github.event.repository.name }}") {
+                  pullRequest(number: ${{ github.event.pull_request.number }}) {
+                    reviewThreads(first: 100) {
+                      nodes { id isResolved }
+                    }
+                  }
+                }
+              }
+            '
+            ```
 
-               Resolve each thread via GraphQL (get thread IDs first, then resolve each):
-               ```
-               gh api graphql -f query='
-                 query {
-                   repository(owner: "${{ github.repository_owner }}", name: "${{ github.event.repository.name }}") {
-                     pullRequest(number: ${{ github.event.pull_request.number }}) {
-                       reviewThreads(first: 100) {
-                         nodes { id isResolved }
-                       }
-                     }
-                   }
-                 }
-               '
-               ```
-               ```
-               gh api graphql -f query='
-                 mutation {
-                   resolveReviewThread(input: {threadId: "<THREAD_ID>"}) {
-                     thread { isResolved }
-                   }
-                 }
-               '
-               ```
+            GraphQL — resolve a single thread:
+            ```
+            gh api graphql -f query='
+              mutation {
+                resolveReviewThread(input: {threadId: "<THREAD_ID>"}) {
+                  thread { isResolved }
+                }
+              }
+            '
+            ```


### PR DESCRIPTION
## Summary

- Fixes broken follow-up reviews: `/replies` URL was missing the PR number (404), mode detection counted inline comments so clean PRs stayed in first-review mode forever, bot login was hardcoded.
- Splits cost by mode: first review keeps Opus + 100 turns, follow-up drops to Sonnet + 40 turns. Cuts the per-push token bill on active PRs by ~70-90%.
- Adds explicit `--request-changes` path so PRs don't sit in limbo when issues remain.
- Instructs Read of `REVIEW.md` / `AGENTS.md` / `CLAUDE.md` before judging — repo-specific rules take precedence over generic best practices.
- Skips fork PRs at the `if:` level (no secrets, would post nothing); documents the broader Renovate/Dependabot skip.

## Behavior changes

- **Mode detection** now lives in a deterministic shell pre-step (`steps.mode`) instead of inside the prompt. `bot-login`, `last-review-sha` and `mode` flow into `claude_args` (model + max-turns) and the prompt header. No more wasted Claude turns on API discovery.
- **Diff window** for follow-ups uses `gh api compare/<LAST_REVIEW_SHA>...<HEAD>` instead of `gh pr diff` (which always returned the full diff vs base).
- **Reply endpoint** corrected to `pulls/<PR>/comments/<id>/replies` with explicit "PR number is part of the path" warning in the prompt.

## Test plan

- [ ] First push to a fresh PR → mode = first, runs `/code-review --comment` with Opus, submits `--request-changes` or `--approve`.
- [ ] Subsequent push to same PR → mode = followup, runs Sonnet, replies to existing inline comments via the corrected `/replies` endpoint, only flags new issues from the compare diff.
- [ ] Clean PR with no findings on first run → still detected as "reviewed" via reviews API on second run (not just inline comments).
- [ ] Fork PR → job is skipped at `if:` level instead of failing silently.
- [ ] Renovate PR → still skipped.