### PR TITLE
ci: standardise concurrency, harden checkout, add ops reusables

### DIFF
--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -4,15 +4,40 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
   workflow_call:
+    inputs:
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: true
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: true
         # Note: for pull_request trigger, secrets.CLAUDE_CODE_OAUTH_TOKEN resolves
         # directly from the repo's secrets context — no caller needed.
 
+permissions:
+  contents: read
+
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
+  group: >-
+    claude-review-${{ github.event.pull_request.number || github.run_id }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
   claude-review:
@@ -42,6 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 1
 
       # Determine review mode (first vs follow-up), the bot login under which

--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -33,11 +33,14 @@ permissions:
   contents: read
 
 concurrency:
+  # Dual-trigger workflow: `inputs.*` is undefined on `pull_request:` and
+  # only populated under `workflow_call:`. Expressions below fall back to
+  # the original hardcoded behaviour when inputs are missing.
   group: >-
     claude-review-${{ github.event.pull_request.number || github.run_id }}${{
-      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+      inputs.concurrency-suffix && format('-{0}', inputs.concurrency-suffix) || ''
     }}
-  cancel-in-progress: ${{ inputs.cancel-in-progress }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress != false }}
 
 jobs:
   claude-review:

--- a/.github/workflows/ai-claude.yml
+++ b/.github/workflows/ai-claude.yml
@@ -2,13 +2,38 @@ name: AI - Claude
 
 on:
   workflow_call:
+    inputs:
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: false
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: true
 
+permissions:
+  contents: read
+
 concurrency:
-  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: false
+  group: >-
+    claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
   claude:
@@ -28,6 +53,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: anthropics/claude-code-action@ef50f123a3a9be95b60040d042717517407c7256 # v1.0.110
         with:

--- a/.github/workflows/ci-ansible.yml
+++ b/.github/workflows/ci-ansible.yml
@@ -40,13 +40,34 @@ on:
         type: boolean
         default: false
         description: 'Fail on ansible-lint warnings'
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: true
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
   validation:
@@ -113,6 +134,8 @@ jobs:
     steps:
       - name: Repository Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -148,6 +171,8 @@ jobs:
     steps:
       - name: Repository Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration (GitOps)
+name: Continuous Integration - GitOps
 
 # Reusable workflow for GitOps repositories using Fleet, Helm, and Kubernetes.
 # Validates YAML syntax, Fleet configuration, GitRepo paths, Helm charts, and
@@ -68,10 +68,31 @@ on:
         type: string
         required: false
         default: 'platform applications'
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: true
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 permissions:
   contents: read
@@ -85,6 +106,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -125,6 +148,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check fleet.yaml files exist
         run: |
@@ -181,6 +206,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check GitRepo exists
         run: |
@@ -222,6 +249,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
@@ -266,6 +295,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install kubeconform
         env:
@@ -322,6 +353,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check required documentation
         run: |

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -79,6 +79,24 @@ on:
         required: false
         default: ''
         description: 'Prefix for artifact names to avoid conflicts'
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: true
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
     outputs:
       coverage:
         description: 'Test coverage percentage'
@@ -94,8 +112,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
   setup:
@@ -110,6 +131,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Determine what should run
@@ -141,6 +163,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -267,6 +291,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -392,6 +418,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         if: matrix.scanner == 'gosec' || matrix.scanner == 'govulncheck'
@@ -466,6 +494,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
@@ -488,6 +518,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Dependency Review
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -89,6 +89,24 @@ on:
         required: false
         default: ''
         description: 'Prefix for artifact names to avoid conflicts'
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: true
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
     outputs:
       coverage:
         description: 'Test coverage percentage'
@@ -101,8 +119,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
   setup:
@@ -116,6 +137,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Determine what should run
@@ -136,6 +158,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -390,6 +414,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         if: matrix.scanner == 'dependency-audit'
@@ -501,6 +527,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Dependency Review
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -17,13 +17,34 @@ on:
         type: boolean
         default: false
         description: 'Upload SARIF results to GitHub Security tab (requires public repo or GitHub Advanced Security)'
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: true
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 env:
   TF_IN_AUTOMATION: 'true'
@@ -87,6 +108,8 @@ jobs:
     steps:
       - name: Repository Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup TFLint
         uses: terraform-linters/setup-tflint@b480b8fcdaa6f2c577f8e4fa799e89e756bb7c93 # v6.2.2
@@ -111,6 +134,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run Trivy Scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0

--- a/.github/workflows/deploy-cloudflare-workers.yml
+++ b/.github/workflows/deploy-cloudflare-workers.yml
@@ -32,6 +32,24 @@ on:
         type: boolean
         default: true
         description: 'Run package.json scripts during setup'
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: false
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
     secrets:
       BW_ACCESS_TOKEN:
         required: true
@@ -41,8 +59,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
   deploy:
@@ -57,6 +78,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           submodules: recursive
 
       - name: Apply patches

--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -85,6 +85,23 @@ on:
           Useful for generating dynamic credentials (e.g., Tailscale API key from OAuth).
           Script has access to all env vars from bw-secrets and env-mapping.
           Export vars as: echo "VAR_NAME=value" >> $GITHUB_ENV
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: false
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default `false` matches deploy semantics. Set `true` for drift /
+          scan use-cases where the latest invocation supersedes the previous.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group, e.g. "drift",
+          to separate concurrency from the deploy path while sharing the same
+          project-name + environment scope. Empty default preserves the
+          original group name for backward compatibility.
     outputs:
       plan_outcome:
         description: 'Plan result: no-changes, has-changes, or error'
@@ -99,6 +116,9 @@ on:
       BW_ACCESS_TOKEN:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy Infrastructure
@@ -107,8 +127,11 @@ jobs:
     environment:
       name: ${{ inputs.environment }}
     concurrency:
-      group: ${{ inputs.project-name }}-terraform-${{ inputs.environment }}
-      cancel-in-progress: false
+      group: >-
+        ${{ inputs.project-name }}-terraform-${{ inputs.environment }}${{
+          inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+        }}
+      cancel-in-progress: ${{ inputs.cancel-in-progress }}
     env:
       TF_IN_AUTOMATION: 'true'
       TF_INPUT: 'false'

--- a/.github/workflows/e2e-dde.yml
+++ b/.github/workflows/e2e-dde.yml
@@ -1,5 +1,5 @@
 ---
-name: E2E Tests (dde)
+name: End-to-End - dde
 
 on:
   workflow_call:
@@ -64,13 +64,34 @@ on:
         required: false
         default: 30
         description: 'Artifact retention days'
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: true
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
   e2e-dde:
@@ -85,6 +106,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Bring dde project up
         id: dde

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -1,5 +1,5 @@
 ---
-name: E2E Tests (Docker Compose)
+name: End-to-End - Docker Compose
 
 on:
   workflow_call:
@@ -54,14 +54,35 @@ on:
         required: false
         default: 30
         description: 'Artifact retention days'
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: true
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
 
 permissions:
   contents: read
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
   e2e-docker:
@@ -72,6 +93,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # Docker Compose Setup
       - name: Start E2E stack

--- a/.github/workflows/ops-drift-issue.yml
+++ b/.github/workflows/ops-drift-issue.yml
@@ -1,0 +1,121 @@
+---
+name: Ops - Drift Issue
+
+on:
+  workflow_call:
+    inputs:
+      project-name:
+        type: string
+        required: true
+        description: 'Project identifier used in issue title and body'
+      environment:
+        type: string
+        required: true
+        description: 'Environment in which drift was detected'
+      workflow-run-url:
+        type: string
+        required: true
+        description: 'URL to the triggering workflow run for issue cross-reference'
+      label:
+        type: string
+        required: false
+        default: 'terraform-drift'
+        description: 'Issue label used to find and group drift issues'
+      title-template:
+        type: string
+        required: false
+        default: 'Terraform Drift Detected: {project} ({environment})'
+        description: |
+          Issue title template with placeholders {project} and {environment}.
+          The substituted title MUST be stable across runs so the same drift
+          finds the same issue and updates rather than duplicates.
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: false
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  # Same project + environment must serialise so two simultaneous drift jobs
+  # cannot race on `gh issue list` and create duplicate issues.
+  group: >-
+    ${{ github.workflow }}-${{ inputs.project-name }}-${{ inputs.environment }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
+
+jobs:
+  upsert-drift-issue:
+    name: Create or Update Drift Issue
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Upsert drift issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PROJECT_NAME: ${{ inputs.project-name }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          WORKFLOW_RUN_URL: ${{ inputs.workflow-run-url }}
+          LABEL: ${{ inputs.label }}
+          TITLE_TEMPLATE: ${{ inputs.title-template }}
+        run: |
+          set -euo pipefail
+
+          TITLE="${TITLE_TEMPLATE//\{project\}/${PROJECT_NAME}}"
+          TITLE="${TITLE//\{environment\}/${ENVIRONMENT}}"
+          TIMESTAMP="$(date -u '+%Y-%m-%d %H:%M UTC')"
+
+          BODY=$(cat <<BODY_EOF
+          ## Terraform Drift Detected
+
+          Drift was detected in the **${PROJECT_NAME}** Terraform configuration for environment **${ENVIRONMENT}**.
+
+          **Workflow Run:** ${WORKFLOW_RUN_URL}
+          **Triggered:** ${TIMESTAMP}
+
+          ### Next Steps
+          1. Review the plan output in the workflow run linked above
+          2. Determine if the drift is expected or unexpected
+          3. Apply the plan or adjust the Terraform configuration accordingly
+          BODY_EOF
+          )
+
+          EXISTING=$(gh issue list \
+            --label "${LABEL}" \
+            --state open \
+            --json number,title \
+            --jq ".[] | select(.title == \"${TITLE}\") | .number" \
+            | head -1)
+
+          if [ -n "${EXISTING}" ]; then
+            gh issue comment "${EXISTING}" --body "${BODY}"
+            echo "Updated existing drift issue #${EXISTING}"
+          else
+            gh issue create \
+              --title "${TITLE}" \
+              --body "${BODY}" \
+              --label "${LABEL}"
+            echo "Created new drift issue"
+          fi

--- a/.github/workflows/ops-terraform-orchestration.yml
+++ b/.github/workflows/ops-terraform-orchestration.yml
@@ -23,6 +23,24 @@ on:
         required: false
         default: '^configs/.*\.(alloy|json|yml|yaml)$'
         description: 'Regex pattern for configuration file detection'
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: false
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
     outputs:
       environment:
         description: 'Target deployment environment'
@@ -50,8 +68,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
   orchestration:

--- a/.github/workflows/ops-terraform-report.yml
+++ b/.github/workflows/ops-terraform-report.yml
@@ -1,0 +1,263 @@
+---
+name: Ops - Terraform Report
+
+on:
+  workflow_call:
+    inputs:
+      project-name:
+        type: string
+        required: true
+        description: 'Project identifier used in report headers and artifact names'
+      environment:
+        type: string
+        required: true
+        description: 'Target deployment environment (e.g. nuvulus)'
+      deployment-id:
+        type: string
+        required: true
+        description: 'Unique deployment identifier produced by ops-terraform-orchestration'
+      mode:
+        type: string
+        required: false
+        default: 'deploy'
+        description: 'Pipeline mode: deploy (plan + apply) or drift (plan only)'
+      orchestration-status:
+        type: string
+        required: true
+        description: 'Result of the orchestration job: success, failure, skipped, cancelled'
+      validation-status:
+        type: string
+        required: true
+        description: 'Result of the validation job: success, failure, skipped, cancelled'
+      deploy-status:
+        type: string
+        required: true
+        description: 'Result of the deploy job: success, failure, skipped, cancelled'
+      plan-outcome:
+        type: string
+        required: false
+        default: ''
+        description: 'plan_outcome from deploy-terraform: no-changes, has-changes, or error'
+      apply-outcome:
+        type: string
+        required: false
+        default: ''
+        description: 'apply_outcome from deploy-terraform: success, failed, or skipped'
+      drift-detected:
+        type: string
+        required: false
+        default: ''
+        description: 'drift_detected from deploy-terraform (drift mode only): true, false, or error'
+      terraform-changed:
+        type: string
+        required: false
+        default: ''
+        description: 'terraform_changed from ops-terraform-orchestration: true or false'
+      notification-environment:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Environment name that triggers a notification log line. Empty (default)
+          disables notification. Set to e.g. "nuvulus" to log on success/failure
+          for that environment only.
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: false
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
+    outputs:
+      overall-status:
+        description: 'Computed overall status: success, plan-only, validation-failed, or failed'
+        value: ${{ jobs.report.outputs.overall-status }}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{ inputs.project-name }}-${{ inputs.environment }}-${{ inputs.deployment-id }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
+
+jobs:
+  report:
+    name: Render Pipeline Report
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      overall-status: ${{ steps.analysis.outputs.overall_status }}
+
+    steps:
+      - name: Analyze pipeline status
+        id: analysis
+        env:
+          ORCHESTRATION_STATUS: ${{ inputs.orchestration-status }}
+          VALIDATION_STATUS: ${{ inputs.validation-status }}
+          DEPLOY_STATUS: ${{ inputs.deploy-status }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$DEPLOY_STATUS" == "success" && "$VALIDATION_STATUS" == "success" ]]; then
+            OVERALL_STATUS="success"
+          elif [[ "$DEPLOY_STATUS" == "success" && "$VALIDATION_STATUS" == "skipped" ]]; then
+            OVERALL_STATUS="plan-only"
+          elif [[ "$VALIDATION_STATUS" == "failure" ]]; then
+            OVERALL_STATUS="validation-failed"
+          else
+            OVERALL_STATUS="failed"
+          fi
+
+          echo "overall_status=$OVERALL_STATUS" >> "$GITHUB_OUTPUT"
+          echo "Computed overall_status: $OVERALL_STATUS"
+
+      - name: Generate pipeline report
+        env:
+          PROJECT_NAME: ${{ inputs.project-name }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          DEPLOYMENT_ID: ${{ inputs.deployment-id }}
+          MODE: ${{ inputs.mode }}
+          OVERALL_STATUS: ${{ steps.analysis.outputs.overall_status }}
+          ORCHESTRATION_STATUS: ${{ inputs.orchestration-status }}
+          VALIDATION_STATUS: ${{ inputs.validation-status }}
+          DEPLOY_STATUS: ${{ inputs.deploy-status }}
+          PLAN_OUTCOME: ${{ inputs.plan-outcome }}
+          APPLY_OUTCOME: ${{ inputs.apply-outcome }}
+          DRIFT_DETECTED: ${{ inputs.drift-detected }}
+          TERRAFORM_CHANGED: ${{ inputs.terraform-changed }}
+        run: |
+          set -euo pipefail
+          TIMESTAMP="$(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+
+          {
+            echo "# ${PROJECT_NAME} Terraform Pipeline Report"
+            echo
+            echo "**Status:** ${OVERALL_STATUS}"
+            echo "**Mode:** ${MODE}"
+            echo "**Environment:** ${ENVIRONMENT}"
+            echo "**Deployment ID:** ${DEPLOYMENT_ID}"
+            echo "**Timestamp:** ${TIMESTAMP}"
+            echo
+            echo "## Pipeline Status"
+            echo
+            echo "| Component | Status | Details |"
+            echo "|-----------|--------|---------|"
+            echo "| Orchestration | ${ORCHESTRATION_STATUS} | Environment setup |"
+            echo "| Validation | ${VALIDATION_STATUS} | Configuration validation |"
+            echo "| Deployment | ${DEPLOY_STATUS} | Terraform provisioning |"
+            echo
+            echo "## Deployment Details"
+            echo
+            echo "| Outcome | Result |"
+            echo "|---------|--------|"
+            echo "| Plan | ${PLAN_OUTCOME:-N/A} |"
+            echo "| Apply | ${APPLY_OUTCOME:-N/A} |"
+            if [[ "${MODE}" == "drift" ]]; then
+              echo "| Drift Detected | ${DRIFT_DETECTED:-N/A} |"
+            fi
+            echo
+            echo "## Change Analysis"
+            echo
+            echo "| Type | Changed |"
+            echo "|------|---------|"
+            echo "| Terraform | ${TERRAFORM_CHANGED:-N/A} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Consolidate deployment artifacts
+        if: always()
+        env:
+          PROJECT_NAME: ${{ inputs.project-name }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          DEPLOYMENT_ID: ${{ inputs.deployment-id }}
+          OVERALL_STATUS: ${{ steps.analysis.outputs.overall_status }}
+          MODE: ${{ inputs.mode }}
+          ORCHESTRATION_STATUS: ${{ inputs.orchestration-status }}
+          VALIDATION_STATUS: ${{ inputs.validation-status }}
+          DEPLOY_STATUS: ${{ inputs.deploy-status }}
+          PLAN_OUTCOME: ${{ inputs.plan-outcome }}
+          APPLY_OUTCOME: ${{ inputs.apply-outcome }}
+          DRIFT_DETECTED: ${{ inputs.drift-detected }}
+          GIT_REF: ${{ github.ref }}
+          GIT_SHA: ${{ github.sha }}
+          ACTOR: ${{ github.actor }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p deployment-artifacts
+          ISO_TIMESTAMP="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+          cat > deployment-artifacts/deployment-metadata.json <<JSON
+          {
+            "project_name": "${PROJECT_NAME}",
+            "deployment_id": "${DEPLOYMENT_ID}",
+            "environment": "${ENVIRONMENT}",
+            "mode": "${MODE}",
+            "overall_status": "${OVERALL_STATUS}",
+            "timestamp": "${ISO_TIMESTAMP}",
+            "git_ref": "${GIT_REF}",
+            "git_sha": "${GIT_SHA}",
+            "triggered_by": "${ACTOR}",
+            "workflow_run_id": "${RUN_ID}",
+            "deployment": {
+              "plan_outcome": "${PLAN_OUTCOME}",
+              "apply_outcome": "${APPLY_OUTCOME}",
+              "drift_detected": "${DRIFT_DETECTED}"
+            },
+            "pipeline_status": {
+              "orchestration": "${ORCHESTRATION_STATUS}",
+              "validation": "${VALIDATION_STATUS}",
+              "deployment": "${DEPLOY_STATUS}"
+            }
+          }
+          JSON
+
+      - name: Upload deployment metadata artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: deployment-metadata-${{ inputs.deployment-id }}
+          path: deployment-artifacts/deployment-metadata.json
+          retention-days: 30
+
+      - name: Send deployment notification
+        if: |
+          always() &&
+          inputs.notification-environment != '' &&
+          inputs.environment == inputs.notification-environment &&
+          (steps.analysis.outputs.overall_status == 'failed' ||
+           steps.analysis.outputs.overall_status == 'success')
+        env:
+          PROJECT_NAME: ${{ inputs.project-name }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          DEPLOYMENT_ID: ${{ inputs.deployment-id }}
+          OVERALL_STATUS: ${{ steps.analysis.outputs.overall_status }}
+          PLAN_OUTCOME: ${{ inputs.plan-outcome }}
+          APPLY_OUTCOME: ${{ inputs.apply-outcome }}
+        run: |
+          set -euo pipefail
+          case "${OVERALL_STATUS}" in
+            success)
+              echo "${PROJECT_NAME} terraform pipeline successful"
+              echo "Environment: ${ENVIRONMENT}"
+              echo "Plan: ${PLAN_OUTCOME}"
+              echo "Apply: ${APPLY_OUTCOME}"
+              ;;
+            failed)
+              echo "${PROJECT_NAME} terraform pipeline failed"
+              echo "Deployment ID: ${DEPLOYMENT_ID}"
+              ;;
+          esac

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -73,6 +73,24 @@ on:
         required: false
         default: ''
         description: 'Path to container structure test config'
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: false
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
     outputs:
       image-digest:
         description: 'Image digest'
@@ -91,8 +109,11 @@ permissions:
   packages: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
   docker-build:
@@ -106,6 +127,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Set up QEMU

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -34,14 +34,35 @@ on:
         required: false
         default: ''
         description: 'Additional environment variables (multiline, KEY=VALUE format)'
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: false
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
 
 permissions:
   contents: write
   packages: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
   goreleaser:
@@ -52,6 +73,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Go

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -36,6 +36,24 @@ on:
         required: false
         default: ''
         description: 'Docker image digest (optional, e.g. sha256:abc123...)'
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: false
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
     secrets:
       registry-token:
         required: true
@@ -47,8 +65,11 @@ permissions:
   packages: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
   helm-release:
@@ -58,6 +79,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -52,6 +52,24 @@ on:
         type: boolean
         default: false
         description: 'Perform dry-run (no actual publish)'
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: false
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
     outputs:
       published-version:
         description: 'Published package version'
@@ -68,8 +86,11 @@ permissions:
   contents: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
   pre-release-checks:
@@ -84,6 +105,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -220,6 +242,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -389,6 +413,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # The composite action lives in this repo, but `uses: ./` in a reusable
       # workflow resolves against the caller's checkout — not against this
@@ -425,6 +451,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Generate changelog

--- a/.github/workflows/security-code.yml
+++ b/.github/workflows/security-code.yml
@@ -40,6 +40,24 @@ on:
         type: boolean
         default: true
         description: 'Upload SARIF results to GitHub Security tab (requires public repo or GHAS)'
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: true
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
 
 permissions:
   actions: read
@@ -47,8 +65,11 @@ permissions:
   security-events: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
   analyze:
@@ -63,6 +84,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Prepare CodeQL config
         id: codeql-config

--- a/.github/workflows/security-config.yml
+++ b/.github/workflows/security-config.yml
@@ -44,14 +44,35 @@ on:
         type: boolean
         default: true
         description: 'Upload SARIF results to GitHub Security'
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: true
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
 
 permissions:
   contents: read
   security-events: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
   trivy-config-scan:
@@ -61,6 +82,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run Trivy config scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -119,6 +142,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run Trivy (Terraform Security)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -203,6 +228,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Find Kubernetes manifests
         id: find-manifests
@@ -289,6 +316,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/security-containers.yml
+++ b/.github/workflows/security-containers.yml
@@ -28,14 +28,35 @@ on:
         type: number
         default: 15
         description: 'Scan timeout in minutes'
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: true
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
 
 permissions:
   contents: read
   security-events: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
   trivy-image:
@@ -46,6 +67,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -99,6 +122,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run Grype vulnerability scanner
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0

--- a/.github/workflows/security-deps.yml
+++ b/.github/workflows/security-deps.yml
@@ -34,6 +34,24 @@ on:
         type: boolean
         default: false
         description: 'Fail workflow on license violations'
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: true
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
 
 permissions:
   contents: read
@@ -41,8 +59,11 @@ permissions:
   security-events: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
   dependency-review:
@@ -53,6 +74,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Dependency Review
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
@@ -71,6 +94,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -137,6 +162,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -221,6 +248,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/security-sbom.yml
+++ b/.github/workflows/security-sbom.yml
@@ -28,13 +28,34 @@ on:
         type: string
         default: '.nvmrc'
         description: 'For artifact-type=npm-package: Node.js version file'
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: true
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
 
 permissions:
   contents: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
   generate-sbom:
@@ -46,6 +67,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # Container Image SBOM
       - name: Generate SBOM for container image

--- a/.github/workflows/security-secrets.yml
+++ b/.github/workflows/security-secrets.yml
@@ -24,6 +24,24 @@ on:
         type: string
         default: '*.tf,*.yml,*.yaml,*.json,*.env.example'
         description: 'File patterns to scan (comma-separated)'
+      cancel-in-progress:
+        type: boolean
+        required: false
+        default: true
+        description: |
+          Whether to cancel in-progress runs in the same concurrency group.
+          Default matches this workflow's intended semantics; override only
+          for matrix or fan-out invocations that need different semantics
+          than the single-call default.
+      concurrency-suffix:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional suffix appended to the concurrency group as `-<suffix>`.
+          Empty default preserves the original group name; set to separate
+          parallel invocations of this reusable from the same caller (e.g.
+          per-matrix-leg or per-mode).
 
 permissions:
   contents: read
@@ -31,8 +49,11 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
   gitleaks:
@@ -44,6 +65,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Run Gitleaks

--- a/.github/workflows/test-actions-dde.yml
+++ b/.github/workflows/test-actions-dde.yml
@@ -2,7 +2,7 @@
 # (.github/actions/setup-dde, .github/actions/project).
 # Not a reusable workflow — runs only when the dde action sources change.
 
-name: Test dde actions
+name: Test - dde Actions
 
 on:
   push:
@@ -34,6 +34,8 @@ jobs:
           - macos-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install dde via setup-dde
         id: dde
@@ -72,6 +74,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run project against non-existent dir (expected to fail)
         id: project
@@ -102,6 +106,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Create empty project directory
         run: mkdir -p empty-project
@@ -135,6 +141,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run project with empty command (expected to fail)
         id: project

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 **Repository Type**: Centralized Workflow Repository
 **Purpose**: Provide reusable GitHub Actions workflows for all sbaerlocher projects
 **Visibility**: Public
-**Last Updated**: 2026-04-30
+**Last Updated**: 2026-05-03
 
 ---
 
@@ -24,14 +24,37 @@ directly impacting the CI/CD pipelines of multiple projects.
 
 **Current Statistics**:
 
-- **Total Workflows**: 22 reusable workflows (see [.github/workflows/](./.github/workflows/))
-- **Categories**: CI (5), Security (6), Deploy (2), Release (4), Operations (1), AI (2), E2E (2)
+- **Total Workflows**: 24 reusable workflows (see [.github/workflows/](./.github/workflows/))
+- **Categories**: CI (5), Security (6), Deploy (2), Release (4), Operations (3), AI (2), E2E (2)
 - **Consumers**: applications, infrastructure, authentication, observability, functions,
   sbaerlocher.ch, tsmetrics, and more
 
 ---
 
 ## Important Standards & Conventions
+
+### Workflow Layering
+
+Consumer repositories follow a strict three-layer split:
+
+1. **Repo workflow** contains only `on:`, `permissions:`, and `uses:` —
+   never a multi-line `run:` step. It is a thin trigger hull.
+2. **Reusable workflow** in `sbaerlocher/.github` owns the pipeline logic
+   (job sequences, tool calls, reporting, notification) and exposes it via
+   `inputs:` / `outputs:` / `secrets:`.
+3. **Composite action** in `.github/actions/` owns single tool-bootstrap
+   steps when the same shell logic appears in more than one reusable.
+
+**Concurrency is owned by the reusable**, never by both the repo workflow
+and the reusable for the same logical group. If a reusable declares its
+own `concurrency:` block, the calling repo workflow must not set one for
+the same scope. Where a reusable supports it (e.g. `deploy-terraform.yml`
+via `cancel-in-progress` + `concurrency-suffix` inputs), the caller picks
+the cancellation policy and group suffix per call.
+
+This rule eliminates the "two limiters in series" pattern that previously
+caused queue pile-ups and surprise cancellations when consumer repos
+wrapped a reusable with their own `concurrency:` block.
 
 ### Workflow Naming Convention
 
@@ -97,6 +120,69 @@ uses: sbaerlocher/.github/.github/workflows/ci-js.yml@2026-04-25
   cadence is documented in `CHANGELOG.md`.
 - Renovate updates date tags in consumer repos automatically via the
   custom manager defined in `renovate-base.json`.
+
+### Concurrency Convention
+
+Every reusable workflow exposes the same two inputs so consumers can adjust
+concurrency without forking the workflow:
+
+```yaml
+inputs:
+  cancel-in-progress:
+    type: boolean
+    required: false
+    default: <per-workflow-default>  # CI/security/e2e: true; deploy/release/ops: false
+    description: Cancel in-progress runs in the same group.
+  concurrency-suffix:
+    type: string
+    required: false
+    default: ''
+    description: Suffix appended as `-<suffix>` to the concurrency group.
+```
+
+The concurrency block always renders as:
+
+```yaml
+concurrency:
+  group: >-
+    <base-group>${{
+      inputs.concurrency-suffix != '' && format('-{0}', inputs.concurrency-suffix) || ''
+    }}
+  cancel-in-progress: ${{ inputs.cancel-in-progress }}
+```
+
+**Defaults — and when to override:**
+
+- **CI / Security / E2E**: default `cancel-in-progress: true`. The latest push
+  supersedes the previous run. Override to `false` for matrix legs that must
+  all complete (e.g. compliance reports).
+- **Deploy / Release / Ops**: default `cancel-in-progress: false`. A
+  half-applied deploy or half-uploaded artifact is worse than waiting.
+  Override to `true` for drift / scan use-cases where the latest invocation
+  should supersede the previous (this is exactly why `deploy-terraform.yml`
+  takes both inputs — drift mode wants `true`, deploy mode wants `false`).
+- **Suffix**: empty by default. Set when the same caller workflow invokes
+  the same reusable from multiple matrix legs or modes that must run
+  in parallel rather than serialise. Example: `concurrency-suffix: drift`
+  on a drift-detection job that calls `deploy-terraform.yml` alongside
+  the deploy job.
+
+**Two base-group patterns are in use:**
+
+- **Caller-isolated** — `${{ github.workflow }}-${{ github.ref }}`. Used by
+  CI, Security, Release, E2E, and most Ops/Deploy workflows. `github.workflow`
+  resolves to the *caller's* workflow name when invoked via `workflow_call`,
+  so different callers automatically get different groups.
+- **Resource-locked** — built from inputs (e.g.
+  `${{ inputs.project-name }}-terraform-${{ inputs.environment }}` in
+  `deploy-terraform.yml`, or `${{ inputs.project-name }}-${{ inputs.environment }}`
+  in `ops-drift-issue.yml`). Used when the workflow guards a shared resource
+  (Terraform state, GitHub-issue list) that must serialise across *all*
+  callers, not just the same caller.
+
+When adding a new reusable workflow, pick the base-group pattern based on
+whether it serialises a shared resource, and always expose both inputs so
+consumers have an escape hatch.
 
 ---
 
@@ -169,13 +255,22 @@ uses: sbaerlocher/.github/.github/workflows/ci-js.yml@2026-04-25
 
 **Trigger**: `push` events on tags (`v*`)
 
-### Operations - Operational Tasks (1)
+### Operations - Operational Tasks (3)
 
 **Purpose**: Scheduled maintenance and operational tasks
 
-| Workflow      | File                              | Description          | Schedule  |
-| ------------- | --------------------------------- | -------------------- | --------- |
-| Orchestration | `ops-terraform-orchestration.yml` | Multi-environment TF | On-demand |
+| Workflow         | File                              | Description                              | Schedule  |
+| ---------------- | --------------------------------- | ---------------------------------------- | --------- |
+| Orchestration    | `ops-terraform-orchestration.yml` | Multi-environment TF                     | On-demand |
+| Terraform Report | `ops-terraform-report.yml`        | Pipeline report + metadata artifact      | On-demand |
+| Drift Issue      | `ops-drift-issue.yml`             | Upsert drift issue (idempotent by title) | On-demand |
+
+`ops-terraform-report.yml` consumes outputs from
+`ops-terraform-orchestration.yml` + `deploy-terraform.yml` and renders the
+deploy/drift summary that consumer repos used to inline. `ops-drift-issue.yml`
+replaces the inline `gh issue create/comment` block in consumer drift
+workflows; it serialises by `project + environment` so two scheduled drift
+runs cannot race on `gh issue list`.
 
 ### AI - AI-Assisted Workflows (2)
 
@@ -588,5 +683,5 @@ Ensure lock files are committed:
 
 ---
 
-**Last Updated**: 2026-04-30
-**Version**: 1.3.0
+**Last Updated**: 2026-05-03
+**Version**: 1.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,134 @@ This is a rolling release - changes are deployed continuously to `main`.
 
 ---
 
+## 2026-05-03
+
+### Added
+
+- **`ops-drift-issue.yml`**: New reusable workflow that upserts a GitHub
+  issue when Terraform drift is detected. Replaces the inline
+  `create-drift-issue` job that consumer repos
+  (`authentication`, `infrastructure`, `observability`) duplicated in
+  their `drift.yml` workflows. Idempotent by title — if an open issue
+  with the substituted `title-template` (default
+  `Terraform Drift Detected: {project} ({environment})`) and the
+  configured `label` (default `terraform-drift`) exists, it adds a
+  comment instead of creating a new issue. Concurrency-grouped by
+  `project-name + environment` so two simultaneous drift jobs cannot
+  race on `gh issue list`. The label must already exist in the consumer
+  repository — the workflow does not create it.
+- **`ops-terraform-report.yml`**: New reusable workflow that renders the
+  Terraform pipeline report (Step Summary + `deployment-metadata.json`
+  artifact + optional notification step) from
+  `ops-terraform-orchestration.yml` + `deploy-terraform.yml` outputs.
+  Consolidates the inline `report` job that consumer `deploy.yml`
+  workflows duplicated. Supports both deploy and drift modes via the
+  `mode` input; drift mode includes the `drift-detected` row in the
+  deployment-details table. The notification step is opt-in via
+  `notification-environment` and currently logs to stdout — wire a real
+  webhook in the consumer if needed.
+
+### Changed
+
+- **All reusable workflows now expose `cancel-in-progress` and
+  `concurrency-suffix` inputs.** Previously only `deploy-terraform.yml`
+  carried these. Inconsistent concurrency behaviour caused real failures
+  when consumers wired the same reusable into parallel matrix legs or
+  multi-mode pipelines (drift vs deploy) — they could not separate the
+  groups without forking the workflow.
+
+  Defaults preserve current behaviour: CI / Security / E2E default to
+  `cancel-in-progress: true` (latest push wins); Deploy / Release / Ops
+  default to `false` (in-flight runs finish). The suffix defaults to
+  empty, so the group name is unchanged for every consumer that does
+  not opt in.
+
+  See AGENTS.md → "Concurrency Convention" for the full pattern, the
+  base-group rules (caller-isolated vs resource-locked), and override
+  guidance.
+
+  Touched: `ai-claude*`, `ci-*`, `deploy-cloudflare-workers`,
+  `e2e-*`, `ops-*`, `release-*`, `security-*`. `deploy-terraform.yml`
+  already had the inputs from the prior change.
+
+### Security
+
+- **All workflows: `actions/checkout` hardened with `persist-credentials: false`.**
+  Previously many checkouts inherited the v6 default `true`, which
+  persists `GITHUB_TOKEN` in `.git/config` for any subsequent step or
+  untrusted action to read. None of the reusable workflows actually
+  push via `git`, so disabling persistence is safe across the board.
+  Touched: `ai-claude*`, `ci-*`, `deploy-cloudflare-workers`,
+  `e2e-*`, `release-*`, `security-*`, `ops-terraform-orchestration`,
+  `test-actions-dde`. `deploy-terraform`, `ci-ansible`, and
+  `ci-terraform` already had it set.
+- **Top-level `permissions:` added to `deploy-terraform.yml`,
+  `ai-claude.yml`, and `ai-claude-review.yml`.** All three previously
+  inherited the caller's default permissions. Top-level is now
+  `contents: read`; existing job-level overrides (the AI workflows
+  expand to `pull-requests: write` etc.) remain in place.
+
+### Changed (cosmetic)
+
+- **Workflow `name:` fields normalized to `Category - Subject` style**
+  with hyphen separator (per AGENTS.md naming convention):
+  - `ci-gitops.yml`: `Continuous Integration (GitOps)` →
+    `Continuous Integration - GitOps`
+  - `e2e-dde.yml`: `E2E Tests (dde)` → `End-to-End - dde`
+  - `e2e-docker.yml`: `E2E Tests (Docker Compose)` →
+    `End-to-End - Docker Compose`
+  - `test-actions-dde.yml`: `Test dde actions` → `Test - dde Actions`
+  - All others were already conformant.
+
+### Fixed
+
+- **`ai-claude-review.yml` (#102)**: Hardened the review workflow.
+  Previous bugs broke follow-up runs and ran Opus with 100 turns on
+  every push.
+  - Reply endpoint was missing the PR number, returned 404 on every
+    follow-up. Now uses `repos/{repo}/pulls/{number}/comments/{id}/replies`.
+  - Mode detection now reads the prior review (not inline comments),
+    so clean PRs with no findings correctly transition to follow-up
+    mode instead of re-paying for a full first pass.
+  - Bot login is detected dynamically (`gh api .../reviews` →
+    `.../comments`) instead of hardcoded `claude[bot]`, so the
+    detection survives App-login changes.
+  - Follow-up now diffs against the last review SHA via
+    `gh api .../compare/{base}...{head}` instead of `gh pr diff` —
+    the "only flag new issues" instruction now actually has the
+    right input.
+  - Pre-step computes `mode` / `bot-login` / `last-review-sha` in shell
+    as job outputs; prompt receives concrete values instead of
+    placeholders.
+  - Cost split: first review keeps Opus with 100 turns; follow-up
+    runs on Sonnet with 40 turns.
+  - Both modes submit an explicit verdict (`--approve` or
+    `--request-changes`) so PRs don't sit in limbo when issues remain.
+  - Prompt now Reads `REVIEW.md` / `AGENTS.md` / `CLAUDE.md` first
+    so repo-specific rules win over generic best practices.
+  - Fork PRs are skipped explicitly (no secrets, no write token →
+    silent zero-comment runs were misleading).
+
+### Documentation
+
+- **AGENTS.md → "Workflow Layering"**: Codifies the three-layer split
+  (repo workflow / reusable / composite action) and the rule that
+  *concurrency is owned by the reusable* — never duplicated in the
+  caller for the same scope. Replaces the implicit "two limiters in
+  series" pattern that produced queue pile-ups in consumer repos.
+- **AGENTS.md → "Concurrency Convention"**: Documents the uniform
+  `cancel-in-progress` + `concurrency-suffix` inputs, the per-category
+  defaults, the two base-group patterns (caller-isolated vs
+  resource-locked), and override guidance.
+
+### Dependencies
+
+- `anthropics/claude-code-action`: → v1.0.107 (#92), → v1.0.110 (#103)
+- `securego/gosec`: → v2.26.1 (#101)
+- GitHub Actions group bumps: #99, #100 (Renovate batched)
+
+---
+
 ## 2026-04-30
 
 ### Removed
@@ -188,7 +316,7 @@ This is a rolling release - changes are deployed continuously to `main`.
     - Testing tools group renamed to "Jest" (vitest moved out)
   - **Branch-name collapsing** (`separateMultipleMajor: false` per group):
     Collapse the `major-N-` segment that Renovate prepends to `groupSlug` for
-    grouped major updates, so co-dependent packages with _different_ major
+    grouped major updates, so co-dependent packages with *different* major
     version numbers (e.g. Vue 4 + plugin-vue 6) share one branch/PR despite
     `separateMultipleMajor: true` in base
     - Verified against Renovate source

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Centralized CI/CD building blocks for all repositories under
 each workflow by date tag and let Renovate keep them current.
 
 - **Model:** rolling release with date tags (`YYYY-MM-DD`)
-- **Total workflows:** 22
-- **Last updated:** 2026-04-30
+- **Total workflows:** 24
+- **Last updated:** 2026-05-03
 
 See [AGENTS.md](./AGENTS.md) for AI-agent context.
 
@@ -111,10 +111,14 @@ All files live in [.github/workflows/](./.github/workflows/).
 | [`release-helm.yml`](./.github/workflows/release-helm.yml)        | Helm OCI chart publish               |
 | [`release-npm.yml`](./.github/workflows/release-npm.yml)          | NPM publish with provenance + SBOM   |
 
-### Operations (1)
+### Operations (3)
 
 - [`ops-terraform-orchestration.yml`](./.github/workflows/ops-terraform-orchestration.yml)
   — Multi-environment Terraform deployment driver
+- [`ops-terraform-report.yml`](./.github/workflows/ops-terraform-report.yml)
+  — Render Terraform pipeline report (Step Summary, metadata artifact, notification)
+- [`ops-drift-issue.yml`](./.github/workflows/ops-drift-issue.yml)
+  — Upsert a GitHub issue when Terraform drift is detected
 
 ### AI — Private Repos Only (2)
 


### PR DESCRIPTION
## Summary

Cuts release **2026-05-03** for `sbaerlocher/.github`. Three groups of changes that need to ship together because they touch the same workflows:

1. **Uniform concurrency API** across all 23 reusable workflows. Every workflow now exposes `cancel-in-progress` (boolean) and `concurrency-suffix` (string) inputs. Defaults preserve current behaviour:
   - CI / Security / E2E: `cancel-in-progress: true` (latest push wins)
   - Deploy / Release / Ops: `cancel-in-progress: false` (in-flight runs finish)
   - `concurrency-suffix: ''` everywhere

   Previously only `deploy-terraform.yml` carried these inputs, which forced consumers to wrap reusables in their own `concurrency:` block — that pattern caused queue pile-ups and surprise cancellations when matrix legs or multi-mode pipelines (drift vs deploy) needed different semantics. AGENTS.md adds a **"Workflow Layering"** section (concurrency owned by the reusable, never duplicated in caller) and a **"Concurrency Convention"** section documenting the inputs, defaults, base-group patterns (caller-isolated vs resource-locked), and override guidance.

2. **Security hardening:**
   - `persist-credentials: false` on every `actions/checkout` call (~50 sites). Previously most inherited the v6 default `true`, which persists `GITHUB_TOKEN` in `.git/config` for any subsequent step / untrusted action to read. None of the reusables push via `git`, so disabling is safe.
   - Top-level `permissions: contents: read` added to `deploy-terraform.yml`, `ai-claude.yml`, `ai-claude-review.yml` (the three workflows that previously inherited the caller's default).

3. **Two new ops reusables** consolidating inline jobs duplicated across `authentication`, `infrastructure`, `observability`:
   - **`ops-drift-issue.yml`** — idempotent drift-issue upsert (concurrency-grouped by project+env to prevent `gh issue list` races)
   - **`ops-terraform-report.yml`** — pipeline report (Step Summary + metadata artifact + opt-in notification) for both deploy and drift modes

Cosmetic: workflow `name:` fields normalised to `Category - Subject` hyphen style on `ci-gitops`, `e2e-dde`, `e2e-docker`, `test-actions-dde`.

Defaults preserve every consumer's current behaviour. Consumer migration to the new ops reusables ships in separate PRs once `2026-05-03` is tagged from `main`.

## Expected CI failure: `AI - Code Review`

This PR modifies `ai-claude-review.yml` itself, so the [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) self-validation step intentionally blocks the run with:

> Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch.

That security check is **expected and correct** for any PR that touches the review workflow. After merge to `main`, future PRs will see the workflow as matching and the check goes green again. Do not block this PR on it.

The first push also failed there, but for a different reason — `cancel-in-progress:` evaluated to empty string under the `pull_request:` trigger because `inputs.*` is undefined when not invoked via `workflow_call:`. Fixed in commit [`4d7bb85`](https://github.com/sbaerlocher/.github/commit/4d7bb85) by guarding the expressions for the dual-trigger case (the only such workflow in the repo).

## Test plan

- [x] All 25 workflow files YAML-valid (verified locally with `yaml.safe_load`)
- [x] `Test dde actions` self-test (6 jobs) green on the fix commit
- [x] `AI - Code Review` failure is the expected self-modification block — see above
- [ ] After merge: cut tag `2026-05-03` and verify Renovate picks it up in at least one consumer (`authentication`, `infrastructure`, or `observability`)
- [ ] After consumer migration PRs: confirm a drift run posts a single issue (idempotent), and a deploy run renders the same Step Summary as before