### PR TITLE
feat(ai-claude-review): expose model as workflow input

### DIFF
--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -5,6 +5,16 @@ on:
     types: [opened, synchronize, ready_for_review, reopened]
   workflow_call:
     inputs:
+      model:
+        type: string
+        required: false
+        default: claude-opus-4-8
+        description: |
+          Claude model id passed to `--model`. Defaults to Opus for the
+          deepest review; consumers can override with a cheaper tier
+          (e.g. claude-sonnet-4-6, claude-haiku-4-5-20251001) to trade
+          review depth for lower CI cost. Undefined on the `pull_request`
+          trigger, where the expression below falls back to the default.
       cancel-in-progress:
         type: boolean
         required: false
@@ -114,7 +124,7 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           claude_args: |
             --max-turns ${{ steps.mode.outputs.mode == 'first' && '100' || '40' }}
-            --model claude-opus-4-8
+            --model ${{ inputs.model || 'claude-opus-4-8' }}
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Agent,Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git log:*),Bash(gh api repos/*/pulls/*/comments*),Bash(gh api repos/*/pulls/comments*),Bash(gh api repos/*/pulls/*/comments/*/replies*),Bash(gh api repos/*/pulls/*/reviews*),Bash(gh api repos/*/compare/*),Bash(gh api graphql:*)"
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Was

Das Review-Modell war auf `claude-opus-4-8` hartcodiert. Neuer optionaler Input `model` (Default `claude-opus-4-8`), damit Konsumenten auf eine günstigere Stufe (z.B. `claude-sonnet-4-6`) wechseln können — Trade-off Review-Tiefe gegen CI-Kosten.

## Details

- Dual-Trigger-Workflow: Auf dem `pull_request`-Trigger sind `inputs.*` undefined, daher Fallback `${{ inputs.model || 'claude-opus-4-8' }}` — analog zur bestehenden Behandlung von `cancel-in-progress`/`concurrency-suffix`.
- Default-Verhalten unverändert.

Notion-Idee: *ai-claude-review Model auf Env-Variable*.