### PR TITLE
docs(changelog): date-stamp 2026-06-21 release entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
-## Unreleased
+## 2026-06-21
 
 ### Changed
 


### PR DESCRIPTION
## Summary

- Promote the `## Unreleased` ci-gitops values-file entry to `## 2026-06-21`, matching the freshly-cut `2026-06-21` tag and the repo's dated-release convention.

## Test plan

- [ ] Changelog renders, heading matches tag name