### PR TITLE
feat(e2e-dde): rework dde reusable workflow and actions

### DIFF
--- a/.github/actions/project/action.yml
+++ b/.github/actions/project/action.yml
@@ -8,11 +8,11 @@ branding:
 
 inputs:
   command:
-    description: 'dde project subcommand to run (up, down, restart, update, ...). Determines whether `system-install` and `wait-url` apply.'
+    description: 'dde project subcommand to run (up, down, stop, update, ...). Determines whether `system-install`, `pre-pull-images` and `wait-url` apply.'
     required: false
     default: 'up'
   version:
-    description: 'dde version to install (e.g. v2.0.0-alpha.5) or "latest"'
+    description: 'dde version to install (e.g. v2.0.0-beta.2) or "latest". Pin an exact tag in CI — "latest" follows pre-releases, so breaking dde changes propagate immediately.'
     required: false
     default: 'latest'
   working-directory:
@@ -25,6 +25,15 @@ inputs:
     default: 'true'
   system-install:
     description: 'Run `dde system:install` to set up the host (Traefik, mkcert CA, dnsmasq). Only applied when `command: up`; ignored otherwise.'
+    required: false
+    default: 'true'
+  pre-pull-images:
+    description: >-
+      Pre-pull all compose images (every profile) before `project:up`.
+      dde's dev-layer build probes each image with a 30-second timeout;
+      on a cold image cache — every fresh CI runner — pulling a larger
+      image inside that probe exceeds the limit and fails the up. Only
+      applied when `command: up`; ignored otherwise.
     required: false
     default: 'true'
   wait-url:
@@ -88,6 +97,26 @@ runs:
         system-install: ${{ inputs.command == 'up' && inputs.system-install || 'false' }}
         github-token: ${{ inputs.github-token }}
         repository: ${{ inputs.repository }}
+
+    # dde's dev-layer build probes every compose image (all profiles, even
+    # inactive ones) with a 30s `docker run … exit 0` timeout. On a cold
+    # image cache pulling a larger image (grafana, loki, ...) inside that
+    # probe exceeds the timeout and fails project:up before the stack
+    # starts. Pre-pull all pinned images so the probe only ever runs
+    # already-present ones. Best-effort by design: every failure path
+    # exits 0 — a missing directory or compose file is re-checked with a
+    # friendly ::error:: in the next step, and a pull failure surfaces
+    # with proper context during project:up.
+    - name: Pre-pull compose images
+      if: inputs.command == 'up' && inputs.pre-pull-images == 'true'
+      shell: bash
+      env:
+        WD: ${{ inputs.working-directory }}
+      run: |
+        set -uo pipefail
+        cd "$WD" 2>/dev/null || exit 0
+        docker compose config --quiet >/dev/null 2>&1 || exit 0
+        docker compose --profile '*' pull --ignore-buildable --quiet || true
 
     # cd is done inside the script (not via working-directory:) so that a
     # missing/typo'd working-directory produces our friendly ::error::

--- a/.github/actions/setup-dde/action.yml
+++ b/.github/actions/setup-dde/action.yml
@@ -8,7 +8,7 @@ branding:
 
 inputs:
   version:
-    description: 'dde version to install (e.g. v2.0.0-alpha.5) or "latest"'
+    description: 'dde version to install (e.g. v2.0.0-beta.2) or "latest". Pin an exact tag in CI — "latest" follows pre-releases, so breaking dde changes propagate immediately.'
     required: false
     default: 'latest'
   install-mkcert:

--- a/.github/workflows/e2e-dde.yml
+++ b/.github/workflows/e2e-dde.yml
@@ -94,7 +94,7 @@ on:
         description: |
           Bash command(s) to capture diagnostics on test failure. When
           non-empty, replaces the default `dde project:logs` capture
-          (`dde project:ps` still runs into `dde-ps.txt`). Output is
+          (`dde project:status` still runs into `dde-status.txt`). Output is
           written to `$RUNNER_TEMP/dde-logs.txt` (overwritten, not
           appended). Runs in the project directory. Useful for
           plugin-driven log helpers like `dde project:e2e:logs -- 200`.
@@ -185,7 +185,7 @@ jobs:
       - name: Show running services
         working-directory: ${{ inputs.project-directory }}
         continue-on-error: true
-        run: dde project:ps
+        run: dde project:status
 
       # ----- Playwright -----
       - name: Setup Node.js
@@ -277,26 +277,26 @@ jobs:
         run: |
           if ! command -v dde >/dev/null 2>&1; then
             echo "dde was never installed — see 'Bring dde project up' step output" \
-              | tee "$RUNNER_TEMP/dde-logs.txt" "$RUNNER_TEMP/dde-ps.txt"
+              | tee "$RUNNER_TEMP/dde-logs.txt" "$RUNNER_TEMP/dde-status.txt"
             exit 0
           fi
           if [ ! -d "$PROJECT_DIR" ]; then
             echo "project-directory '$PROJECT_DIR' does not exist" \
-              | tee "$RUNNER_TEMP/dde-logs.txt" "$RUNNER_TEMP/dde-ps.txt"
+              | tee "$RUNNER_TEMP/dde-logs.txt" "$RUNNER_TEMP/dde-status.txt"
             exit 0
           fi
           cd "$PROJECT_DIR"
           if [ -n "$LOGS_OVERRIDE" ]; then
             # Override mode: caller owns log collection (e.g. a
             # `dde project:e2e:logs -- 200` plugin). We still write
-            # dde-ps.txt from the standard `project:ps` so the artifact
+            # dde-status.txt from the standard `project:status` so the artifact
             # bundle stays useful even when the override only captures
             # service logs.
             bash -c "$LOGS_OVERRIDE" > "$RUNNER_TEMP/dde-logs.txt" 2>&1 || true
-            dde project:ps           > "$RUNNER_TEMP/dde-ps.txt"   2>&1 || true
+            dde project:status       > "$RUNNER_TEMP/dde-status.txt"   2>&1 || true
           else
             dde project:logs > "$RUNNER_TEMP/dde-logs.txt" 2>&1 || true
-            dde project:ps   > "$RUNNER_TEMP/dde-ps.txt"   2>&1 || true
+            dde project:status > "$RUNNER_TEMP/dde-status.txt"   2>&1 || true
           fi
 
       - name: Upload Playwright report
@@ -324,7 +324,7 @@ jobs:
           name: dde-logs
           path: |
             ${{ runner.temp }}/dde-logs.txt
-            ${{ runner.temp }}/dde-ps.txt
+            ${{ runner.temp }}/dde-status.txt
           retention-days: ${{ inputs.artifact-retention-days }}
           if-no-files-found: ignore
 

--- a/.github/workflows/e2e-dde.yml
+++ b/.github/workflows/e2e-dde.yml
@@ -9,7 +9,11 @@ on:
         type: string
         required: false
         default: 'latest'
-        description: 'dde version to install (e.g. v2.0.0-alpha.5) or "latest"'
+        description: |
+          dde version to install (e.g. v2.0.0-beta.2) or "latest". Pin an
+          exact tag — "latest" follows pre-releases, so breaking dde
+          changes (e.g. the alpha→beta plugin-namespace rename) propagate
+          to the pipeline immediately.
       project-directory:
         type: string
         required: false
@@ -94,10 +98,11 @@ on:
         description: |
           Bash command(s) to capture diagnostics on test failure. When
           non-empty, replaces the default `dde project:logs` capture
-          (`dde project:status` still runs into `dde-status.txt`). Output is
-          written to `$RUNNER_TEMP/dde-logs.txt` (overwritten, not
-          appended). Runs in the project directory. Useful for
-          plugin-driven log helpers like `dde project:e2e:logs -- 200`.
+          (`dde project:status` and `docker ps -a` still run into
+          `dde-status.txt` / `docker-ps.txt`). Output is written to
+          `$RUNNER_TEMP/dde-logs.txt` (overwritten, not appended). Runs
+          in the project directory. Useful for plugin-driven log helpers
+          like `dde project:e2e:logs -- 200`.
       teardown-command:
         type: string
         required: false
@@ -275,6 +280,11 @@ jobs:
           PROJECT_DIR: ${{ inputs.project-directory }}
           LOGS_OVERRIDE: ${{ inputs.failure-logs-command }}
         run: |
+          # Raw container state first — unlike the dde calls below this
+          # works even when dde itself never installed or is broken, and
+          # it is the one signal that always tells whether the stack came
+          # up at all.
+          docker ps -a > "$RUNNER_TEMP/docker-ps.txt" 2>&1 || true
           if ! command -v dde >/dev/null 2>&1; then
             echo "dde was never installed — see 'Bring dde project up' step output" \
               | tee "$RUNNER_TEMP/dde-logs.txt" "$RUNNER_TEMP/dde-status.txt"
@@ -325,6 +335,7 @@ jobs:
           path: |
             ${{ runner.temp }}/dde-logs.txt
             ${{ runner.temp }}/dde-status.txt
+            ${{ runner.temp }}/docker-ps.txt
           retention-days: ${{ inputs.artifact-retention-days }}
           if-no-files-found: ignore
 
@@ -372,15 +383,23 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PROJECT_DIRECTORY: ${{ inputs.project-directory }}
+          CONCURRENCY_SUFFIX: ${{ inputs.concurrency-suffix }}
           DDE_VERSION: ${{ needs.e2e-dde.outputs.dde-version }}
           JOB_STATUS: ${{ needs.e2e-dde.result }}
         with:
           script: |
             const projectDir = process.env.PROJECT_DIRECTORY;
+            const suffix = process.env.CONCURRENCY_SUFFIX;
             const ddeVersion = process.env.DDE_VERSION;
             const jobStatus = process.env.JOB_STATUS;
 
-            let comment = '## 🎭 E2E Test Results (dde)\n\n';
+            // Hidden marker so re-runs update their own comment instead of
+            // stacking a new one per push. Project directory and the
+            // concurrency suffix keep parallel invocations (matrix legs,
+            // multi-project repos) on separate comments.
+            const marker = `<!-- e2e-dde-results:${projectDir}:${suffix} -->`;
+
+            let comment = `${marker}\n## 🎭 E2E Test Results (dde)\n\n`;
             comment += `**Project**: \`${projectDir}\`\n`;
             comment += `**dde**: \`${ddeVersion}\`\n\n`;
 
@@ -396,9 +415,28 @@ jobs:
               comment += `View the [test results](${runUrl}) for details.\n`;
             }
 
-            await github.rest.issues.createComment({
+            const { data: comments } = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: comment
+              per_page: 100
             });
+            const existing = comments.find(
+              (c) => c.body && c.body.startsWith(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                comment_id: existing.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: comment
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: comment
+              });
+            }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,16 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   tag support policy (see the section at the top of this file). Breaking
   changes now carry a `### ⚠ BREAKING` heading with a migration step; only
   the latest date tag is supported.
+- **actions/project**: New `pre-pull-images` input (default `true`). Before
+  `project:up` the action now pre-pulls all compose images (every profile)
+  via `docker compose --profile '*' pull --ignore-buildable --quiet`. dde's
+  dev-layer build probes each image with a 30-second `docker run` timeout;
+  on a cold image cache — every fresh CI runner — pulling a larger image
+  (grafana, loki, …) inside that probe exceeded the timeout and failed
+  `project:up` before the stack started (reproduced with sbaerlocher/savvy's
+  observability images). Best-effort: pull failures fall through to
+  `project:up`, which reports them with proper context. **Consumers:** no
+  action needed; set `pre-pull-images: false` to restore the old behaviour.
 
 ### Changed
 
@@ -60,6 +70,17 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   invocations, and the Renovate datasource annotation are updated together.
   **Consumers:** no action needed — the license-check job behaviour and
   output artifacts are unchanged.
+- **e2e-dde.yml**: The PR results comment is now updated in place instead
+  of posting a new comment on every run. A hidden marker — keyed by
+  `project-directory` and `concurrency-suffix`, so matrix legs keep
+  separate comments — identifies the workflow's own comment; the first run
+  still creates it. **Consumers:** no action needed — long-running PRs
+  stop accumulating one results comment per push.
+- **e2e-dde.yml**: Failure diagnostics additionally capture raw
+  `docker ps -a` into `docker-ps.txt` in the `dde-logs` artifact. Unlike
+  the `dde project:logs` / `dde project:status` calls this works even when
+  dde itself never installed, and it is the one signal that always shows
+  whether the stack came up at all.
 
 ### Fixed
 
@@ -104,6 +125,11 @@ terraform-provider package registry.terraform.io/<ns>/<name>: no-result`
   command. **Consumers:** no action needed unless tooling greps the
   `dde-logs` artifact for the literal `dde-ps.txt` filename — update it to
   `dde-status.txt`.
+- **actions/project, actions/setup-dde**: Input docs no longer advertise
+  `restart` (dde v2 has no `project:restart`; the real lifecycle commands
+  are `up`, `down`, `stop`, `update`) and now recommend pinning an exact
+  dde tag in CI instead of `latest`, which follows pre-releases and lets
+  breaking dde changes propagate immediately.
 
 ## 2026-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,18 @@ terraform-provider package registry.terraform.io/<ns>/<name>: no-result`
   update, not datasource lookup. Disabling only the `.terraform.lock.hcl`
   source (`matchFileNames` + `enabled: false`) clears the warning without
   affecting provider tracking or lock updates.
+- **e2e-dde.yml**: Replace `dde project:ps` with `dde project:status` in the
+  "Show running services" step and the failure-diagnostics collection.
+  `project:ps` does not exist in dde v2 — every invocation failed with
+  `Command "project:ps" is not defined`, so the step printed an error
+  instead of the service list and the `dde-ps.txt` file in the `dde-logs`
+  artifact only contained that usage error (observed in sbaerlocher/savvy
+  PR #102 run artifacts). All call sites were
+  `continue-on-error`/`|| true`-guarded, so job results are unchanged. The
+  artifact file is renamed `dde-ps.txt` → `dde-status.txt` to match the
+  command. **Consumers:** no action needed unless tooling greps the
+  `dde-logs` artifact for the literal `dde-ps.txt` filename — update it to
+  `dde-status.txt`.
 
 ## 2026-06-09
 


### PR DESCRIPTION
## Summary

Rework of the dde E2E pipeline, driven by findings from running it end-to-end on sbaerlocher/savvy PR #102:

- **Fix broken diagnostics**: `dde project:ps` does not exist in dde v2 (`Command "project:ps" is not defined`) — the "Show running services" step and the failure-diagnostics collection always failed silently (`continue-on-error`/`|| true`-guarded). All call sites now use `dde project:status`; the artifact file is renamed `dde-ps.txt` → `dde-status.txt`.
- **actions/project: pre-pull compose images before `project:up`** (new `pre-pull-images` input, default `true`). dde's dev-layer build probes every compose image with a 30s `docker run` timeout; on a cold cache — every fresh CI runner — pulling larger images (grafana, loki, …) inside that probe exceeds the timeout and fails `project:up` before the stack starts (reproduced with savvy's observability images). Best-effort: pull failures fall through to `project:up` for proper error context.
- **e2e-dde.yml: PR comment upsert** — the results comment is updated in place via a hidden marker (keyed by `project-directory` + `concurrency-suffix`, so matrix legs keep separate comments) instead of stacking one comment per push.
- **e2e-dde.yml: `docker ps -a` fallback diagnostics** into `docker-ps.txt` — works even when dde itself never installed (the failing-savvy-run artifact was a useless 658 bytes), and always shows whether the stack came up.
- **Docs**: drop `restart` from the command examples (dde v2 has no `project:restart`; lifecycle commands are `up`, `down`, `stop`, `update`); recommend pinning an exact dde tag over `latest` (pre-release follows caused the alpha→beta plugin-namespace break to propagate).

## Test plan

- [x] `dde project:status` confirmed in dde v2.0.0-beta.1 (command list in failing run artifact) and v2.0.0-beta.2 (`dde list`)
- [x] `docker compose --profile '*' pull --ignore-buildable --quiet` verified locally against savvy (skips buildable services, warm-cache no-op in <1s)
- [x] `actionlint` and YAML parse clean on all three files
- [x] No `project:ps` / `dde-ps` references left in the repo
- [ ] CI green
- [ ] Verified end-to-end via the next date tag in a consumer repo (sbaerlocher/savvy)