### PR TITLE
fix(deploy-terraform): block fork PRs before loading secrets

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -143,6 +143,25 @@ jobs:
       drift_detected: ${{ steps.plan.outputs.drift_detected }}
 
     steps:
+      # Fork guard — fail fast BEFORE any checkout or Bitwarden retrieval.
+      # This reusable pulls R2 + Authentik/Grafana secrets from Bitwarden. On
+      # a `pull_request` from a forked repository, a malicious .tf change (or
+      # provider/external hook) could exfiltrate those secrets during the plan
+      # before a human reviews the diff. Same-repo PRs, push, schedule and
+      # workflow_dispatch are unaffected (the condition is only ever true for
+      # a fork-originated pull_request). The fork flag is consumed via env to
+      # avoid interpolating event data directly into the shell.
+      - name: 'Fork Guard'
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          echo "::error::deploy-terraform.yml refuses to run on a pull_request" \
+               "from a fork ($HEAD_REPO): it would load R2/Authentik secrets" \
+               "from Bitwarden before the diff is reviewed. Run plan/apply from" \
+               "a branch in the base repository instead."
+          exit 1
+
       - name: 'Repository Checkout'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ## 2026-06-10
 
+### Security
+
+- **deploy-terraform.yml**: Add a fork guard as the first step of the
+  `deploy` job. The workflow retrieves R2 and Authentik/Grafana secrets from
+  Bitwarden; on a `pull_request` from a forked repository a malicious `.tf`
+  change could exfiltrate them during the plan before review. The guard fails
+  fast (before checkout and the Bitwarden step) when
+  `github.event_name == 'pull_request'` and
+  `github.event.pull_request.head.repo.fork` is true. **Consumers:** no action
+  needed — same-repo PRs, `push`, `schedule` and `workflow_dispatch` are
+  unaffected; only fork-originated pull requests are blocked (they previously
+  would have loaded secrets). Not breaking for any current caller, which all
+  run from branches in the base repository.
+
 ### Added
 
 - **ai-claude-review.yml**: New optional `model` input (default


### PR DESCRIPTION
## Problem

`deploy-terraform.yml` retrieves R2 + Authentik/Grafana secrets from Bitwarden (`Credential Retrieval` step). On a `pull_request` from a **forked** repository, a malicious `.tf` change (or an external provider hook) could exfiltrate those secrets during the plan, before a human reviews the diff. Surfaced via the `authentication` board (Experten-Audit: Security): the consumer's `pull-request.yml` calls this reusable in `drift` mode for PR plans.

## Fix

Add a **Fork Guard** as the first step of the `deploy` job — before checkout and the Bitwarden step — that fails fast when:

```yaml
github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
```

- Same-repo PRs, `push`, `schedule`, `workflow_dispatch` → **unaffected** (condition only ever true for a fork-originated PR).
- The fork's repo name is read via `env:` (`HEAD_REPO`), not interpolated into the shell — per the workflow-injection guidance.
- Fails before any secret is fetched, so nothing leaks.

## Breaking?

No. Every current consumer runs plan/apply from branches in the base repo (private repos, no fork PRs today). This only blocks a path that would otherwise leak secrets. Logged under `### Security` in CHANGELOG `2026-06-10`, not `⚠ BREAKING`.

## Test

- `actionlint .github/workflows/deploy-terraform.yml` → exit 0
- YAML parse ✅

## Follow-up

A new date tag must be cut so consumers (`authentication` et al.) pick this up via Renovate — current pin is `@2026-06-10`.