### PR TITLE
docs(changelog): note pull-requests permission removal in 2026-06-08

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ This is a rolling release - changes are deployed continuously to `main`.
 
 ## 2026-06-08
 
+### Removed
+
+- **security-secrets.yml**: Drop the unused `pull-requests: read` token
+  permission. Gitleaks and TruffleHog only read repository contents and the
+  Actions metadata; neither queries the pull-requests API, so the grant was
+  dead scope. Tightens the workflow to least-privilege.
+
 ### Fixed
 
 - **security-deps.yml**: Correct the `go-licenses` install path to include


### PR DESCRIPTION
## Summary

- Add a `### Removed` entry to the `2026-06-08` CHANGELOG section for #154 — dropping the unused `pull-requests: read` permission from `security-secrets.yml`.
- Keeps today's rolling release notes complete before the `2026-06-08` tag is moved onto the final HEAD.

## Test plan

- [ ] CHANGELOG renders correctly, entry sits under the existing 2026-06-08 block
- [ ] CI green
- [ ] Move the `2026-06-08` tag onto this commit after merge