### PR TITLE
feat(actions): add validate-observability-configs composite action

### DIFF
--- a/.github/actions/validate-observability-configs/action.yml
+++ b/.github/actions/validate-observability-configs/action.yml
@@ -1,0 +1,92 @@
+---
+name: 'Validate Observability Configs'
+description: |
+  Validate Grafana Alloy and JSON config files in an observability
+  Terraform repo. Runs `alloy fmt --test` against every `*.alloy` file
+  under the configured Alloy directory and `jq empty` against every
+  `*.json` file under the configured JSON directories. Single source of
+  truth used by the observability repo's pull-request workflow.
+author: 'sbaerlocher'
+
+inputs:
+  alloy-version:
+    description: 'Grafana Alloy version to install (e.g. v1.16.1)'
+    required: true
+  alloy-dir:
+    description: 'Directory containing *.alloy files'
+    required: false
+    default: 'configs/fleet'
+  json-dirs:
+    description: |
+      Newline-separated list of directories containing *.json files to
+      validate with `jq empty`. Each directory is relative to the repo
+      root. Missing directories are skipped without error.
+    required: false
+    default: |
+      configs/synthetic-monitoring
+      configs/alerting
+      configs/notification-policies
+      configs/dashboards
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install Grafana Alloy
+      shell: bash
+      env:
+        ALLOY_VERSION: ${{ inputs.alloy-version }}
+      run: |
+        curl -fsSL "https://github.com/grafana/alloy/releases/download/${ALLOY_VERSION}/alloy-linux-amd64.zip" -o alloy.zip
+        unzip -q alloy.zip
+        chmod +x alloy-linux-amd64
+        sudo mv alloy-linux-amd64 /usr/local/bin/alloy
+        echo "Grafana Alloy ${ALLOY_VERSION} installed"
+
+    - name: Validate Alloy configs
+      shell: bash
+      env:
+        ALLOY_DIR: ${{ inputs.alloy-dir }}
+      run: |
+        ERRORS=0
+        if [ -d "${ALLOY_DIR}" ]; then
+          for config in "${ALLOY_DIR}"/*.alloy; do
+            [ -f "$config" ] || continue
+            if ! alloy fmt --test "$config" > /dev/null 2>&1; then
+              echo "::error file=$config::Alloy syntax error or formatting issue"
+              ERRORS=$((ERRORS + 1))
+            fi
+          done
+        else
+          echo "::notice::Alloy directory '${ALLOY_DIR}' not found, skipping"
+        fi
+        if [ "$ERRORS" -gt 0 ]; then
+          echo "::error::Found $ERRORS Alloy configuration errors"
+          exit 1
+        fi
+        echo "All Alloy configurations valid"
+
+    - name: Validate JSON configs
+      shell: bash
+      env:
+        JSON_DIRS: ${{ inputs.json-dirs }}
+      run: |
+        ERRORS=0
+        while IFS= read -r dir; do
+          [ -n "$dir" ] || continue
+          if [ ! -d "$dir" ]; then
+            echo "::notice::JSON directory '$dir' not found, skipping"
+            continue
+          fi
+          for config in "$dir"/*.json; do
+            [ -f "$config" ] || continue
+            if ! jq empty "$config" > /dev/null 2>&1; then
+              echo "::error file=$config::Invalid JSON syntax"
+              ERRORS=$((ERRORS + 1))
+            fi
+          done
+        done <<< "$JSON_DIRS"
+        if [ "$ERRORS" -gt 0 ]; then
+          echo "::error::Found $ERRORS JSON syntax errors"
+          exit 1
+        fi
+        echo "All JSON configurations valid"

--- a/.github/actions/validate-observability-configs/action.yml
+++ b/.github/actions/validate-observability-configs/action.yml
@@ -4,7 +4,8 @@ description: |
   Validate Grafana Alloy and JSON config files in an observability
   Terraform repo. Runs `alloy fmt --test` against every `*.alloy` file
   under the configured Alloy directory and `jq empty` against every
-  `*.json` file under the configured JSON directories. Single source of
+  `*.json` file under the configured JSON directories (recursive).
+  Supports Linux and macOS on amd64/arm64 runners. Single source of
   truth used by the observability repo's pull-request workflow.
 author: 'sbaerlocher'
 
@@ -13,14 +14,15 @@ inputs:
     description: 'Grafana Alloy version to install (e.g. v1.16.1)'
     required: true
   alloy-dir:
-    description: 'Directory containing *.alloy files'
+    description: 'Directory containing *.alloy files (searched recursively)'
     required: false
     default: 'configs/fleet'
   json-dirs:
     description: |
       Newline-separated list of directories containing *.json files to
-      validate with `jq empty`. Each directory is relative to the repo
-      root. Missing directories are skipped without error.
+      validate with `jq empty`. Each directory is searched recursively
+      and is relative to the repo root. Missing directories are skipped
+      without error.
     required: false
     default: |
       configs/synthetic-monitoring
@@ -31,36 +33,86 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Detect platform
+      id: platform
+      shell: bash
+      run: |
+        set -euo pipefail
+        case "$RUNNER_OS" in
+          Linux)  os=linux ;;
+          macOS)  os=darwin ;;
+          *)
+            echo "::error::alloy does not ship a binary for $RUNNER_OS"
+            exit 1
+            ;;
+        esac
+        case "$RUNNER_ARCH" in
+          X64)   arch=amd64 ;;
+          ARM64) arch=arm64 ;;
+          *)
+            echo "::error::alloy does not ship a binary for $RUNNER_ARCH"
+            exit 1
+            ;;
+        esac
+        echo "asset=alloy-${os}-${arch}.zip" >> "$GITHUB_OUTPUT"
+        echo "binary=alloy-${os}-${arch}" >> "$GITHUB_OUTPUT"
+
     - name: Install Grafana Alloy
       shell: bash
       env:
         ALLOY_VERSION: ${{ inputs.alloy-version }}
+        ASSET: ${{ steps.platform.outputs.asset }}
+        BINARY: ${{ steps.platform.outputs.binary }}
       run: |
-        curl -fsSL "https://github.com/grafana/alloy/releases/download/${ALLOY_VERSION}/alloy-linux-amd64.zip" -o alloy.zip
-        unzip -q alloy.zip
-        chmod +x alloy-linux-amd64
-        sudo mv alloy-linux-amd64 /usr/local/bin/alloy
-        echo "Grafana Alloy ${ALLOY_VERSION} installed"
+        set -euo pipefail
+        dl="$RUNNER_TEMP/alloy-download"
+        bin_dir="$RUNNER_TEMP/alloy-bin"
+        mkdir -p "$dl" "$bin_dir"
+
+        base="https://github.com/grafana/alloy/releases/download/${ALLOY_VERSION}"
+        echo "Downloading $base/$ASSET"
+        curl -fsSL --retry 3 "$base/$ASSET" -o "$dl/$ASSET"
+        curl -fsSL --retry 3 "$base/SHA256SUMS" -o "$dl/SHA256SUMS"
+
+        # SHA256SUMS format is "<sha>  <filename>" (two spaces). Match any
+        # whitespace run so we don't break if the format ever shifts to a
+        # tab. Extract the line first and fail with a clear message if
+        # the asset is missing, then pipe to shasum so the verification
+        # error path stays clean.
+        echo "Verifying SHA256 for $ASSET"
+        if ! grep -E "[[:space:]]+${ASSET}\$" "$dl/SHA256SUMS" > "$dl/expected.sum"; then
+          echo "::error::Asset '${ASSET}' not listed in SHA256SUMS for ${ALLOY_VERSION}"
+          echo "SHA256SUMS contents:" && cat "$dl/SHA256SUMS"
+          exit 1
+        fi
+        ( cd "$dl" && shasum -a 256 -c expected.sum )
+
+        unzip -q "$dl/$ASSET" -d "$dl"
+        install -m 0755 "$dl/$BINARY" "$bin_dir/alloy"
+        echo "$bin_dir" >> "$GITHUB_PATH"
+
+        "$bin_dir/alloy" --version
 
     - name: Validate Alloy configs
       shell: bash
       env:
         ALLOY_DIR: ${{ inputs.alloy-dir }}
       run: |
+        set -euo pipefail
         ERRORS=0
-        if [ -d "${ALLOY_DIR}" ]; then
-          for config in "${ALLOY_DIR}"/*.alloy; do
-            [ -f "$config" ] || continue
-            if ! alloy fmt --test "$config" > /dev/null 2>&1; then
-              echo "::error file=$config::Alloy syntax error or formatting issue"
+        if [ -d "$ALLOY_DIR" ]; then
+          while IFS= read -r -d '' config; do
+            if ! out=$(alloy fmt --test "$config" 2>&1); then
+              echo "::error file=$config::Alloy validation failed"
+              echo "$out"
               ERRORS=$((ERRORS + 1))
             fi
-          done
+          done < <(find "$ALLOY_DIR" -type f -name '*.alloy' -print0)
         else
-          echo "::notice::Alloy directory '${ALLOY_DIR}' not found, skipping"
+          echo "::notice::Alloy directory '$ALLOY_DIR' not found, skipping"
         fi
         if [ "$ERRORS" -gt 0 ]; then
-          echo "::error::Found $ERRORS Alloy configuration errors"
+          echo "::error::Found $ERRORS Alloy configuration error(s)"
           exit 1
         fi
         echo "All Alloy configurations valid"
@@ -70,6 +122,7 @@ runs:
       env:
         JSON_DIRS: ${{ inputs.json-dirs }}
       run: |
+        set -euo pipefail
         ERRORS=0
         while IFS= read -r dir; do
           [ -n "$dir" ] || continue
@@ -77,16 +130,16 @@ runs:
             echo "::notice::JSON directory '$dir' not found, skipping"
             continue
           fi
-          for config in "$dir"/*.json; do
-            [ -f "$config" ] || continue
-            if ! jq empty "$config" > /dev/null 2>&1; then
+          while IFS= read -r -d '' config; do
+            if ! out=$(jq empty "$config" 2>&1); then
               echo "::error file=$config::Invalid JSON syntax"
+              echo "$out"
               ERRORS=$((ERRORS + 1))
             fi
-          done
+          done < <(find "$dir" -type f -name '*.json' -print0)
         done <<< "$JSON_DIRS"
         if [ "$ERRORS" -gt 0 ]; then
-          echo "::error::Found $ERRORS JSON syntax errors"
+          echo "::error::Found $ERRORS JSON syntax error(s)"
           exit 1
         fi
         echo "All JSON configurations valid"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ This is a rolling release - changes are deployed continuously to `main`.
 
 ---
 
+## 2026-05-17
+
+### Added
+
+- **`validate-observability-configs`**: New composite action that
+  installs Grafana Alloy and validates `*.alloy` files via
+  `alloy fmt --test` plus `*.json` config files via `jq empty`. Used by
+  the observability repo's `pull-request.yml` to gate Alloy / JSON
+  drift before Terraform plan/apply. Inputs let consumers override the
+  Alloy version, Alloy directory and the newline-separated list of JSON
+  directories.
+
+---
+
 ## 2026-05-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,13 @@ This is a rolling release - changes are deployed continuously to `main`.
   the observability repo's `pull-request.yml` to gate Alloy / JSON
   drift before Terraform plan/apply. Inputs let consumers override the
   Alloy version, Alloy directory and the newline-separated list of JSON
-  directories.
+  directories. Mirrors the `setup-dde` supply-chain pattern: platform
+  detection (`linux`/`darwin` × `amd64`/`arm64`), SHA256 verification
+  against `SHA256SUMS`, install into `$RUNNER_TEMP` + `$GITHUB_PATH`
+  (no `sudo`), `curl --retry 3`. Validation steps capture and surface
+  the tool's stderr/stdout so failed configs report the actual error,
+  and search both `*.alloy` and `*.json` recursively so nested
+  layouts (e.g. `configs/dashboards/<service>/foo.json`) are covered.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -141,11 +141,12 @@ All files live in [.github/workflows/](./.github/workflows/).
 In addition to reusable workflows, this repo ships composite actions under
 [.github/actions/](./.github/actions/) for use from any consumer workflow.
 
-| Action                                      | Purpose                                                                |
-| ------------------------------------------- | ---------------------------------------------------------------------- |
-| [`setup-dde`](./.github/actions/setup-dde/) | Install the [whatwedo dde](https://github.com/whatwedo/dde) CLI        |
-| [`project`](./.github/actions/project/)     | Install dde + run any `dde project:<command>` (default `up`) for E2E   |
-| [`sbom-npm`](./.github/actions/sbom-npm/)   | CycloneDX SBOM for npm/pnpm/yarn/bun projects (internal)               |
+| Action                                                                                  | Purpose                                                                |
+| --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| [`setup-dde`](./.github/actions/setup-dde/)                                             | Install the [whatwedo dde](https://github.com/whatwedo/dde) CLI        |
+| [`project`](./.github/actions/project/)                                                 | Install dde + run any `dde project:<command>` (default `up`) for E2E   |
+| [`sbom-npm`](./.github/actions/sbom-npm/)                                               | CycloneDX SBOM for npm/pnpm/yarn/bun projects (internal)               |
+| [`validate-observability-configs`](./.github/actions/validate-observability-configs/)   | Validate Grafana Alloy and JSON configs in observability Terraform repos |
 
 For a complete Playwright + dde E2E job, use the
 [`e2e-dde.yml`](./.github/workflows/e2e-dde.yml) reusable workflow — it


### PR DESCRIPTION
## Summary

- New composite action `validate-observability-configs` installs Grafana Alloy and validates `*.alloy` files (`alloy fmt --test`) plus `*.json` config files (`jq empty`).
- Consumed by `sbaerlocher/observability`'s upcoming `pull-request.yml` to gate Alloy/JSON drift before `terraform plan`/`apply`.
- Inputs let consumers override `alloy-version` (required), `alloy-dir` (default `configs/fleet`) and `json-dirs` (newline-separated list, default covers synthetic-monitoring, alerting, notification-policies, dashboards). Missing dirs are skipped with a notice so the action stays reusable.

README composite-actions table and CHANGELOG entry for 2026-05-17 added.

## Test plan

- [ ] Merge → cut a new date-tag (`2026-05-17`) on `main` so consumers can pin.
- [ ] Verify in `sbaerlocher/observability` `pull-request.yml` that the action runs green against an Alloy/JSON-changing PR.
- [ ] Verify error path: introduce a malformed `*.alloy` or `*.json` and confirm the action fails the job with annotated file/line output.

#observability