### PR TITLE
fix(ci-go): stop govulncheck false-red from stale patch and import-only findings

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -463,7 +463,8 @@ jobs:
           # called, e.g. deprecated packages with no fixed version) are reported
           # as notices, not failures.
           reachable=$(jq -rc 'select(.finding.trace[0].function != null) | .finding.osv' govulncheck.json | sort -u)
-          imported=$(jq -rc 'select(.finding.trace[0].function == null) | .finding.osv' govulncheck.json | sort -u)
+          all_osv=$(jq -rc '.finding.osv // empty' govulncheck.json | sort -u)
+          imported=$(comm -23 <(printf '%s\n' "$all_osv") <(printf '%s\n' "$reachable") | sed '/^$/d')
           if [ -n "$imported" ]; then
             echo "::notice::Non-reachable (import-only) findings, not gating:"
             echo "$imported"

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -170,6 +170,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ inputs.go-version }}
+          check-latest: true
           cache: true
           cache-dependency-path: go.sum
 
@@ -298,6 +299,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ inputs.go-version }}
+          check-latest: true
           cache: true
           cache-dependency-path: go.sum
 
@@ -426,6 +428,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ inputs.go-version }}
+          check-latest: true
           cache: true
 
       - name: Run gosec Security Scanner
@@ -454,12 +457,23 @@ jobs:
             echo "::error::govulncheck failed (exit $rc)"
             exit "$rc"
           fi
-          if grep -q '"finding"' govulncheck.json; then
-            echo "::warning::Vulnerabilities detected by govulncheck"
-            jq -r '.finding // empty | .osv' govulncheck.json | sort -u | head -10
+          # Gate only on call-reachable findings. A finding whose top trace frame
+          # carries a `function` is reachable in source mode; import-only /
+          # module-level findings (a module pulled in transitively but never
+          # called, e.g. deprecated packages with no fixed version) are reported
+          # as notices, not failures.
+          reachable=$(jq -rc 'select(.finding.trace[0].function != null) | .finding.osv' govulncheck.json | sort -u)
+          imported=$(jq -rc 'select(.finding.trace[0].function == null) | .finding.osv' govulncheck.json | sort -u)
+          if [ -n "$imported" ]; then
+            echo "::notice::Non-reachable (import-only) findings, not gating:"
+            echo "$imported"
+          fi
+          if [ -n "$reachable" ]; then
+            echo "::warning::Reachable vulnerabilities detected by govulncheck"
+            echo "$reachable"
             exit 1
           fi
-          echo "::notice::No vulnerabilities found by govulncheck"
+          echo "::notice::No reachable vulnerabilities found by govulncheck"
 
       - name: Run Trivy filesystem scanner
         if: matrix.scanner == 'trivy-fs'

--- a/.github/workflows/security-deps.yml
+++ b/.github/workflows/security-deps.yml
@@ -101,6 +101,7 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: 'go.mod'
+          check-latest: true
           cache: true
 
       # Vulnerability scanning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
+## 2026-07-10
+
+### Fixed
+
+- **`ci-go.yml`**, **`security-deps.yml`**: Add `check-latest: true` to every
+  `setup-go` step. Runners preferred a stale Go patch from the tool-cache (e.g.
+  `go1.26.4`) over the latest patch for the requested minor, so stdlib
+  vulnerabilities fixed in a newer patch (`go1.26.5`) kept the `govulncheck` gate
+  red even though nothing in the consumer code was affected. `check-latest`
+  resolves the newest patch from the version index instead of the cache.
+- **`ci-go.yml`**: `govulncheck` now gates only on **call-reachable** findings.
+  The previous gate keyed on any `"finding"` line, so import-only / module-level
+  findings — a module pulled in transitively but never called (e.g. a deprecated
+  package with no fixed version, like `golang.org/x/crypto/openpgp` reached only
+  through `crypto/bcrypt`) — held the gate red permanently. Non-reachable
+  findings are now reported as notices; the build fails only on findings whose
+  trace is actually reachable in source mode.
+
 ## 2026-07-08
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Add `check-latest: true` to every `setup-go` step in `ci-go.yml` and `security-deps.yml`. Runners preferred a stale Go patch from the tool-cache over the latest patch for the requested minor, so stdlib vulnerabilities fixed in a newer patch kept the `govulncheck` gate red for consumer repos even though nothing in their code was affected. `check-latest` resolves the newest patch from the version index instead of the cache.
- `ci-go.yml` `govulncheck` now gates only on **call-reachable** findings. The old gate keyed on any `"finding"` line, so import-only / module-level findings (a module pulled in transitively but never called — e.g. a deprecated package with no fixed version, reached only through an unrelated import) held the gate red permanently. Non-reachable findings are now reported as notices; the build fails only on reachable ones.

## Further occurrences (not changed)

- `security-deps.yml` govulncheck step keeps the crude gate on purpose: it is report-only (never `exit 1`), so the import-only noise is cosmetic there, not blocking. Only `check-latest` was added.
- `release-go.yml`, `security-code.yml`, `security-sbom.yml` also run `setup-go` but are not the vuln gate; `check-latest` was left off to keep release/build toolchain resolution deterministic.

## Test plan

- [ ] CI green on this PR
- [x] Local: YAML parses (`ci-go.yml`, `security-deps.yml`), govulncheck gate shell `bash -n` clean
- [x] Local: gate logic verified against synthetic findings — import-only finding passes, reachable finding fails, mixed fails and reports both, empty passes
- [ ] End-to-end: a consumer re-run shows the newest Go patch in the runner log and a green govulncheck gate