### PR TITLE
fix(ci-gitops): render Helm charts with conventional CI values file

### DIFF
--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -340,10 +340,26 @@ jobs:
               }
             fi
 
+            # Charts that `required`-guard secret values (e.g.
+            # `database.existingSecret`) cannot render from values.yaml
+            # defaults alone — the guard aborts the template. Honour a
+            # conventional CI values file in the chart dir if present, so the
+            # chart renders with placeholder secret names without weakening
+            # the production guard. First match wins; absence is a no-op so
+            # charts that render from defaults are unaffected.
+            VALUES_ARGS=()
+            for vf in values-test.yaml ci-values.yaml values-ci.yaml; do
+              if [ -f "$dir/$vf" ]; then
+                echo "Using values override $dir/$vf"
+                VALUES_ARGS=(-f "$dir/$vf")
+                break
+              fi
+            done
+
             # `helm template` resolves values + templates; kubeconform then
             # validates the *rendered* objects against the K8s schemas.
             # -ignore-missing-schemas tolerates CRDs without published schemas.
-            if ! helm template "$dir" \
+            if ! helm template "$dir" "${VALUES_ARGS[@]}" \
                 | kubeconform -summary -strict -ignore-missing-schemas -output text; then
               echo "ERROR: rendered manifests from $dir failed kubeconform"
               ERRORS=$((ERRORS + 1))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
+## Unreleased
+
+### Changed
+
+- **`ci-gitops.yml`**: The `validate-helm-template` job now honours a
+  conventional CI values file per chart. If a chart directory contains
+  `values-test.yaml` (or `ci-values.yaml` / `values-ci.yaml`, first match
+  wins), `helm template` renders with `-f <file>`. Charts that `required`-guard
+  secret values (e.g. `database.existingSecret`) could not render from
+  `values.yaml` defaults alone — the guard aborted the template and failed the
+  job. Drop a values file with placeholder secret names to fix this without
+  weakening the production guard. Charts without such a file render from
+  defaults exactly as before — no behaviour change for them.
+
 ## 2026-06-19
 
 ### Added


### PR DESCRIPTION
## Summary

- The `validate-helm-template` job (added in `2026-06-19`) renders every chart with bare `helm template` — `values.yaml` defaults only. Charts that `required`-guard secret values (e.g. savvy's `database.existingSecret`) abort the template, kubeconform sees 0 objects, the job fails. The guard is intentional for real deploys, so weakening the chart is wrong.
- The render step now honours a conventional CI values file per chart: `values-test.yaml` → `ci-values.yaml` → `values-ci.yaml` (first match wins) is passed via `-f`. Charts without one render from defaults exactly as before — non-breaking.
- Unblocks savvy GitOps CI (`sbaerlocher/savvy#181`), which already ships `deploy/helm/values-test.yaml` with a placeholder secret name.

## Test plan

- [ ] Bash array logic validated (`bash -n`); empty-array expansion safe on ubuntu-latest bash 5.x under `set -u`
- [ ] After a new date tag is cut, bump savvy#181 to it → `Validate Rendered Helm Output` renders savvy's chart with `values-test.yaml` and passes