### PR TITLE
docs(templates): add Keep-a-Changelog CHANGELOG template

### DIFF
--- a/.github/templates/CHANGELOG.md
+++ b/.github/templates/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!--
+Org convention (sbaerlocher / arillso):
+
+- Newest entries on top. Keep an `## [Unreleased]` section at the top and move
+  its content into a dated, versioned heading on release.
+- Group changes under the Keep-a-Changelog categories, in this order, omitting
+  empty ones: Added, Changed, Deprecated, Removed, Fixed, Security.
+- One bullet per change. Lead with the affected component in bold
+  (`**role-name**:` / `**workflow.yml**:`), then what changed and why a
+  consumer cares — not just a subject paraphrase.
+- Breaking changes get a `### ⚠ BREAKING` sub-heading inside the version entry,
+  naming the affected surface and a one-line migration step.
+
+This template is the org default. Repos with a different cadence
+(e.g. the rolling date-tag model in sbaerlocher/.github itself) document the
+deviation in their own header instead of copying this verbatim.
+-->
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Security
+
+## [0.0.0] - YYYY-MM-DD
+
+### Added
+
+- Initial release.


### PR DESCRIPTION
## Summary

Add a Keep-a-Changelog `CHANGELOG.md` template under `.github/templates/`,
with an embedded comment block documenting the org convention (newest on top,
`## [Unreleased]`, Keep-a-Changelog categories, breaking-change sub-heading).

Repos with a different cadence (e.g. `.github` itself) document the deviation
in their own header rather than copying verbatim.