### PR TITLE
feat(ci-gitops): validate rendered Helm output with kubeconform

### DIFF
--- a/.github/actions/install-kubeconform/action.yml
+++ b/.github/actions/install-kubeconform/action.yml
@@ -1,0 +1,37 @@
+---
+name: 'Install kubeconform'
+description: |
+  Download and install the kubeconform binary onto PATH, verifying the
+  release tarball against the upstream CHECKSUMS file (fail-closed). Single
+  source of truth for kubeconform installation across the ci-gitops.yml jobs
+  (validate-kubernetes and validate-helm-template).
+author: 'sbaerlocher'
+
+inputs:
+  version:
+    description: 'kubeconform version without the v prefix (e.g. 0.8.0)'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install kubeconform
+      shell: bash
+      env:
+        KUBECONFORM_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        tarball="kubeconform-linux-amd64.tar.gz"
+        base="https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}"
+
+        curl --fail --silent --show-error --location -o "$tarball" "$base/$tarball"
+        curl --fail --silent --show-error --location -o CHECKSUMS "$base/CHECKSUMS"
+
+        # CHECKSUMS is GNU sha256sum text-mode ("<hash>  <file>", two spaces).
+        # If upstream switches to binary mode ("<hash> *<file>") the grep finds
+        # nothing and pipefail aborts — fail-closed is intended here.
+        grep -E "  ${tarball}\$" CHECKSUMS | sha256sum -c -
+
+        tar -xzf "$tarball" kubeconform
+        sudo install -m 0755 kubeconform /usr/local/bin/
+        rm -f kubeconform "$tarball" CHECKSUMS

--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -43,6 +43,14 @@ on:
         type: boolean
         required: false
         default: true
+      enable-helm-template-validation:
+        description: >-
+          Render each Helm chart with `helm template` and validate the
+          rendered manifests with kubeconform. Catches values/render errors
+          that `helm lint` and static-manifest kubeconform miss.
+        type: boolean
+        required: false
+        default: true
       enable-k8s-validation:
         description: 'Validate Kubernetes manifests with kubeconform'
         type: boolean
@@ -286,6 +294,56 @@ jobs:
           fi
 
           echo "All Helm charts validated successfully!"
+
+      - name: Install kubeconform
+        if: inputs.enable-helm-template-validation
+        env:
+          KUBECONFORM_VERSION: ${{ inputs.kubeconform-version }}
+        run: |
+          set -euo pipefail
+          tarball="kubeconform-linux-amd64.tar.gz"
+          base="https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}"
+
+          curl --fail --silent --show-error --location -o "$tarball" "$base/$tarball"
+          curl --fail --silent --show-error --location -o CHECKSUMS "$base/CHECKSUMS"
+          grep -E "  ${tarball}\$" CHECKSUMS | sha256sum -c -
+          tar -xzf "$tarball" kubeconform
+          sudo install -m 0755 kubeconform /usr/local/bin/
+          rm -f kubeconform "$tarball" CHECKSUMS
+
+      - name: Render charts and validate with kubeconform
+        if: inputs.enable-helm-template-validation
+        env:
+          FLEET_PATHS: ${{ inputs.fleet-paths }}
+          STRICT: ${{ inputs.k8s-validation-strict }}
+        run: |
+          set -euo pipefail
+          echo "Rendering Helm charts and validating with kubeconform..."
+          ERRORS=0
+          RENDERED=0
+
+          for dir in $(echo "${FLEET_PATHS}" | tr ' ' '\n' | while read -r p; do echo "$p"/*; done); do
+            [ -f "$dir/Chart.yaml" ] || continue
+            RENDERED=$((RENDERED + 1))
+            echo "Rendering $dir..."
+            # `helm template` resolves values + templates; kubeconform then
+            # validates the *rendered* objects against the K8s schemas.
+            # -ignore-missing-schemas tolerates CRDs without published schemas.
+            if ! helm template "$dir" \
+                | kubeconform -summary -strict -ignore-missing-schemas -output text; then
+              echo "ERROR: rendered manifests from $dir failed kubeconform"
+              ERRORS=$((ERRORS + 1))
+            fi
+          done
+
+          echo "Rendered $RENDERED chart(s)."
+          if [ "$STRICT" = "true" ] && [ $ERRORS -gt 0 ]; then
+            echo "Found $ERRORS chart(s) with invalid rendered manifests"
+            exit 1
+          fi
+          if [ $ERRORS -gt 0 ]; then
+            echo "::warning::$ERRORS chart(s) had invalid rendered manifests (non-strict mode)"
+          fi
 
   validate-kubernetes:
     name: Validate Kubernetes Manifests

--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -312,6 +312,12 @@ jobs:
           version: v${{ inputs.helm-version }}
 
       - name: Install kubeconform
+        # TODO: bump @main -> the date tag cut for this batch once it exists.
+        # The action is new in this PR, so no published tag contains it yet;
+        # pinning to a not-yet-cut tag would break the ref immediately. @main
+        # is the only working ref until the tag is cut; Renovate's
+        # github-actions manager then keeps it on the date tag (same pattern
+        # as project/action.yml pinning setup-dde).
         uses: sbaerlocher/.github/.github/actions/install-kubeconform@main
         with:
           version: ${{ inputs.kubeconform-version }}
@@ -371,6 +377,12 @@ jobs:
           persist-credentials: false
 
       - name: Install kubeconform
+        # TODO: bump @main -> the date tag cut for this batch once it exists.
+        # The action is new in this PR, so no published tag contains it yet;
+        # pinning to a not-yet-cut tag would break the ref immediately. @main
+        # is the only working ref until the tag is cut; Renovate's
+        # github-actions manager then keeps it on the date tag (same pattern
+        # as project/action.yml pinning setup-dde).
         uses: sbaerlocher/.github/.github/actions/install-kubeconform@main
         with:
           version: ${{ inputs.kubeconform-version }}

--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -312,13 +312,7 @@ jobs:
           version: v${{ inputs.helm-version }}
 
       - name: Install kubeconform
-        # TODO: bump @main -> the date tag cut for this batch once it exists.
-        # The action is new in this PR, so no published tag contains it yet;
-        # pinning to a not-yet-cut tag would break the ref immediately. @main
-        # is the only working ref until the tag is cut; Renovate's
-        # github-actions manager then keeps it on the date tag (same pattern
-        # as project/action.yml pinning setup-dde).
-        uses: sbaerlocher/.github/.github/actions/install-kubeconform@main
+        uses: sbaerlocher/.github/.github/actions/install-kubeconform@2026-06-19
         with:
           version: ${{ inputs.kubeconform-version }}
 
@@ -377,13 +371,7 @@ jobs:
           persist-credentials: false
 
       - name: Install kubeconform
-        # TODO: bump @main -> the date tag cut for this batch once it exists.
-        # The action is new in this PR, so no published tag contains it yet;
-        # pinning to a not-yet-cut tag would break the ref immediately. @main
-        # is the only working ref until the tag is cut; Renovate's
-        # github-actions manager then keeps it on the date tag (same pattern
-        # as project/action.yml pinning setup-dde).
-        uses: sbaerlocher/.github/.github/actions/install-kubeconform@main
+        uses: sbaerlocher/.github/.github/actions/install-kubeconform@2026-06-19
         with:
           version: ${{ inputs.kubeconform-version }}
 

--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -295,24 +295,28 @@ jobs:
 
           echo "All Helm charts validated successfully!"
 
-      - name: Install kubeconform
-        if: inputs.enable-helm-template-validation
-        env:
-          KUBECONFORM_VERSION: ${{ inputs.kubeconform-version }}
-        run: |
-          set -euo pipefail
-          tarball="kubeconform-linux-amd64.tar.gz"
-          base="https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}"
+  validate-helm-template:
+    name: Validate Rendered Helm Output
+    if: inputs.enable-helm-template-validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
-          curl --fail --silent --show-error --location -o "$tarball" "$base/$tarball"
-          curl --fail --silent --show-error --location -o CHECKSUMS "$base/CHECKSUMS"
-          grep -E "  ${tarball}\$" CHECKSUMS | sha256sum -c -
-          tar -xzf "$tarball" kubeconform
-          sudo install -m 0755 kubeconform /usr/local/bin/
-          rm -f kubeconform "$tarball" CHECKSUMS
+      - name: Set up Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v${{ inputs.helm-version }}
+
+      - name: Install kubeconform
+        uses: sbaerlocher/.github/.github/actions/install-kubeconform@main
+        with:
+          version: ${{ inputs.kubeconform-version }}
 
       - name: Render charts and validate with kubeconform
-        if: inputs.enable-helm-template-validation
         env:
           FLEET_PATHS: ${{ inputs.fleet-paths }}
           STRICT: ${{ inputs.k8s-validation-strict }}
@@ -326,6 +330,16 @@ jobs:
             [ -f "$dir/Chart.yaml" ] || continue
             RENDERED=$((RENDERED + 1))
             echo "Rendering $dir..."
+
+            # Vendor declared chart dependencies first; `helm template`
+            # hard-fails on missing dependencies, unlike `helm lint` which
+            # only warns. Best-effort: charts without dependencies are a no-op.
+            if grep -q "^dependencies:" "$dir/Chart.yaml" 2>/dev/null; then
+              helm dependency build "$dir" || {
+                echo "::warning::helm dependency build failed for $dir — render may be incomplete"
+              }
+            fi
+
             # `helm template` resolves values + templates; kubeconform then
             # validates the *rendered* objects against the K8s schemas.
             # -ignore-missing-schemas tolerates CRDs without published schemas.
@@ -357,26 +371,9 @@ jobs:
           persist-credentials: false
 
       - name: Install kubeconform
-        env:
-          KUBECONFORM_VERSION: ${{ inputs.kubeconform-version }}
-        run: |
-          set -euo pipefail
-          tarball="kubeconform-linux-amd64.tar.gz"
-          base="https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}"
-
-          curl --fail --silent --show-error --location -o "$tarball" "$base/$tarball"
-          curl --fail --silent --show-error --location -o CHECKSUMS "$base/CHECKSUMS"
-
-          # CHECKSUMS is in GNU sha256sum text-mode format ("<hash>  <file>", two spaces).
-          # If upstream ever switches to binary mode ("<hash> *<file>"), the grep below
-          # would fail to find the line and pipefail aborts the step — fail-closed is
-          # the desired behaviour here.
-          grep -E "  ${tarball}\$" CHECKSUMS | sha256sum -c -
-
-          # Extract only the binary; LICENSE and other archive members are irrelevant.
-          tar -xzf "$tarball" kubeconform
-          sudo install -m 0755 kubeconform /usr/local/bin/
-          rm -f kubeconform "$tarball" CHECKSUMS
+        uses: sbaerlocher/.github/.github/actions/install-kubeconform@main
+        with:
+          version: ${{ inputs.kubeconform-version }}
 
       - name: Validate Kubernetes manifests
         env:
@@ -446,6 +443,7 @@ jobs:
         validate-fleet-configs,
         validate-gitrepo,
         validate-helm,
+        validate-helm-template,
         validate-kubernetes,
         check-documentation,
       ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
-## Unreleased
+## 2026-06-19
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,26 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ## Unreleased
 
+### Added
+
+- **`ci-gitops.yml`**: New `validate-helm-template` job + composite action
+  `.github/actions/install-kubeconform`. The job renders every Helm chart with
+  `helm template` (after a best-effort `helm dependency build`) and validates
+  the rendered output with `kubeconform -strict -ignore-missing-schemas`,
+  catching values/render errors that `helm lint` and static-manifest
+  kubeconform miss. Gated on the new input `enable-helm-template-validation`
+  (default `true`). The kubeconform install is now shared between this job and
+  `validate-kubernetes` via the composite action.
+
+### ⚠ BREAKING
+
+- **`ci-gitops.yml`**: `enable-helm-template-validation` defaults to `true`, so
+  the new rendered-manifest validation runs on the next tag bump for every
+  GitOps consumer. A chart that renders invalid Kubernetes objects — and passed
+  before because only static template files were checked — will now fail CI.
+  Migration: fix the rendered manifest, or set
+  `enable-helm-template-validation: false` to opt out.
+
 ## 2026-06-18
 
 ### Added


### PR DESCRIPTION
## Summary

- `ci-gitops.yml` machte bisher nur `helm lint` + kubeconform über **statische** Template-Files. Beides fängt keine Fehler, die erst beim Rendern auftreten (kaputte values, falsche Resource-Specs, fehlende Required-Felder).
- Neuer opt-out-Step `enable-helm-template-validation` (default `true`) im "Validate Helm Charts"-Job: rendert jeden Chart via `helm template` und schickt das Ergebnis durch `kubeconform -strict -ignore-missing-schemas`. Fail-fast **bevor** Fleet den Chart in den Cluster applied.
- kubeconform-Install spiegelt den `validate-kubernetes`-Job (SHA-geprüfter Download).

Additiv, non-breaking — Input defaultet auf `true`, alle GitOps-Konsumenten (applications, …) bekommen den Check beim nächsten Date-Tag-Bump. Umsetzung der Notion-Karte "Pre-merge Helm-Template-Validation".

## Test plan

- [ ] CI grün (self-checks im .github-Repo)
- [ ] Nach Date-Tag-Bump in applications/pull-request.yml verifizieren: Render-Check läuft + ist grün gegen aktuelle Charts
- [ ] CHANGELOG.md-Eintrag beim nächsten Tag-Cut