### PR TITLE
ci(ai-claude-review): bump review model to claude-opus-4-8

### DIFF
--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -114,7 +114,7 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           claude_args: |
             --max-turns ${{ steps.mode.outputs.mode == 'first' && '100' || '40' }}
-            --model ${{ steps.mode.outputs.mode == 'first' && 'claude-opus-4-7' || 'claude-sonnet-4-6' }}
+            --model claude-opus-4-8
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Agent,Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git log:*),Bash(gh api repos/*/pulls/*/comments*),Bash(gh api repos/*/pulls/comments*),Bash(gh api repos/*/pulls/*/comments/*/replies*),Bash(gh api repos/*/pulls/*/reviews*),Bash(gh api repos/*/compare/*),Bash(gh api graphql:*)"
           prompt: |
             REPO: ${{ github.repository }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ This is a rolling release - changes are deployed continuously to `main`.
 
 ---
 
+## 2026-05-30
+
+### Changed
+
+- **ai-claude-review.yml**: Bump `--model` to `claude-opus-4-8` for both
+  the first and follow-up review passes (previously `claude-opus-4-7`
+  for first and `claude-sonnet-4-6` for follow-up). The per-mode
+  conditional collapses to a single fixed model ID since both branches
+  now use the same model.
+
+### Dependencies
+
+- **`codecov/codecov-action`**: v6.0.0 → v6.0.1 (`ci-go.yml`, `ci-js.yml`).
+- **`github/codeql-action`**: v4.35.5 → v4.36.0 (`ci-go.yml`, `ci-js.yml`,
+  `ci-terraform.yml`, `release-docker.yml`, `security-code.yml`,
+  `security-config.yml`, `security-containers.yml`).
+- **`docker/setup-buildx-action`**: v4.0.0 → v4.1.0 (`release-docker.yml`).
+- **`docker/login-action`**: v4.1.0 → v4.2.0 (`release-docker.yml`).
+- **`docker/metadata-action`**: v6.0.0 → v6.1.0 (`release-docker.yml`).
+- **`docker/build-push-action`**: v7.1.0 → v7.2.0 (`release-docker.yml`).
+- **`goreleaser/goreleaser-action`**: v7.2.1 → v7.2.2 (`release-go.yml`).
+- **`anthropics/claude-code-action`**: v1.0.123 → v1.0.133 (`ai-claude.yml`,
+  `ai-claude-review.yml`).
+- **`ansible`**: 13.6.0 → 13.7.0 (`security-config.yml`).
+- **`safety`**: 3.7.0 → 3.8.0 (`security-deps.yml`).
+- **internal `setup-dde` / `project` refs**: pinned to `@2026-05-17`
+  (`actions/project/action.yml`, `e2e-dde.yml`).
+
+---
+
 ## 2026-05-17
 
 ### Added


### PR DESCRIPTION
## Summary

Bumps the AI code-review workflow to `claude-opus-4-8` for both passes:

- **first review:** `claude-opus-4-7` → `claude-opus-4-8` (intra-family patch)
- **follow-up:** `claude-sonnet-4-6` → `claude-opus-4-8`

Both branches now use the same model, so the per-mode `--model` conditional
collapses to a single fixed model ID. `--max-turns` is intentionally left
unchanged (100 first / 40 follow-up) — those are upper bounds, not targets,
and Opus tends to need fewer turns than Sonnet.

The model ID is confirmed against the [Claude Code GitHub Actions docs](https://code.claude.com/docs/en/github-actions).

## CHANGELOG

The new `2026-05-30` section also documents the Renovate dependency bumps
that landed since the `2026-05-17` tag (codecov-action, codeql-action,
docker/*, goreleaser-action, claude-code-action, ansible, safety, internal
`setup-dde`/`project` refs), so the next rolling-release tag has a complete
entry.

## Note

Reusable-workflow change — after merge a new date tag (`2026-05-30`) should
be cut from `main` so Renovate propagates it to consumer repos.
