### PR TITLE
docs(changelog): add breaking-change channel and tag support policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,8 +383,11 @@ public action.
 
 1. **Test First**: Create a test version (e.g., `ci-js-test.yml`)
 2. **Consumer Testing**: Test in 1-2 consumer repos pointing at `@main`
-3. **Breaking Changes**: Cut a new dated tag and call out the break in
-   `CHANGELOG.md` so consumers know not to bump until they migrate
+3. **Breaking Changes**: Cut a new dated tag and add a `### ⚠ BREAKING`
+   heading to that tag's `CHANGELOG.md` entry, naming the affected workflow
+   and a one-line migration step. This is the single channel consumers scan
+   before bumping — see the "Breaking changes & support policy" section at
+   the top of `CHANGELOG.md`.
 4. **Non-Breaking**: A regular dated tag is sufficient
 5. **Document**: Update CHANGELOG.md with all changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
-This is a rolling release - changes are deployed continuously to `main`.
+This is a rolling release - changes are deployed continuously to `main` and
+consumed via date-based tags (`YYYY-MM-DD`).
+
+## Breaking changes & support policy
+
+Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
+
+- **Breaking changes are flagged explicitly.** Any change that alters required
+  inputs, removes an input/output, or changes default behaviour gets a
+  `### ⚠ BREAKING` heading in its dated entry below, naming the affected
+  workflow and a one-line migration step. Scan for `⚠ BREAKING` before bumping
+  a tag — that is the single source of truth for what might break.
+- **Only the latest tag is supported.** Older date tags keep working
+  (immutable), but fixes and security patches land only on `main` / the newest
+  tag. Pin an old tag at your own risk; there is no backport.
 
 ---
 


### PR DESCRIPTION
## Was

Konsumenten pinnen ein Datum-Tag und bumpen via Renovate, hatten aber keine zentrale Stelle, um zu erfahren *was* bricht. Dokumentiert zwei Regeln:

1. **Breaking Changes werden explizit markiert** — `### ⚠ BREAKING`-Heading im jeweiligen dated CHANGELOG-Eintrag mit betroffenem Workflow + Ein-Zeilen-Migration. Single source of truth vor jedem Tag-Bump.
2. **Nur das jeweils letzte Tag wird supported** — ältere Tags bleiben immutable, aber Fixes/Security-Patches landen nur auf `main`/neuestem Tag. Keine Backports.

Konvention zusätzlich in den AGENTS.md-Release-Prozess gespiegelt.

Notion-Ideen: *Breaking-Change-Channel für Konsumenten* (umgesetzt) + *Deprecate-Pfad für alte Tags* (als Support-Policy hier mit-absorbiert).