### PR TITLE
docs(changelog): record changes since 2026-06-10 and cut 2026-06-18 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ## Unreleased
 
+## 2026-06-18
+
 ### Added
 
 - **`templates/CHANGELOG.md`**: Keep-a-Changelog `CHANGELOG.md` template with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,22 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ## Unreleased
 
+### Added
+
+- **`templates/CHANGELOG.md`**: Keep-a-Changelog `CHANGELOG.md` template with
+  an embedded comment block documenting the org convention (newest on top,
+  `## [Unreleased]`, the category order, breaking-change sub-heading). Repos
+  with a different cadence (e.g. `.github` itself) document the deviation in
+  their own header instead of copying it verbatim.
+- **`templates/vitest-cloudflare-workers/`**: Vitest projects template for
+  Cloudflare Astro/Worker repos, lifted from `sbaerlocher/sbaerlo.ch`. Splits a
+  fast `unit` project (DOM env, no worker runtime) from an `integration`
+  project that runs the built worker in Miniflare via
+  `@cloudflare/vitest-pool-workers`, with a mock-upstream worker serving any
+  outbound service binding. Ships `vitest.config.ts`, `wrangler.test.jsonc`,
+  `tests/env.d.ts`, a mock upstream and an example test, plus a README with
+  adoption steps and the istanbul-coverage / no-outbound-service caveats.
+
 ### Changed
 
 - **internal action refs**: Replace remaining `@main` references for
@@ -32,6 +48,14 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   trusted-only escape hatch.
 - **repo metadata**: Add `CONTRIBUTING.md`, `lefthook.yml`, and `.yamllint`;
   update CODEOWNERS and AGENTS.md to match the current repo structure.
+
+### Dependencies
+
+- **`actions/checkout`**: v6.0.3 → v7.0.0 (all workflows). Internal to the
+  reusables; consumers pin date tags and are unaffected.
+- **`pnpm/action-setup`**: v6.0.8 → v6.0.9 (`ci-js.yml`, `release-npm.yml`).
+- **`@cyclonedx/cyclonedx-npm`**: 4.2.1 → 5.0.0 (`sbom-npm/action.yml`).
+- **`govulncheck`**: v1.3.0 → v1.4.0 (`ci-go.yml`, `security-deps.yml`).
 
 ## 2026-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,9 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 - **`actions/checkout`**: v6.0.3 → v7.0.0 (all workflows). Internal to the
   reusables; consumers pin date tags and are unaffected.
-- **`pnpm/action-setup`**: v6.0.8 → v6.0.9 (`ci-js.yml`, `release-npm.yml`).
+- **`pnpm/action-setup`**: v6.0.8 → v6.0.9 (`sbom-npm/action.yml`, `ci-js.yml`,
+  `deploy-cloudflare-workers.yml`, `e2e-dde.yml`, `e2e-docker.yml`,
+  `release-npm.yml`, `security-code.yml`, `security-deps.yml`).
 - **`@cyclonedx/cyclonedx-npm`**: 4.2.1 → 5.0.0 (`sbom-npm/action.yml`).
 - **`govulncheck`**: v1.3.0 → v1.4.0 (`ci-go.yml`, `security-deps.yml`).
 


### PR DESCRIPTION
## Summary

- Fill the `## Unreleased` section with everything merged since the last tag (`2026-06-10`), then cut it into a dated `## 2026-06-18` section for today's rolling release.
- **Added**: CHANGELOG.md template (#177), vitest-cloudflare-workers projects template (#178).
- **Dependencies**: `actions/checkout` v6.0.3→v7.0.0 (#180), `pnpm/action-setup` v6.0.8→v6.0.9 (#181), `@cyclonedx/cyclonedx-npm` 4.2.1→5.0.0 (#179), `govulncheck` v1.3.0→v1.4.0 (#182).

The `checkout` v7 major is internal to the reusables — consumers pin date tags and call no `checkout` directly — so it is not flagged `⚠ BREAKING`.

## Follow-up

After merge: cut the `2026-06-18` git tag on the merge commit so consumers' Renovate can bump to it.

## Test plan

- [ ] CI green (claude-review)
- [ ] Dep bumps cross-checked against actual diffs (versions + affected files)