### PR TITLE
fix(ai-claude-review): allow bot-initiated runs

### DIFF
--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -119,6 +119,12 @@ jobs:
       - uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # claude-code-action@v1 blocks bot-initiated runs by default.
+          # The `if:` above already filters renovate/dependabot; the
+          # bots that still reach here are trusted first-party ones
+          # (e.g. github-actions[bot] opening the flake-lock update PR),
+          # so allow all rather than maintaining a per-login list.
+          allowed_bots: '*'
           classify_inline_comments: 'false'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'


### PR DESCRIPTION
## Summary

`claude-code-action@v1` rejects runs initiated by bot actors unless their login is listed in `allowed_bots`, failing with:

> Workflow initiated by non-human actor: github-actions (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

The job `if:` already skips `renovate[bot]` and `dependabot[bot]`, but `github-actions[bot]` (which opens the automated flake-lock update PRs) still reaches the action and fails the review job. Observed on [sbaerlocher/dotfiles#198](https://github.com/sbaerlocher/dotfiles/pull/198).

## Change

Set `allowed_bots: '*'` on the action. The remaining bots that pass the `if:` filter are trusted first-party ones, so allow all rather than maintaining a per-login list.

## Test plan

- [ ] Merge, then re-run the Claude review on a bot-authored PR (e.g. next flake-lock update) — the review job should no longer fail on the actor check.