### PR TITLE
fix(ci-js): allow BSD-2-Clause-Views in dependency review

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -534,7 +534,7 @@ jobs:
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: moderate
-          allow-licenses: Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MIT, 0BSD, LGPL-2.1+, MPL-2.0, BlueOak-1.0.0, CC-BY-4.0, CC0-1.0, LicenseRef-scancode-google-patent-license-golang, BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang
+          allow-licenses: Apache-2.0, BSD-2-Clause, BSD-2-Clause-Views, BSD-3-Clause, ISC, MIT, 0BSD, LGPL-2.1+, MPL-2.0, BlueOak-1.0.0, CC-BY-4.0, CC0-1.0, LicenseRef-scancode-google-patent-license-golang, BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang, BSD-2-Clause AND BSD-2-Clause-Views
 
   summary:
     name: Create Summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
+## 2026-06-26
+
+### Changed
+
+- **`ci-js.yml`**: Allow the `BSD-2-Clause-Views` license (and the
+  `BSD-2-Clause AND BSD-2-Clause-Views` compound) in the dependency-review
+  gate. `uri-js` ships under that SPDX expression and is pulled in
+  transitively by common JS toolchains (ajv/eslint), so the gate rejected it
+  even though it is a permissive BSD license. No behaviour change for any
+  other dependency.
+
 ## 2026-06-21
 
 ### Changed


### PR DESCRIPTION
## Summary

- Allow the `BSD-2-Clause-Views` license and the `BSD-2-Clause AND BSD-2-Clause-Views` compound in the `ci-js.yml` dependency-review gate.
- `uri-js` ships under that SPDX expression and is pulled in transitively (ajv/eslint), so the gate rejected it despite it being a permissive BSD license. No behaviour change for any other dependency.

## Test plan

- [ ] CI green
- [ ] After merge: cut tag `2026-06-26`, then consumers bumping to it pass dependency-review on uri-js