### PR TITLE
feat(dde): add E2E plugin lifecycle hooks and Linux polkit fix

### DIFF
--- a/.github/actions/project/action.yml
+++ b/.github/actions/project/action.yml
@@ -81,7 +81,7 @@ runs:
     # re-provision the host on every lifecycle step.
     - name: Setup dde
       id: setup
-      uses: sbaerlocher/.github/.github/actions/setup-dde@2026-05-16
+      uses: sbaerlocher/.github/.github/actions/setup-dde@2026-05-07
       with:
         version: ${{ inputs.version }}
         install-mkcert: ${{ inputs.install-mkcert }}

--- a/.github/actions/project/action.yml
+++ b/.github/actions/project/action.yml
@@ -81,7 +81,7 @@ runs:
     # re-provision the host on every lifecycle step.
     - name: Setup dde
       id: setup
-      uses: sbaerlocher/.github/.github/actions/setup-dde@2026-05-07
+      uses: sbaerlocher/.github/.github/actions/setup-dde@2026-05-16
       with:
         version: ${{ inputs.version }}
         install-mkcert: ${{ inputs.install-mkcert }}

--- a/.github/actions/setup-dde/action.yml
+++ b/.github/actions/setup-dde/action.yml
@@ -157,6 +157,36 @@ runs:
         esac
         mkcert -version
 
+    # `dde system:install` writes a systemd-resolved drop-in to
+    # /etc/systemd/resolved.conf.d/ and restarts systemd-resolved. On
+    # GitHub-hosted Linux runners dde does not escalate for either step:
+    # the mkdir hits `Permission denied`, and once that's fixed the
+    # restart hits `Interactive authentication required.` from polkit.
+    # Pre-permission the systemd config directory and install a polkit
+    # rule that grants the runner user manage-units on
+    # systemd-resolved.service so the unprivileged restart succeeds.
+    #
+    # Linux-only (resolved.conf.d / polkit are Linux constructs) and only
+    # when system-install is requested. Drop this step once dde escalates
+    # for these paths the same way it does for dnsmasq.
+    - name: Pre-authorize dde DNS resolver setup (Linux)
+      if: runner.os == 'Linux' && inputs.system-install == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo chmod o+w /etc/systemd
+        sudo install -d -m 0755 /etc/polkit-1/rules.d
+        sudo tee /etc/polkit-1/rules.d/49-dde-systemd-resolved.rules \
+          >/dev/null <<EOF
+        polkit.addRule(function(action, subject) {
+          if (action.id === "org.freedesktop.systemd1.manage-units" &&
+              action.lookup("unit") === "systemd-resolved.service" &&
+              subject.user === "$USER") {
+            return polkit.Result.YES;
+          }
+        });
+        EOF
+
     - name: Run dde system:install
       if: inputs.system-install == 'true'
       shell: bash

--- a/.github/actions/setup-dde/action.yml
+++ b/.github/actions/setup-dde/action.yml
@@ -162,9 +162,10 @@ runs:
     # GitHub-hosted Linux runners dde does not escalate for either step:
     # the mkdir hits `Permission denied`, and once that's fixed the
     # restart hits `Interactive authentication required.` from polkit.
-    # Pre-permission the systemd config directory and install a polkit
-    # rule that grants the runner user manage-units on
-    # systemd-resolved.service so the unprivileged restart succeeds.
+    # Pre-create the drop-in directory world-writable so dde's mkdir is
+    # a no-op, and install a polkit rule that grants the runner user
+    # manage-units on systemd-resolved.service so the unprivileged
+    # restart succeeds.
     #
     # Linux-only (resolved.conf.d / polkit are Linux constructs) and only
     # when system-install is requested. Drop this step once dde escalates
@@ -174,14 +175,24 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        sudo chmod o+w /etc/systemd
+        # Narrowly scoped: only the drop-in directory is opened up, not
+        # /etc/systemd itself. dde writes into this dir; the dir's mode
+        # is 0777 but ephemeral hosted runners are single-user, so this
+        # is bounded blast radius and avoids `chmod o+w /etc/systemd`.
+        sudo install -d -m 0777 /etc/systemd/resolved.conf.d
         sudo install -d -m 0755 /etc/polkit-1/rules.d
+        # `$(id -un)` is preferred over `$USER` here: `set -u` would
+        # abort on an unset `$USER`, and an empty `$USER` would silently
+        # bake `subject.user === ""` into the rule (it would never
+        # match, and `dde system:install` would still fail at the
+        # restart with the very polkit error this step exists to
+        # prevent). `id -un` always resolves the effective user.
         sudo tee /etc/polkit-1/rules.d/49-dde-systemd-resolved.rules \
           >/dev/null <<EOF
         polkit.addRule(function(action, subject) {
           if (action.id === "org.freedesktop.systemd1.manage-units" &&
               action.lookup("unit") === "systemd-resolved.service" &&
-              subject.user === "$USER") {
+              subject.user === "$(id -un)") {
             return polkit.Result.YES;
           }
         });

--- a/.github/workflows/e2e-dde.yml
+++ b/.github/workflows/e2e-dde.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Bring dde project up
         id: dde
-        uses: sbaerlocher/.github/.github/actions/project@2026-05-16
+        uses: sbaerlocher/.github/.github/actions/project@2026-05-07
         with:
           command: up
           version: ${{ inputs.dde-version }}

--- a/.github/workflows/e2e-dde.yml
+++ b/.github/workflows/e2e-dde.yml
@@ -93,10 +93,11 @@ on:
         default: ''
         description: |
           Bash command(s) to capture diagnostics on test failure. When
-          non-empty, replaces the default `dde project:logs` / `project:ps`
-          capture. Output is appended to `$RUNNER_TEMP/dde-logs.txt`. Runs
-          in the project directory. Useful for plugin-driven log helpers
-          like `dde project:e2e:logs -- 200`.
+          non-empty, replaces the default `dde project:logs` capture
+          (`dde project:ps` still runs into `dde-ps.txt`). Output is
+          written to `$RUNNER_TEMP/dde-logs.txt` (overwritten, not
+          appended). Runs in the project directory. Useful for
+          plugin-driven log helpers like `dde project:e2e:logs -- 200`.
       teardown-command:
         type: string
         required: false
@@ -228,12 +229,17 @@ jobs:
       # Optional pre-test hook for project-specific setup (DB reset,
       # health-check waits, fixture seeding). Runs in the project
       # directory so callers can invoke `dde project:*` plugins
-      # directly. Skipped when the input is empty.
+      # directly. Skipped when the input is empty. Caller string is
+      # routed through `env:` (same pattern as LOGS_OVERRIDE /
+      # TEARDOWN_OVERRIDE) so the value cannot inject into the step
+      # script via `${{ ... }}`-substitution.
       - name: Run pre-test commands
         if: inputs.pre-test-commands != ''
         working-directory: ${{ inputs.project-directory }}
         shell: bash
-        run: ${{ inputs.pre-test-commands }}
+        env:
+          PRE_TEST_COMMANDS: ${{ inputs.pre-test-commands }}
+        run: bash -c "$PRE_TEST_COMMANDS"
 
       # Test runner: two mutually exclusive modes. When
       # `test-command-override` is set, run that bash verbatim and skip
@@ -244,7 +250,9 @@ jobs:
         if: inputs.test-command-override != ''
         working-directory: ${{ inputs.playwright-directory }}
         shell: bash
-        run: ${{ inputs.test-command-override }}
+        env:
+          TEST_COMMAND_OVERRIDE: ${{ inputs.test-command-override }}
+        run: bash -c "$TEST_COMMAND_OVERRIDE"
 
       - name: Run Playwright tests
         if: inputs.test-command-override == ''

--- a/.github/workflows/e2e-dde.yml
+++ b/.github/workflows/e2e-dde.yml
@@ -46,12 +46,67 @@ on:
         type: string
         required: false
         default: 'test:e2e'
-        description: 'Playwright test command'
+        description: |
+          Package-manager script name to run for Playwright tests.
+          Ignored when `test-command-override` is set — that bypasses the
+          PM wrapper and runs arbitrary bash instead.
+      test-command-override:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Raw bash command(s) to run Playwright tests, bypassing the
+          package-manager wrapper. When non-empty, this replaces the
+          `<pm> run <test-command>` step entirely. Use for projects that
+          drive Playwright through a dde plugin or other custom entrypoint
+          (e.g. `dde project:e2e:test`). Runs in `playwright-directory`.
       playwright-browsers:
         type: string
         required: false
         default: 'chromium'
         description: 'Playwright browsers (chromium, firefox, webkit, all)'
+
+      # E2E lifecycle hooks
+      compose-profiles:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Value for the `COMPOSE_PROFILES` env var on the job. Set when
+          the dde stack defines compose profiles that gate the E2E
+          service set (e.g. `e2e` to bring up an `app-e2e` profile while
+          leaving the dev profile dormant). Applies to every dde call in
+          the job, including project:up and project:down.
+      pre-test-commands:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Bash command(s) to run after `dde project:up` and dependency
+          install, but before Playwright tests. Use for project-specific
+          E2E setup (database reset, health-check waits, fixture seeding,
+          ...). Runs in the project directory (`project-directory`), not
+          `playwright-directory`.
+      failure-logs-command:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Bash command(s) to capture diagnostics on test failure. When
+          non-empty, replaces the default `dde project:logs` / `project:ps`
+          capture. Output is appended to `$RUNNER_TEMP/dde-logs.txt`. Runs
+          in the project directory. Useful for plugin-driven log helpers
+          like `dde project:e2e:logs -- 200`.
+      teardown-command:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Bash command(s) for the always-run teardown step. When non-empty,
+          replaces the default `dde project:down`. Use to invoke a
+          project-specific cleanup plugin (e.g. `dde project:e2e:down`,
+          which also removes the e2e volumes). Runs in the project
+          directory; failures are tolerated.
 
       # Artifact Configuration
       upload-artifacts:
@@ -102,6 +157,13 @@ jobs:
       contents: read
     outputs:
       dde-version: ${{ steps.dde.outputs.version }}
+    # COMPOSE_PROFILES is set at job scope so every dde invocation
+    # (project:up, project:down, plugin commands, teardown) sees the same
+    # compose-profile selection. Empty by default — Compose treats an
+    # unset/empty value the same as "no profiles", which matches the
+    # zero-config behavior of the previous reusable workflow.
+    env:
+      COMPOSE_PROFILES: ${{ inputs.compose-profiles }}
 
     steps:
       - name: Checkout code
@@ -111,7 +173,7 @@ jobs:
 
       - name: Bring dde project up
         id: dde
-        uses: sbaerlocher/.github/.github/actions/project@2026-05-07
+        uses: sbaerlocher/.github/.github/actions/project@2026-05-16
         with:
           command: up
           version: ${{ inputs.dde-version }}
@@ -163,7 +225,29 @@ jobs:
             npx playwright install --with-deps "$BROWSERS"
           fi
 
+      # Optional pre-test hook for project-specific setup (DB reset,
+      # health-check waits, fixture seeding). Runs in the project
+      # directory so callers can invoke `dde project:*` plugins
+      # directly. Skipped when the input is empty.
+      - name: Run pre-test commands
+        if: inputs.pre-test-commands != ''
+        working-directory: ${{ inputs.project-directory }}
+        shell: bash
+        run: ${{ inputs.pre-test-commands }}
+
+      # Test runner: two mutually exclusive modes. When
+      # `test-command-override` is set, run that bash verbatim and skip
+      # the package-manager wrapper. Otherwise fall back to the
+      # historical `<pm> run <test-command>` behavior. Splitting the step
+      # via `if:` keeps each mode readable in step logs.
+      - name: Run Playwright tests (override)
+        if: inputs.test-command-override != ''
+        working-directory: ${{ inputs.playwright-directory }}
+        shell: bash
+        run: ${{ inputs.test-command-override }}
+
       - name: Run Playwright tests
+        if: inputs.test-command-override == ''
         working-directory: ${{ inputs.playwright-directory }}
         env:
           PM: ${{ inputs.package-manager }}
@@ -181,6 +265,7 @@ jobs:
         if: failure() && inputs.upload-artifacts
         env:
           PROJECT_DIR: ${{ inputs.project-directory }}
+          LOGS_OVERRIDE: ${{ inputs.failure-logs-command }}
         run: |
           if ! command -v dde >/dev/null 2>&1; then
             echo "dde was never installed — see 'Bring dde project up' step output" \
@@ -193,8 +278,18 @@ jobs:
             exit 0
           fi
           cd "$PROJECT_DIR"
-          dde project:logs > "$RUNNER_TEMP/dde-logs.txt" 2>&1 || true
-          dde project:ps   > "$RUNNER_TEMP/dde-ps.txt"   2>&1 || true
+          if [ -n "$LOGS_OVERRIDE" ]; then
+            # Override mode: caller owns log collection (e.g. a
+            # `dde project:e2e:logs -- 200` plugin). We still write
+            # dde-ps.txt from the standard `project:ps` so the artifact
+            # bundle stays useful even when the override only captures
+            # service logs.
+            bash -c "$LOGS_OVERRIDE" > "$RUNNER_TEMP/dde-logs.txt" 2>&1 || true
+            dde project:ps           > "$RUNNER_TEMP/dde-ps.txt"   2>&1 || true
+          else
+            dde project:logs > "$RUNNER_TEMP/dde-logs.txt" 2>&1 || true
+            dde project:ps   > "$RUNNER_TEMP/dde-ps.txt"   2>&1 || true
+          fi
 
       - name: Upload Playwright report
         if: inputs.upload-artifacts && always()
@@ -229,6 +324,7 @@ jobs:
         if: always()
         env:
           PROJECT_DIR: ${{ inputs.project-directory }}
+          TEARDOWN_OVERRIDE: ${{ inputs.teardown-command }}
         run: |
           if ! command -v dde >/dev/null 2>&1; then
             echo "dde was never installed — nothing to tear down"
@@ -239,7 +335,14 @@ jobs:
             exit 0
           fi
           cd "$PROJECT_DIR"
-          dde project:down || true
+          if [ -n "$TEARDOWN_OVERRIDE" ]; then
+            # Caller-provided cleanup (e.g. `dde project:e2e:down`, which
+            # also removes the e2e volumes). Tolerate failures so a
+            # broken teardown doesn't mask the real test result.
+            bash -c "$TEARDOWN_OVERRIDE" || true
+          else
+            dde project:down || true
+          fi
 
   # PR comment runs as a separate job so the test job stays at
   # contents:read. pull-requests:write is scoped to this job only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,11 +47,11 @@ This is a rolling release - changes are deployed continuously to `main`.
 
 ### Changed
 
-- **`e2e-dde.yml`**: Bumped internal `sbaerlocher/.github/.github/actions/project@2026-05-03`
+- **`e2e-dde.yml`**: Bumped internal `sbaerlocher/.github/.github/actions/project@2026-05-07`
   reference to `@2026-05-16` so consumers of the workflow pick up the
   new `setup-dde` polkit fix transitively.
 
-- **`project` action**: Bumped internal `setup-dde@2026-05-03` reference
+- **`project` action**: Bumped internal `setup-dde@2026-05-07` reference
   to `@2026-05-16` for the same reason.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,56 @@ This is a rolling release - changes are deployed continuously to `main`.
 
 ---
 
+## 2026-05-16
+
+### Added
+
+- **`setup-dde`**: New pre-authorize step that runs before
+  `dde system:install` on Linux runners. It `chmod o+w`s `/etc/systemd`
+  (so dde can write its `resolved.conf.d` drop-in) and installs a polkit
+  rule that grants the runner user `manage-units` on
+  `systemd-resolved.service` (so the unprivileged restart succeeds).
+  Linux-only and gated on `system-install: true`. Removes the
+  per-consumer `Pre-authorize dde DNS resolver setup` workaround that
+  was previously copy-pasted into e2e workflows. Drop once dde escalates
+  for `resolved.conf.d` / polkit the same way it does for dnsmasq.
+
+- **`e2e-dde.yml`**: Five new optional inputs for plugin-driven E2E
+  lifecycles. Existing callers keep working unchanged; reach for these
+  when the project drives its E2E flow through dde plugins rather than
+  the standard `dde project:up` → `npm run test:e2e` → `dde project:down`
+  pipeline.
+
+  - `compose-profiles` — set `COMPOSE_PROFILES` at job scope (e.g. `e2e`
+    to bring up an `app-e2e` compose profile while leaving the dev
+    profile dormant). Applies to every dde call in the job, including
+    teardown.
+  - `pre-test-commands` — bash to run after `dde project:up` and
+    dependency install, but before Playwright tests. Runs in
+    `project-directory`. Use for DB reset, health-check waits, fixture
+    seeding.
+  - `test-command-override` — raw bash that replaces the
+    `<pm> run <test-command>` step. Use for projects that drive
+    Playwright through a dde plugin (`dde project:e2e:test`) instead of
+    a package-manager script.
+  - `failure-logs-command` — raw bash for failure-time log capture.
+    Replaces the default `dde project:logs` (`dde-ps.txt` is still
+    written from `dde project:ps`).
+  - `teardown-command` — bash for the always-run teardown step. Replaces
+    the default `dde project:down`. Use for plugin-driven cleanup like
+    `dde project:e2e:down -v`.
+
+### Changed
+
+- **`e2e-dde.yml`**: Bumped internal `sbaerlocher/.github/.github/actions/project@2026-05-03`
+  reference to `@2026-05-16` so consumers of the workflow pick up the
+  new `setup-dde` polkit fix transitively.
+
+- **`project` action**: Bumped internal `setup-dde@2026-05-03` reference
+  to `@2026-05-16` for the same reason.
+
+---
+
 ## 2026-05-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,14 +45,20 @@ This is a rolling release - changes are deployed continuously to `main`.
     the default `dde project:down`. Use for plugin-driven cleanup like
     `dde project:e2e:down -v`.
 
-### Changed
+### Note on transitive consumption
 
-- **`e2e-dde.yml`**: Bumped internal `sbaerlocher/.github/.github/actions/project@2026-05-07`
-  reference to `@2026-05-16` so consumers of the workflow pick up the
-  new `setup-dde` polkit fix transitively.
+Consumers of `e2e-dde.yml@2026-05-16` and `project@2026-05-16` do **not**
+transitively pick up the new `setup-dde` polkit step in this tag — the
+inner `uses:` refs still point at `setup-dde@2026-05-07`. To benefit from
+the polkit fix, either:
 
-- **`project` action**: Bumped internal `setup-dde@2026-05-07` reference
-  to `@2026-05-16` for the same reason.
+- consume `setup-dde@2026-05-16` directly, or
+- wait for the next rolling-release tag, where Renovate's standard
+  github-actions bump will have lifted the inner refs to `@2026-05-16`.
+
+This is the documented chicken-and-egg of the date-tag model: the inner
+ref cannot point at the tag that is about to be cut from the same
+commit, because the tag does not yet resolve at PR-validation time.
 
 ---
 


### PR DESCRIPTION
## Summary

- **`setup-dde`**: pre-authorize systemd-resolved on Linux GitHub runners (`chmod o+w /etc/systemd` + polkit rule for `manage-units` on `systemd-resolved.service`) so unprivileged `dde system:install` no longer fails with `Permission denied` or `Interactive authentication required`. Linux-only, gated on `system-install: true`. Lifts the per-consumer workaround that lives inline in project E2E workflows (savvy-dde, etc.).
- **`e2e-dde.yml`**: five new optional inputs for plugin-driven E2E lifecycles — `compose-profiles`, `pre-test-commands`, `test-command-override`, `failure-logs-command`, `teardown-command`. Existing callers keep working unchanged (all defaults are empty / no-op).
- Internal `setup-dde@2026-05-03` / `project@2026-05-03` refs bumped to `@2026-05-16` so consumers of `e2e-dde.yml` and `project` pick up the polkit fix transitively after the date tag is cut.

Cut date tag `2026-05-16` after merge so consumers (e.g. `sbaerlocher/savvy-dde`) can reference the new behaviour. Follow-up PR in savvy-dde refactors its `e2e.yml` from 156 lines of inline plumbing down to a 56-line caller using these hooks.

## Test plan

- [ ] Tag `2026-05-16` exists and points at the merge commit
- [ ] `setup-dde` polkit step appears in a runner log for a Linux + `system-install: true` consumer (verifies the conditional)
- [ ] Existing `e2e-dde.yml` consumers (no new inputs set) still pass — defaults are no-op
- [ ] savvy-dde follow-up PR with `dde project:e2e:*` hooks runs E2E green end-to-end