### PR TITLE
fix(security-deps): use correct v2 module path for go-licenses

### DIFF
--- a/.github/workflows/security-deps.yml
+++ b/.github/workflows/security-deps.yml
@@ -133,11 +133,11 @@ jobs:
         if: inputs.enable-license-check
         working-directory: ${{ inputs.working-directory }}
         env:
-          # renovate: datasource=go depName=github.com/google/go-licenses
+          # renovate: datasource=go depName=github.com/google/go-licenses/v2
           GO_LICENSES_VERSION: 'v2.0.1'
           ALLOWED_LICENSES: ${{ inputs.allowed-licenses }}
         run: |
-          go install "github.com/google/go-licenses@${GO_LICENSES_VERSION}"
+          go install "github.com/google/go-licenses/v2@${GO_LICENSES_VERSION}"
           echo "Checking Go dependency licenses..."
           go-licenses check ./... --allowed_licenses="${ALLOWED_LICENSES}" 2>&1 | tee go-licenses.txt || true
           go-licenses csv ./... > go-licenses.csv 2>&1 || true


### PR DESCRIPTION
## Summary

- **Root cause**: `go install github.com/google/go-licenses@v2.0.1` fails because the module's v2 path is `github.com/google/go-licenses/v2` — the `/v2` suffix is required for major-version Go modules
- **Fix**: Change install command to `github.com/google/go-licenses/v2@v2.0.1` and update the Renovate datasource comment to `depName=github.com/google/go-licenses/v2` so future Renovate bumps use the correct path
- **Impact**: Fixes the weekly Security Scan failure in `tsmetrics` (and any other Go repo using this reusable workflow) that has been failing every Sunday since the v2.0.1 version was pinned

## Test plan

- [ ] Merge and cut a new date tag
- [ ] Trigger a manual Security Scan run on `tsmetrics` to verify `Dependencies & Licenses / Audit Go` passes