### PR TITLE
fix(renovate): skip terraform-provider lookups from .terraform.lock.hcl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ This is a rolling release - changes are deployed continuously to `main`.
 
 ---
 
+## 2026-06-10
+
+### Fixed
+
+- **renovate-terraform.json**: Stop the spurious `Failed to look up
+terraform-provider package registry.terraform.io/<ns>/<name>: no-result`
+  warnings that the `registryUrls` pin (2026-06-09) did not resolve. Root
+  cause is in the terraform manager, not the registry: it extracts providers
+  from `.terraform.lock.hcl` under their fully-qualified name
+  (`registry.terraform.io/<ns>/<name>`), and the v2 datasource does not strip
+  the host prefix — so it requests
+  `/v2/providers/registry.terraform.io/<ns>/<name>` which 404s (verified: the
+  same path without the host prefix returns 200). These lock-file lookups are
+  redundant — the identical providers are already tracked from
+  `versions.tf` / `required_providers` (packageName `<ns>/<name>`, resolves
+  fine), and the lock file is maintained via `lockFileMaintenance` / artifact
+  update, not datasource lookup. Disabling only the `.terraform.lock.hcl`
+  source (`matchFileNames` + `enabled: false`) clears the warning without
+  affecting provider tracking or lock updates.
+
 ## 2026-06-09
 
 ### Fixed

--- a/renovate-terraform.json
+++ b/renovate-terraform.json
@@ -19,6 +19,12 @@
       "registryUrls": ["https://registry.terraform.io"]
     },
     {
+      "description": "Skip provider lookups originating from .terraform.lock.hcl. The terraform manager extracts lock-file providers under their fully-qualified name (registry.terraform.io/<ns>/<name>, depType=provider); the v2 datasource does not strip the host prefix and requests /v2/providers/registry.terraform.io/<ns>/<name> -> 404 -> persistent 'no-result' dashboard warning. These lookups are redundant: the same providers are tracked from versions.tf / required_providers (packageName <ns>/<name>, resolves fine), and the lock file itself is maintained via lockFileMaintenance / artifact update, not datasource lookup. Disabling only the lock-file source removes the spurious warning without touching provider tracking or lock updates.",
+      "matchManagers": ["terraform"],
+      "matchFileNames": ["**/.terraform.lock.hcl", ".terraform.lock.hcl"],
+      "enabled": false
+    },
+    {
       "description": "Terraform Core version updates - higher stability",
       "matchManagers": ["terraform-version"],
       "matchPackageNames": ["hashicorp/terraform"],


### PR DESCRIPTION
## Summary

- Follow-up to #157. The `registryUrls` pin removed the `releases.hashicorp.com` fallback but the `no-result` dashboard warnings persisted — confirmed via three live Renovate run logs (the 19:19 run used `ref=2026-06-09`, fallback gone, warning still there).
- **Root cause** is in the terraform manager, not the registry: it extracts providers from `.terraform.lock.hcl` under their fully-qualified name `registry.terraform.io/<ns>/<name>`. The v2 datasource does not strip the host prefix → requests `/v2/providers/registry.terraform.io/<ns>/<name>` → **404** (verified live: same path *without* the host prefix returns **200**). With no fallback left, the lookup ends in `no-result`.
- These lock-file lookups are **redundant** — the identical providers are tracked from `versions.tf` / `required_providers` (packageName `<ns>/<name>`, resolves fine, seen in the log as `ok`), and the lock file is maintained via `lockFileMaintenance` / artifact update, not datasource lookup.
- Fix: disable **only** the `.terraform.lock.hcl` source (`matchManagers: terraform` + `matchFileNames` + `enabled: false`). Provider tracking and lock updates are untouched.

## Test plan

- [ ] CI green (prettier, JSON)
- [ ] After merge + tag + consumer pin bump: confirm the `no-result` warnings clear on the next Renovate run for `authentication` / `infrastructure` / `observability`, and that `versions.tf` provider updates still appear