### PR TITLE
fix(ci-gitops): tighten kubeconform path filter to path segments

### DIFF
--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -330,7 +330,8 @@ jobs:
 
           mapfile -t manifests < <(
             find ${FLEET_PATHS} \( -name '*.yaml' -o -name '*.yml' \) \
-              | grep -E '(templates|manifests)' \
+              ! -name 'fleet.yaml' \
+              | grep -E '/(templates|manifests)/' \
               || true
           )
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ This is a rolling release - changes are deployed continuously to `main`.
 
 ---
 
+## 2026-05-07
+
+### Fixed
+
+- **`ci-gitops.yml`**: The `Validate Kubernetes manifests` step's path
+  filter (`grep -E '(templates|manifests)'`) matched the substring
+  anywhere in the path, so a Fleet bundle living under e.g.
+  `applications/<svc>/email-templates/fleet.yaml` was handed to
+  kubeconform and failed with `error while parsing: missing 'kind' key`
+  — `fleet.yaml` is a Fleet bundle config, not a Kubernetes manifest.
+  The pre-`2026-05-03` step trailed `|| true` and silently swallowed
+  this; the strict default introduced in `2026-05-03` exposed it as
+  a real failure for any consumer with a `*-templates` or `*-manifests`
+  directory name.
+
+  Two changes:
+  - Tightened the regex to `'/(templates|manifests)/'` so only
+    `templates` / `manifests` as standalone path segments match (the
+    intended helm-chart-templates / raw-k8s-manifests directories).
+  - Added `! -name 'fleet.yaml'` to the `find` so Fleet bundle configs
+    are excluded defensively even if a future path layout puts one
+    inside a `templates/` directory.
+
+  Consumer-visible: a bundle path containing `*-templates` or
+  `*-manifests` in a directory name no longer produces a kubeconform
+  failure, and `fleet.yaml` files are never evaluated as K8s manifests.
+
+---
+
 ## 2026-05-03
 
 ### Added


### PR DESCRIPTION
## Summary

- Tightens the `Validate Kubernetes manifests` step's path filter from
  `(templates|manifests)` (substring match anywhere in path) to
  `/(templates|manifests)/` (path-segment match), so directory names like
  `email-templates` no longer trigger kubeconform.
- Adds `! -name 'fleet.yaml'` to the `find` so Fleet bundle configs are
  excluded defensively even if a future layout puts one inside a
  `templates/` directory.

## Why

The pre-2026-05-03 step trailed `|| true` and silently swallowed bogus
matches. The strict default introduced in 2026-05-03 promoted them to real
failures: `sbaerlocher/applications` PR #137 (the bot bump to 2026-05-03)
fails because `applications/authentik/email-templates/fleet.yaml` is fed
to kubeconform and reports `error while parsing: missing 'kind' key` —
that file is a Fleet bundle config, not a K8s manifest.

## Test plan

- [ ] CI green on this PR (smoke for the workflow itself)
- [ ] After merge + new date-tag, retest `sbaerlocher/applications` PR #137
      with the new pin: kubeconform should skip
      `email-templates/fleet.yaml`, real K8s manifests under
      `<svc>/templates/` and `<svc>/manifests/` still validate.