### PR TITLE
fix(security-secrets): remove unused pull-requests: read permission

### DIFF
--- a/.github/workflows/security-secrets.yml
+++ b/.github/workflows/security-secrets.yml
@@ -46,7 +46,6 @@ on:
 permissions:
   contents: read
   actions: read
-  pull-requests: read
 
 concurrency:
   group: >-


### PR DESCRIPTION
## Summary

- **Root cause**: `pull-requests: read` was declared in `security-secrets.yml`'s `permissions:` block but is never used by any step in the workflow. GitHub enforces that a calling workflow must grant at least every permission the reusable declares — if the caller doesn't have `pull-requests: read`, GitHub aborts the run with `startup_failure` before any job starts.
- **Impact**: `applications`, `authentication`, `infrastructure`, and `observability` have all had `startup_failure` on their weekly Security Scan since the nightly workflows were created in May 2026. Their callers do not grant `pull-requests` because there is no PR context in a scheduled run.
- **Fix**: Remove the unused permission from the reusable. Callers no longer need a workaround.

> Note: Separate PRs on the four infra repos add `pull-requests: read` as a short-term workaround. Once this PR is merged and a new tag is cut, those infra PRs can be updated to drop the workaround — or they can stay (harmless extra permission).

## Test plan

- [ ] Merge + cut new date tag
- [ ] Manually trigger `workflow_dispatch` on `sbaerlocher/applications` nightly-security — verify no `startup_failure`