### PR TITLE
docs(templates): add vitest projects template for cloudflare workers

### DIFF
--- a/.github/templates/vitest-cloudflare-workers/README.md
+++ b/.github/templates/vitest-cloudflare-workers/README.md
@@ -32,8 +32,11 @@ Unit tests stay co-located with source (`src/**/*.test.ts`).
 2. Install dev deps:
 
    ```bash
-   pnpm add -D vitest @vitest/coverage-v8 @cloudflare/vitest-pool-workers happy-dom
+   pnpm add -D vitest @vitest/coverage-istanbul @cloudflare/vitest-pool-workers happy-dom
    ```
+
+   Coverage uses **istanbul**, not v8 — the Workers pool can't run v8 coverage
+   (no functional `node:inspector` in workerd) and throws if you try.
 
    Reference versions (sbaerlo.ch, 2026-06): `vitest@4`,
    `@cloudflare/vitest-pool-workers@0.16`, `happy-dom@20`. Match your prod
@@ -43,11 +46,13 @@ Unit tests stay co-located with source (`src/**/*.test.ts`).
 
    ```jsonc
    {
-     "test": "vitest run --project unit",
-     "test:unit": "vitest run --project unit",
-     "test:integration": "vitest run --project integration",
-     "test:watch": "vitest --project unit",
-     "test:coverage": "vitest run --coverage"
+     "scripts": {
+       "test": "vitest run --project unit",
+       "test:unit": "vitest run --project unit",
+       "test:integration": "vitest run --project integration",
+       "test:watch": "vitest --project unit",
+       "test:coverage": "vitest run --coverage"
+     }
    }
    ```
 

--- a/.github/templates/vitest-cloudflare-workers/README.md
+++ b/.github/templates/vitest-cloudflare-workers/README.md
@@ -1,0 +1,78 @@
+# Vitest Projects Template — Cloudflare Astro/Worker
+
+Org template for testing a Cloudflare Worker (typically an Astro SSR app) with
+two Vitest **projects** in one config:
+
+| Project       | Runs                                   | Speed | What it catches                          |
+| ------------- | -------------------------------------- | ----- | ---------------------------------------- |
+| `unit`        | plain logic in a DOM-ish env, no Worker | fast  | pure functions, components, lib code     |
+| `integration` | the **built** worker inside Miniflare  | slow  | routing, rendering, service bindings     |
+
+The integration project loads the real build output and serves any outbound
+service binding from a **mock upstream worker**, so the worker is exercised
+end-to-end without hitting a live backend.
+
+Extracted from `sbaerlocher/sbaerlo.ch`.
+
+## Files
+
+```text
+vitest.config.ts                      # the two-project setup (unit + integration)
+wrangler.test.jsonc                   # test-only wrangler config, fake ids, mock service
+tests/env.d.ts                        # types for exports.default + Cloudflare.Env
+tests/integration/mock-upstream.mjs   # mock for the outbound service binding
+tests/integration/example.test.ts     # integration test skeleton
+```
+
+Unit tests stay co-located with source (`src/**/*.test.ts`).
+
+## Adopt
+
+1. Copy the files above into the repo root (keep the `tests/` layout).
+2. Install dev deps:
+
+   ```bash
+   pnpm add -D vitest @vitest/coverage-v8 @cloudflare/vitest-pool-workers happy-dom
+   ```
+
+   Reference versions (sbaerlo.ch, 2026-06): `vitest@4`,
+   `@cloudflare/vitest-pool-workers@0.16`, `happy-dom@20`. Match your prod
+   `wrangler` major.
+
+3. Add scripts to `package.json`:
+
+   ```jsonc
+   {
+     "test": "vitest run --project unit",
+     "test:unit": "vitest run --project unit",
+     "test:integration": "vitest run --project integration",
+     "test:watch": "vitest --project unit",
+     "test:coverage": "vitest run --coverage"
+   }
+   ```
+
+4. Walk the `── adjust ──` markers in `vitest.config.ts` and
+   `wrangler.test.jsonc`:
+   - unit project: framework plugin (`svelte()`/`react()`/none), `environment`,
+     `setupFiles`, coverage `include`/`exclude`.
+   - integration: outbound service name (must match across `vitest.config.ts`
+     `outboundService`, the mock worker `name`, and `wrangler.test.jsonc`
+     `services[].service`), `compatibility_date`/`flags` (mirror prod).
+   - `wrangler.test.jsonc`: `name`, `main`, bindings — same shape as prod
+     `wrangler.jsonc` with fake ids.
+   - `mock-upstream.mjs`: the path it matches and the fixtures it returns.
+
+5. Replace `example.test.ts` with real assertions.
+
+## Notes
+
+- **No outbound service?** Drop the `outboundService`/`workers` block in
+  `vitest.config.ts`, the `services` array in `wrangler.test.jsonc`, and the
+  mock file. The integration project still runs the built worker.
+- **`dangerouslyIgnoreUnhandledErrors`** is only needed when the build compiles
+  WASM on import (common with Astro's `es-module-lexer`). Drop it otherwise —
+  see the inline comment.
+- Root-only knobs in vitest 4: `coverage` and
+  `dangerouslyIgnoreUnhandledErrors` cannot be set per-project.
+- The integration project needs the worker **built first**
+  (`pnpm build`) — `dist/` must exist before `test:integration`.

--- a/.github/templates/vitest-cloudflare-workers/tests/env.d.ts
+++ b/.github/templates/vitest-cloudflare-workers/tests/env.d.ts
@@ -3,7 +3,7 @@
 declare namespace Cloudflare {
   interface Env {
     // ── adjust: the vars/bindings your worker reads, mirrored from wrangler ──
-    GRAPHQL_ENDPOINT: string;
+    UPSTREAM_ENDPOINT: string;
   }
 
   // Make `exports.default` from `cloudflare:workers` resolve to the loopback

--- a/.github/templates/vitest-cloudflare-workers/tests/env.d.ts
+++ b/.github/templates/vitest-cloudflare-workers/tests/env.d.ts
@@ -1,0 +1,16 @@
+/// <reference types="@cloudflare/vitest-pool-workers/types" />
+
+declare namespace Cloudflare {
+  interface Env {
+    // ── adjust: the vars/bindings your worker reads, mirrored from wrangler ──
+    GRAPHQL_ENDPOINT: string;
+  }
+
+  // Make `exports.default` from `cloudflare:workers` resolve to the loopback
+  // Fetcher for your default-exported handler. Without this, `Cloudflare.Exports`
+  // is `{}` and `exports.default` is a type error. Augments the empty
+  // `GlobalProps` declared by `@cloudflare/workers-types`.
+  interface GlobalProps {
+    mainModule: { default: ExportedHandler<Cloudflare.Env> };
+  }
+}

--- a/.github/templates/vitest-cloudflare-workers/tests/integration/example.test.ts
+++ b/.github/templates/vitest-cloudflare-workers/tests/integration/example.test.ts
@@ -1,0 +1,27 @@
+import { exports } from "cloudflare:workers";
+import { describe, expect, test } from "vitest";
+
+// Loopback Fetcher for the worker's default export. `exports.default` is typed
+// via tests/env.d.ts. Calls hit the real built worker; its outbound service
+// binding is served by tests/integration/mock-upstream.mjs.
+const worker = exports.default;
+
+describe("worker — integration", () => {
+  test("serves a known route", async () => {
+    const res = await worker.fetch("https://example.com/");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/text\/html/);
+  });
+
+  test("renders data from the mock upstream", async () => {
+    const res = await worker.fetch("https://example.com/");
+    const html = await res.text();
+    // Assert against the fixture in mock-upstream.mjs.
+    expect(html).toContain("First");
+  });
+
+  test("unknown route 404s", async () => {
+    const res = await worker.fetch("https://example.com/does-not-exist");
+    expect(res.status).toBe(404);
+  });
+});

--- a/.github/templates/vitest-cloudflare-workers/tests/integration/mock-upstream.mjs
+++ b/.github/templates/vitest-cloudflare-workers/tests/integration/mock-upstream.mjs
@@ -1,0 +1,42 @@
+// Mock upstream worker — stands in for whatever service binding your worker
+// calls outbound (an API, a GraphQL endpoint, another worker). The integration
+// project routes the worker's outbound fetches here via `outboundService`.
+//
+// Pattern:
+//   - Match on the request shape (path + payload), not on incidental details
+//     like an operation name, so refactors don't silently break the mock.
+//   - Drive variant responses (ok / empty / fail) from an env binding (MODE)
+//     so a single test can flip behaviour without a second mock file.
+//
+// Replace the body below with your own fixtures and matching logic.
+
+const fixture = {
+  message: "hello from the mock upstream",
+  items: [
+    { id: "1", title: "First" },
+    { id: "2", title: "Second" },
+  ],
+};
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    // ── adjust: the path(s) your worker actually calls ──
+    if (url.pathname !== "/api/data") {
+      return new Response("not found", { status: 404 });
+    }
+
+    // MODE comes from `bindings.MODE` in vitest.config.ts. Override per test by
+    // re-running the worker with a different binding, or branch on a header.
+    const mode = env.MODE ?? "ok";
+    if (mode === "fail") {
+      return new Response("upstream error", { status: 500 });
+    }
+
+    return Response.json({
+      ...fixture,
+      items: mode === "empty" ? [] : fixture.items,
+    });
+  },
+};

--- a/.github/templates/vitest-cloudflare-workers/vitest.config.ts
+++ b/.github/templates/vitest-cloudflare-workers/vitest.config.ts
@@ -1,0 +1,94 @@
+import path from "node:path";
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
+
+// Org template: Vitest "projects" split for a Cloudflare Astro/Worker app.
+//
+// Two projects run side by side:
+//   - unit        — fast, runs in a DOM-ish env, no Worker runtime. Pure logic
+//                   under src/lib (or wherever your testable code lives).
+//   - integration — runs the BUILT worker inside Miniflare via the Cloudflare
+//                   vitest pool, with a mock-upstream worker standing in for
+//                   any outbound service binding.
+//
+// Adopt: copy this dir's files, then adjust the marked spots below. Most apps
+// only touch (1) the unit `plugins`/`environment`/`setupFiles`, (2) the
+// outbound service name, and (3) wrangler.test.jsonc.
+
+const mockUpstreamScript = path.resolve("tests/integration/mock-upstream.mjs");
+
+export default defineConfig({
+  test: {
+    // Root-only knobs (vitest 4 forbids these per-project) ───────────────
+    //
+    // The integration project loads the built worker, which may compile a
+    // WASM module on import (e.g. es-module-lexer in an Astro build). The
+    // Workers test sandbox forbids that and surfaces it as an unhandled
+    // rejection. The unit project never imports the built worker, so this
+    // suppression cannot mask a real unit failure — it only stops the WASM
+    // reject from flaking the exit code. Drop it if your build has no WASM.
+    dangerouslyIgnoreUnhandledErrors: true,
+
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      reportsDirectory: "./coverage",
+      // ── adjust: what you actually want covered ──
+      include: ["src/lib/**"],
+      exclude: ["src/lib/**/__tests__/**", "src/lib/types/**", "src/lib/config.ts"],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
+      },
+    },
+
+    projects: [
+      {
+        // ── adjust: framework plugin + env for your unit tests ──
+        // Svelte: plugins: [svelte()]  ·  React: [react()]  ·  none: drop it.
+        plugins: [],
+        test: {
+          name: "unit",
+          include: ["src/**/*.test.ts"],
+          // happy-dom is lighter than jsdom; use "node" if no DOM needed.
+          environment: "happy-dom",
+          // ── adjust or drop if you have no global test setup ──
+          setupFiles: ["./src/test-setup.ts"],
+        },
+      },
+      {
+        test: {
+          name: "integration",
+          include: ["tests/integration/**/*.test.ts"],
+        },
+        plugins: [
+          cloudflareTest({
+            wrangler: { configPath: "./wrangler.test.jsonc" },
+            miniflare: {
+              // ── adjust: the binding name your worker calls outbound ──
+              // Must match the `services[].service` in wrangler.test.jsonc and
+              // the worker `name` below. Drop this whole block if your worker
+              // has no outbound service binding to mock.
+              outboundService: "mock-upstream",
+              workers: [
+                {
+                  name: "mock-upstream",
+                  modules: true,
+                  modulesRoot: path.resolve("."),
+                  scriptPath: mockUpstreamScript,
+                  // ── adjust: keep in sync with your prod compat settings ──
+                  compatibilityDate: "2026-05-13",
+                  compatibilityFlags: ["nodejs_compat"],
+                  // Toggle mock behaviour from a test via env (see mock-upstream).
+                  bindings: { MODE: "ok" },
+                },
+              ],
+            },
+          }),
+        ],
+      },
+    ],
+  },
+});

--- a/.github/templates/vitest-cloudflare-workers/vitest.config.ts
+++ b/.github/templates/vitest-cloudflare-workers/vitest.config.ts
@@ -30,7 +30,11 @@ export default defineConfig({
     dangerouslyIgnoreUnhandledErrors: true,
 
     coverage: {
-      provider: "v8",
+      // The vitest-pool-workers runtime cannot do v8 coverage (it needs
+      // node:inspector, which workerd only stubs) — the pool throws on
+      // `provider: "v8"`. Use istanbul, which instruments at build time and
+      // runs anywhere. Install @vitest/coverage-istanbul.
+      provider: "istanbul",
       reporter: ["text", "lcov"],
       reportsDirectory: "./coverage",
       // ── adjust: what you actually want covered ──

--- a/.github/templates/vitest-cloudflare-workers/wrangler.test.jsonc
+++ b/.github/templates/vitest-cloudflare-workers/wrangler.test.jsonc
@@ -1,0 +1,25 @@
+{
+  // Test-only wrangler config: same shape as your real wrangler.jsonc, but with
+  // fake/local IDs and the outbound service repointed at the mock worker.
+  // Keep this in sync with prod wrangler.jsonc whenever bindings change.
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "my-worker",
+  "main": "./dist/server/entry.mjs",
+  "compatibility_date": "2026-05-13",
+  "compatibility_flags": ["nodejs_compat"],
+  // Astro adapter output. Adjust if your build emits elsewhere.
+  "assets": {
+    "directory": "./dist/client",
+    "binding": "ASSETS"
+  },
+  // Use a throwaway id for any KV/D1/R2 the worker declares — the test pool
+  // provisions a local store, the id just has to be present.
+  "kv_namespaces": [{ "binding": "SESSION", "id": "test-session" }],
+  "vars": {
+    // App vars the worker reads at runtime; fake values for tests.
+    "GRAPHQL_ENDPOINT": "https://example.com/api/graphql"
+  },
+  // Point every outbound service binding at the mock worker. The `service`
+  // value must match the mock worker `name` in vitest.config.ts.
+  "services": [{ "binding": "UPSTREAM", "service": "mock-upstream" }]
+}

--- a/.github/templates/vitest-cloudflare-workers/wrangler.test.jsonc
+++ b/.github/templates/vitest-cloudflare-workers/wrangler.test.jsonc
@@ -16,8 +16,9 @@
   // provisions a local store, the id just has to be present.
   "kv_namespaces": [{ "binding": "SESSION", "id": "test-session" }],
   "vars": {
-    // App vars the worker reads at runtime; fake values for tests.
-    "GRAPHQL_ENDPOINT": "https://example.com/api/graphql"
+    // App vars the worker reads at runtime; fake values for tests. The path
+    // here must match what the mock worker (mock-upstream.mjs) intercepts.
+    "UPSTREAM_ENDPOINT": "https://example.com/api/data"
   },
   // Point every outbound service binding at the mock worker. The `service`
   // value must match the mock worker `name` in vitest.config.ts.


### PR DESCRIPTION
## Summary

- Lift the two-project vitest setup from `sbaerlocher/sbaerlo.ch` into an org template under `.github/templates/vitest-cloudflare-workers/`, so other Cloudflare Astro/Worker repos can adopt it.
- Pattern: fast `unit` project (DOM env, no worker runtime) + `integration` project that runs the built worker in Miniflare via `@cloudflare/vitest-pool-workers`, with a mock-upstream worker serving any outbound service binding.
- Genericised from source: Svelte plugin, GraphQL fixtures and er-route assertions replaced with adjust-markers and a neutral skeleton; README covers adoption steps, reference dep versions, no-outbound-service and WASM-suppression caveats.

## Test plan

- [ ] CI green (claude-review)
- [ ] Template files are illustrative (not executed in CI) — verified the lefthook json glob excludes `*.jsonc`