### PR TITLE
docs(changelog): add 2026-07-08 release entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
+## 2026-07-08
+
+### Fixed
+
+- **`ai-claude-review.yml`**: Set `allowed_bots: '*'` so bot-initiated runs
+  reach the action. `claude-code-action@v1` rejects runs from bot actors
+  unless their login is allow-listed; the job `if:` already skips
+  renovate/dependabot, but `github-actions[bot]` (flake-lock update PRs) still
+  reached the action and failed with "Workflow initiated by non-human actor".
+  The remaining bots that pass the `if:` filter are trusted first-party ones.
+
+### Changed
+
+- **Dependencies**: Renovate updates for pinned action SHAs and tool versions —
+  `actions/cache` v6, `@cyclonedx/cyclonedx-npm` v6, `golang.org/x/vuln`
+  v1.5.0, `ansible-lint` v26.6.0, `anthropics/claude-code-action` v1.0.158,
+  `postgres:18-alpine` digest, plus batched GitHub Actions SHA bumps.
+
 ## 2026-06-26
 
 ### Changed


### PR DESCRIPTION
## Summary

Documents all changes since the \`2026-06-26\` tag, ahead of cutting the next dated release tag.

- \`ai-claude-review.yml\`: set \`allowed_bots: '*'\` so bot-initiated runs (flake-lock \`github-actions[bot]\` PRs) reach the action instead of failing with "Workflow initiated by non-human actor" (#209).
- Renovate dependency updates: \`actions/cache\` v6, \`@cyclonedx/cyclonedx-npm\` v6, \`golang.org/x/vuln\` v1.5.0, \`ansible-lint\` v26.6.0, \`anthropics/claude-code-action\` v1.0.158, \`postgres:18-alpine\` digest, plus batched GitHub Actions SHA bumps.

No breaking changes this cycle.

## Test plan

- [x] Changelog entry follows the rolling-release date-tag format
- [ ] Cut the \`2026-07-08\` tag after merge