### PR TITLE
chore(repo): harden workflow repository defaults

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,5 +7,7 @@
 # Renovate presets affect all repos - require review
 /renovate-*.json @sbaerlocher
 
-# Standards affect all repos - require review
-/STANDARDS.md @sbaerlocher
+# Repository standards and review guidance affect all consumers
+/AGENTS.md @sbaerlocher
+/REVIEW.md @sbaerlocher
+/SECURITY.md @sbaerlocher

--- a/.github/actions/project/action.yml
+++ b/.github/actions/project/action.yml
@@ -81,7 +81,7 @@ runs:
     # re-provision the host on every lifecycle step.
     - name: Setup dde
       id: setup
-      uses: sbaerlocher/.github/.github/actions/setup-dde@2026-05-30
+      uses: sbaerlocher/.github/.github/actions/setup-dde@2026-06-10
       with:
         version: ${{ inputs.version }}
         install-mkcert: ${{ inputs.install-mkcert }}

--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -81,8 +81,10 @@ on:
         required: false
         default: ''
         description: |
-          Optional bash script to run before Terraform init.
+          Optional trusted bash script to run before Terraform init.
           Useful for generating dynamic credentials (e.g., Tailscale API key from OAuth).
+          This input executes as shell code and must only be set by trusted
+          caller workflows, never from PR-controlled data.
           Script has access to all env vars from bw-secrets and env-mapping.
           Export vars as: echo "VAR_NAME=value" >> $GITHUB_ENV
       cancel-in-progress:
@@ -171,6 +173,8 @@ jobs:
           secrets: ${{ inputs.bw-secrets }}
 
       - name: 'Environment Configuration'
+        env:
+          ENV_MAPPING: ${{ inputs.env-mapping }}
         run: |
           # R2 backend credentials (always required)
           {
@@ -180,22 +184,24 @@ jobs:
           } >> "$GITHUB_ENV"
 
           # Map Bitwarden secrets to Terraform/runtime variables
-          if [ -n "${{ inputs.env-mapping }}" ]; then
+          if [ -n "$ENV_MAPPING" ]; then
             while IFS= read -r line; do
               [ -z "$line" ] && continue
               src=$(echo "$line" | awk -F'>' '{print $1}' | xargs)
               dst=$(echo "$line" | awk -F'>' '{print $2}' | xargs)
               value="${!src}"
               [ -n "$value" ] && echo "$dst=$value" >> "$GITHUB_ENV"
-            done <<< "${{ inputs.env-mapping }}"
+            done <<< "$ENV_MAPPING"
             echo "Environment variable mapping complete"
           fi
 
       - name: 'Pre-Script Execution'
         if: inputs.pre-script != ''
+        env:
+          PRE_SCRIPT: ${{ inputs.pre-script }}
         run: |
           echo "Executing pre-script..."
-          ${{ inputs.pre-script }}
+          bash -Eeuo pipefail -c "$PRE_SCRIPT"
           echo "Pre-script execution complete"
 
       - name: 'Terraform Initialization'

--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -201,7 +201,7 @@ jobs:
           PRE_SCRIPT: ${{ inputs.pre-script }}
         run: |
           echo "Executing pre-script..."
-          bash -Eeuo pipefail -c "$PRE_SCRIPT"
+          bash -Eeo pipefail -c "$PRE_SCRIPT"
           echo "Pre-script execution complete"
 
       - name: 'Terraform Initialization'

--- a/.github/workflows/e2e-dde.yml
+++ b/.github/workflows/e2e-dde.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Bring dde project up
         id: dde
-        uses: sbaerlocher/.github/.github/actions/project@2026-05-30
+        uses: sbaerlocher/.github/.github/actions/project@2026-06-10
         with:
           command: up
           version: ${{ inputs.dde-version }}

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -418,12 +418,11 @@ jobs:
 
       # The composite action lives in this repo, but `uses: ./` in a reusable
       # workflow resolves against the caller's checkout — not against this
-      # workflow's source repo. So we reference it absolutely. `@main` tracks
-      # the rolling release; Renovate's github-actions manager will pin this
-      # to the most recent date tag once one exists for the action.
+      # workflow's source repo. So we reference it absolutely and pin it to
+      # the same rolling date-tag model used by consumers.
       - name: Generate npm SBOM
         id: sbom
-        uses: sbaerlocher/.github/.github/actions/sbom-npm@main
+        uses: sbaerlocher/.github/.github/actions/sbom-npm@2026-06-10
         with:
           package-manager: ${{ inputs.package-manager }}
           working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/security-sbom.yml
+++ b/.github/workflows/security-sbom.yml
@@ -110,12 +110,12 @@ jobs:
       # NPM Package SBOM — uses the shared composite action so this step
       # stays in lockstep with the SBOM job in release-npm.yml. `uses: ./`
       # in a reusable workflow resolves against the caller's checkout, so
-      # we reference the action absolutely. `@main` rides the rolling
-      # release; Renovate updates this once tagged versions exist.
+      # we reference the action absolutely and pin it to the same rolling
+      # date-tag model used by consumers.
       - name: Generate npm SBOM
         if: inputs.artifact-type == 'npm-package'
         id: sbom-npm
-        uses: sbaerlocher/.github/.github/actions/sbom-npm@main
+        uses: sbaerlocher/.github/.github/actions/sbom-npm@2026-06-10
         with:
           package-manager: ${{ inputs.package-manager }}
           working-directory: ${{ inputs.working-directory }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,12 @@ Thumbs.db
 
 # IDE
 .idea/
-.vscode/
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/mcp.json
 *.swp
 *.swo
 *~

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,12 @@
+---
+extends: default
+
+rules:
+  comments: disable
+  document-start: disable
+  line-length: disable
+  truthy:
+    check-keys: false
+
+ignore: |
+  .git/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,11 +312,12 @@ change. Not reusable from consumer repos.
 Located under [`.github/actions/`](./.github/actions/). Consume from any
 workflow via `sbaerlocher/.github/.github/actions/<name>@<DATE-TAG>`.
 
-| Action      | File                          | Purpose                                                       |
-| ----------- | ----------------------------- | ------------------------------------------------------------- |
-| `setup-dde` | `.github/actions/setup-dde/`  | Install whatwedo dde CLI; optional mkcert + `system:install`  |
-| `project`   | `.github/actions/project/`    | Install dde + run any `dde project:<command>` (default `up`)  |
-| `sbom-npm`  | `.github/actions/sbom-npm/`   | CycloneDX SBOM for npm/pnpm/yarn/bun (internal helper)        |
+| Action                           | File                                                | Purpose                                                       |
+| -------------------------------- | --------------------------------------------------- | ------------------------------------------------------------- |
+| `setup-dde`                      | `.github/actions/setup-dde/`                        | Install whatwedo dde CLI; optional mkcert + `system:install`  |
+| `project`                        | `.github/actions/project/`                          | Install dde + run any `dde project:<command>` (default `up`)  |
+| `sbom-npm`                       | `.github/actions/sbom-npm/`                         | CycloneDX SBOM for npm/pnpm/yarn/bun (internal helper)        |
+| `validate-observability-configs` | `.github/actions/validate-observability-configs/`   | Validate Grafana Alloy and JSON observability configs         |
 
 ### dde actions (`setup-dde`, `project`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ This is a rolling release - changes are deployed continuously to `main`.
 
 ---
 
+## Unreleased
+
+### Changed
+
+- **internal action refs**: Replace remaining `@main` references for
+  `sbom-npm` with the date tag `@2026-06-10`, and align the dde internal
+  action refs with the same date-tag model.
+- **deploy-terraform.yml**: Pass `env-mapping` and `pre-script` through
+  environment variables before shell execution, and document `pre-script` as a
+  trusted-only escape hatch.
+- **repo metadata**: Add `CONTRIBUTING.md`, `lefthook.yml`, and `.yamllint`;
+  update CODEOWNERS and AGENTS.md to match the current repo structure.
+
 ## 2026-06-10
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+## Workflow
+
+All changes go through a feature branch and pull request. Do not commit
+directly to `main`.
+
+Use a focused branch name such as `fix/workflow-permissions` or
+`chore/renovate-preset-cleanup`.
+
+## Commits
+
+Commit messages follow Conventional Commits:
+
+```text
+<type>(<scope>): <subject>
+```
+
+Common types are `feat`, `fix`, `docs`, `ci`, `chore`, `refactor`, `test`,
+and `style`. Keep the subject lowercase, specific, and without trailing
+punctuation.
+
+Sign and sign off commits:
+
+```bash
+git commit -S --signoff
+```
+
+## Pull Requests
+
+PR titles use the same Conventional Commits subject format.
+
+Before opening a PR:
+
+- run the relevant local checks where practical
+- update `README.md`, `AGENTS.md`, and `CHANGELOG.md` when behavior changes
+- pin GitHub Actions to full commit SHA with a version comment
+- use date tags for reusable workflows and internal composite actions
+- document breaking changes and consumer migration notes
+
+## Local Checks
+
+This repository is mostly YAML, Markdown, and Renovate JSON. Recommended
+checks:
+
+```bash
+yamllint .github/workflows .github/actions .github/ISSUE_TEMPLATE
+jq empty renovate.json .github/renovate.json renovate-*.json
+```
+
+If `lefthook` is installed, enable local hooks with:
+
+```bash
+lefthook install
+```

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,25 @@
+---
+pre-commit:
+  commands:
+    protect-main:
+      run: |
+        branch=$(git rev-parse --abbrev-ref HEAD)
+        case "$branch" in
+          main|master)
+            echo "Direct commits to $branch are blocked. Create a feature branch and open a PR."
+            exit 1
+            ;;
+        esac
+
+    yaml:
+      glob: "*.{yml,yaml}"
+      run: |
+        if command -v yamllint >/dev/null 2>&1; then
+          yamllint {staged_files}
+        else
+          echo "yamllint not installed; skipping YAML lint"
+        fi
+
+    json:
+      glob: "*.json"
+      run: jq empty {staged_files}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -23,5 +23,5 @@ pre-commit:
     json:
       # Strict JSON only — exclude .vscode/*.json (JSONC: comments/trailing commas
       # are idiomatic there and `jq empty` would reject them).
-      glob: "{renovate*.json,.github/**/*.json,package.json,tsconfig*.json}"
+      glob: "{renovate*.json,.github/**/*.json,package.json}"
       run: jq empty {staged_files}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,5 +21,7 @@ pre-commit:
         fi
 
     json:
-      glob: "*.json"
+      # Strict JSON only — exclude .vscode/*.json (JSONC: comments/trailing commas
+      # are idiomatic there and `jq empty` would reject them).
+      glob: "{renovate*.json,.github/**/*.json,package.json,tsconfig*.json}"
       run: jq empty {staged_files}


### PR DESCRIPTION
## Summary

- Pin internal reusable action references to date tags (project, e2e-dde, release-npm, security-sbom) to stop drifting against `@main`
- Reduce direct shell interpolation in the Terraform deploy workflow
- Add local contribution and lint guardrails (CONTRIBUTING.md, .yamllint, lefthook.yml, .gitignore) for this central workflow repo

## Test plan

- [ ] CI green
- [ ] yamllint passes on changed workflows
- [ ] lefthook hooks run clean locally