### PR TITLE
refactor(security)!: merge scan jobs to cut per-job minute rounding

### DIFF
--- a/.github/workflows/security-config.yml
+++ b/.github/workflows/security-config.yml
@@ -374,3 +374,24 @@ jobs:
 
           > Secret detection is handled separately by \`security-secrets.yml\`
           EOF
+
+      # continue-on-error on the trivy-config / terraform scanners only lets the
+      # later sequential steps run; it must not swallow the fail-on-findings
+      # gate. On origin/main both keyed exit-code off fail-on-findings and had
+      # no continue-on-error, so a finding with fail-on-findings:true failed the
+      # workflow. Re-raise here. kubernetes/ansible used `|| true` on main and
+      # stay non-blocking.
+      - name: Enforce config-scan result
+        if: always() && inputs.fail-on-findings
+        run: |
+          fail=0
+          if [ "${{ steps.trivy-config-scan.outcome }}" = "failure" ]; then
+            echo "::error::Trivy config scan found issues at/above the severity threshold"
+            fail=1
+          fi
+          if [ "${{ inputs.scan-terraform }}" = "true" ] \
+             && [ "${{ steps.terraform-security.outcome }}" = "failure" ]; then
+            echo "::error::Terraform security scan found issues at/above the severity threshold"
+            fail=1
+          fi
+          exit "$fail"

--- a/.github/workflows/security-config.yml
+++ b/.github/workflows/security-config.yml
@@ -75,17 +75,25 @@ concurrency:
   cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
-  trivy-config-scan:
-    name: Trivy Config Scan
+  # trivy-config + terraform + kubernetes + ansible + report shared the same
+  # permissions and differed only by scan-* guards, so they merge into one
+  # sequential-step job (one checkout, one runner). Each scanner is a step
+  # behind its original `if:`; the report is the final always()-step.
+  config-scan:
+    name: Scan Configuration
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Union of the merged jobs' timeouts (4×15).
+    timeout-minutes: 60
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
+      # --- Trivy config (always runs, like the old unconditional job) ---
       - name: Run Trivy config scan
+        id: trivy-config-scan
+        continue-on-error: true
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'config'
@@ -134,18 +142,11 @@ jobs:
             trivy-config-report.txt
           retention-days: 30
 
-  terraform-security:
-    name: Terraform Security
-    if: inputs.scan-terraform
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
+      # --- Terraform ---
       - name: Run Trivy (Terraform Security)
+        id: terraform-security
+        if: inputs.scan-terraform
+        continue-on-error: true
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'config'
@@ -158,7 +159,7 @@ jobs:
 
       - name: Check if SARIF file exists
         id: sarif_check
-        if: always()
+        if: always() && inputs.scan-terraform
         run: |
           if [ -f "trivy-results.sarif" ]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
@@ -169,7 +170,7 @@ jobs:
 
       - name: Upload Trivy results
         if: |
-          inputs.enable-sarif && always() &&
+          inputs.scan-terraform && inputs.enable-sarif && always() &&
           steps.sarif_check.outputs.exists == 'true' &&
           github.event.repository.visibility == 'public'
         uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
@@ -180,15 +181,15 @@ jobs:
 
       - name: Skip SARIF upload for private repo
         if: |
-          inputs.enable-sarif && always() &&
+          inputs.scan-terraform && inputs.enable-sarif && always() &&
           steps.sarif_check.outputs.exists == 'true' &&
           github.event.repository.visibility != 'public'
         run: |
           echo "::notice::Skipping SARIF upload - Code Scanning requires GitHub Advanced Security for private repos"
           echo "::notice::Security results are available as workflow artifacts"
 
-      - name: Upload Trivy artifacts
-        if: always() && steps.sarif_check.outputs.exists == 'true'
+      - name: Upload Trivy Terraform artifacts
+        if: always() && inputs.scan-terraform && steps.sarif_check.outputs.exists == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: trivy-terraform-results
@@ -196,6 +197,7 @@ jobs:
           retention-days: 30
 
       - name: Custom Terraform validators
+        if: inputs.scan-terraform
         working-directory: ${{ inputs.terraform-path }}
         run: |
           echo "Running custom Terraform validators..."
@@ -220,19 +222,11 @@ jobs:
             echo "::warning::Found hardcoded IP addresses in Terraform files"
           fi
 
-  kubernetes-security:
-    name: Scan Kubernetes
-    if: inputs.scan-kubernetes
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
+      # --- Kubernetes ---
       - name: Find Kubernetes manifests
-        id: find-manifests
+        id: kubernetes-security
+        if: inputs.scan-kubernetes
+        continue-on-error: true
         working-directory: ${{ inputs.kubernetes-path }}
         run: |
           echo "Searching for Kubernetes manifests..."
@@ -248,7 +242,7 @@ jobs:
           fi
 
       - name: Run Kubesec
-        if: steps.find-manifests.outputs.found == 'true'
+        if: inputs.scan-kubernetes && steps.kubernetes-security.outputs.found == 'true'
         working-directory: ${{ inputs.kubernetes-path }}
         env:
           # renovate: datasource=docker depName=kubesec/kubesec
@@ -277,7 +271,7 @@ jobs:
           fi
 
       - name: Check for hardcoded credentials
-        if: steps.find-manifests.outputs.found == 'true'
+        if: inputs.scan-kubernetes && steps.kubernetes-security.outputs.found == 'true'
         working-directory: ${{ inputs.kubernetes-path }}
         run: |
           echo "Checking for hardcoded credentials in Kubernetes manifests..."
@@ -298,7 +292,7 @@ jobs:
           fi
 
       - name: Upload Kubernetes scan results
-        if: steps.find-manifests.outputs.found == 'true' && always()
+        if: always() && inputs.scan-kubernetes && steps.kubernetes-security.outputs.found == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: kubernetes-security-results
@@ -308,23 +302,17 @@ jobs:
           retention-days: 30
           if-no-files-found: ignore
 
-  ansible-security:
-    name: Scan Ansible
-    if: inputs.scan-ansible
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
+      # --- Ansible ---
       - name: Setup Python
+        if: inputs.scan-ansible
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
       - name: Install Ansible and ansible-lint
+        id: ansible-security
+        if: inputs.scan-ansible
+        continue-on-error: true
         env:
           # renovate: datasource=pypi depName=ansible
           ANSIBLE_VERSION: '14.1.0'
@@ -339,19 +327,21 @@ jobs:
             "yamllint==${YAMLLINT_VERSION}"
 
       - name: Run ansible-lint
+        if: inputs.scan-ansible
         working-directory: ${{ inputs.ansible-path }}
         run: |
           echo "Running ansible-lint..."
           ansible-lint -f pep8 . | tee ansible-lint-results.txt || true
 
       - name: Run yamllint
+        if: inputs.scan-ansible
         working-directory: ${{ inputs.ansible-path }}
         run: |
           echo "Running yamllint on playbooks..."
           yamllint -f parsable . | tee yamllint-results.txt || true
 
       - name: Upload Ansible scan results
-        if: always()
+        if: always() && inputs.scan-ansible
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ansible-security-results
@@ -361,13 +351,10 @@ jobs:
           retention-days: 30
           if-no-files-found: ignore
 
-  security-report:
-    name: Create Report
-    runs-on: ubuntu-latest
-    needs: [trivy-config-scan, terraform-security, kubernetes-security, ansible-security]
-    if: always() && !cancelled()
-    steps:
+      # Report folded from the old security-report job. trivy-config always
+      # runs; the others report `skipped` when their scan-* input is off.
       - name: Generate Security Report
+        if: always()
         run: |
           TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
 
@@ -380,10 +367,10 @@ jobs:
 
           | Scan | Enabled | Status |
           | --- | --- | --- |
-          | Trivy Config | yes | ${{ needs.trivy-config-scan.result }} |
-          | Terraform | ${{ inputs.scan-terraform && 'yes' || 'no' }} | ${{ needs.terraform-security.result }} |
-          | Kubernetes | ${{ inputs.scan-kubernetes && 'yes' || 'no' }} | ${{ needs.kubernetes-security.result }} |
-          | Ansible | ${{ inputs.scan-ansible && 'yes' || 'no' }} | ${{ needs.ansible-security.result }} |
+          | Trivy Config | yes | ${{ steps.trivy-config-scan.outcome }} |
+          | Terraform | ${{ inputs.scan-terraform && 'yes' || 'no' }} | ${{ steps.terraform-security.outcome }} |
+          | Kubernetes | ${{ inputs.scan-kubernetes && 'yes' || 'no' }} | ${{ steps.kubernetes-security.outcome }} |
+          | Ansible | ${{ inputs.scan-ansible && 'yes' || 'no' }} | ${{ steps.ansible-security.outcome }} |
 
           > Secret detection is handled separately by \`security-secrets.yml\`
           EOF

--- a/.github/workflows/security-containers.yml
+++ b/.github/workflows/security-containers.yml
@@ -68,9 +68,8 @@ jobs:
     runs-on: ubuntu-latest
     # Upper bound for the merged trivy + grype + analysis steps. Fixed rather
     # than derived from scan-timeout: GitHub-expression arithmetic isn't
-    # portable across linters, and a timeout is only a ceiling. Each scanner
-    # keeps its own effective budget; 40 covers 2×15 scans + analysis.
-    # ponytail: fixed ceiling, bump if a caller raises scan-timeout past ~15.
+    # portable across linters, and a timeout is only a ceiling. 40 covers
+    # 2×15 scans + analysis; bump if a caller raises scan-timeout past ~15.
     timeout-minutes: 40
     steps:
       - name: Checkout code
@@ -92,6 +91,7 @@ jobs:
 
       - name: Run Trivy SARIF scan
         if: inputs.enable-trivy-scan && inputs.enable-sarif-upload
+        continue-on-error: true
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ inputs.image-ref }}

--- a/.github/workflows/security-containers.yml
+++ b/.github/workflows/security-containers.yml
@@ -59,18 +59,30 @@ concurrency:
   cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
-  trivy-image:
-    name: Scan with Trivy
-    if: inputs.enable-trivy-scan
+  # trivy + grype + image-analysis + report shared the same permissions and
+  # differed only by enable-* guards, so they merge into one sequential-step
+  # job (one runner). Each scanner is a step behind its original `if:`; the
+  # report is the final always()-step reading step outcomes.
+  container-scan:
+    name: Scan Container Image
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ inputs.scan-timeout }}
+    # Upper bound for the merged trivy + grype + analysis steps. Fixed rather
+    # than derived from scan-timeout: GitHub-expression arithmetic isn't
+    # portable across linters, and a timeout is only a ceiling. Each scanner
+    # keeps its own effective budget; 40 covers 2×15 scans + analysis.
+    # ponytail: fixed ceiling, bump if a caller raises scan-timeout past ~15.
+    timeout-minutes: 40
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
+      # --- Trivy ---
       - name: Run Trivy vulnerability scanner
+        id: trivy-image
+        if: inputs.enable-trivy-scan
+        continue-on-error: true
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ inputs.image-ref }}
@@ -79,7 +91,7 @@ jobs:
           exit-code: '0'
 
       - name: Run Trivy SARIF scan
-        if: inputs.enable-sarif-upload
+        if: inputs.enable-trivy-scan && inputs.enable-sarif-upload
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ inputs.image-ref }}
@@ -88,7 +100,7 @@ jobs:
           severity: ${{ inputs.severity-level }}
 
       - name: Upload Trivy SARIF
-        if: inputs.enable-sarif-upload
+        if: inputs.enable-trivy-scan && inputs.enable-sarif-upload
         uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           sarif_file: 'trivy-image.sarif'
@@ -96,7 +108,7 @@ jobs:
         continue-on-error: true
 
       - name: Run Trivy JSON scan
-        if: always()
+        if: always() && inputs.enable-trivy-scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ inputs.image-ref }}
@@ -106,7 +118,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload Trivy Results
-        if: always()
+        if: always() && inputs.enable-trivy-scan
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: trivy-image-results
@@ -114,69 +126,57 @@ jobs:
           retention-days: 30
           if-no-files-found: ignore
 
-  grype-image:
-    name: Scan with Grype
-    if: inputs.enable-grype-scan
-    runs-on: ubuntu-latest
-    timeout-minutes: ${{ inputs.scan-timeout }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
+      # --- Grype ---
       - name: Run Grype vulnerability scanner
+        id: grype-image
+        if: inputs.enable-grype-scan
+        continue-on-error: true
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
-        id: grype
         with:
           image: ${{ inputs.image-ref }}
           fail-build: false
           severity-cutoff: medium
 
       - name: Upload Grype Results
-        if: always()
+        if: always() && inputs.enable-grype-scan
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: grype-image-results
-          path: ${{ steps.grype.outputs.sarif }}
+          path: ${{ steps.grype-image.outputs.sarif }}
           retention-days: 30
           if-no-files-found: ignore
 
-  image-analysis:
-    name: Analyze Images
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
+      # --- Image analysis (always runs, like the old unconditional job) ---
       - name: Analyze image layers
+        id: image-analysis
+        continue-on-error: true
+        env:
+          IMAGE_REF: ${{ inputs.image-ref }}
         run: |
-          echo "Analyzing image: ${{ inputs.image-ref }}"
+          echo "Analyzing image: $IMAGE_REF"
 
           # Pull image (if accessible)
-          if docker pull "${{ inputs.image-ref }}" 2>/dev/null; then
+          if docker pull "$IMAGE_REF" 2>/dev/null; then
             echo "✓ Image pulled successfully"
 
             # Show image size
-            SIZE=$(docker image inspect "${{ inputs.image-ref }}" --format='{{.Size}}' | numfmt --to=iec-i --suffix=B)
+            SIZE=$(docker image inspect "$IMAGE_REF" --format='{{.Size}}' | numfmt --to=iec-i --suffix=B)
             echo "Image size: $SIZE"
 
             # Show layer count
-            LAYERS=$(docker image inspect "${{ inputs.image-ref }}" --format='{{len .RootFS.Layers}}')
+            LAYERS=$(docker image inspect "$IMAGE_REF" --format='{{len .RootFS.Layers}}')
             echo "Layer count: $LAYERS"
 
             # Show base image (if detectable)
-            BASE=$(docker image inspect "${{ inputs.image-ref }}" --format='{{index .Config.Labels "org.opencontainers.image.base.name"}}' 2>/dev/null || echo "Unknown")
+            BASE=$(docker image inspect "$IMAGE_REF" --format='{{index .Config.Labels "org.opencontainers.image.base.name"}}' 2>/dev/null || echo "Unknown")
             echo "Base image: $BASE"
           else
             echo "::warning::Unable to pull image for analysis"
           fi
 
-  security-report:
-    name: Create Report
-    runs-on: ubuntu-latest
-    needs: [trivy-image, grype-image, image-analysis]
-    if: always() && !cancelled()
-    steps:
+      # Report folded from the old security-report job.
       - name: Generate Security Report
+        if: always()
         run: |
           TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
           cat >> "$GITHUB_STEP_SUMMARY" << EOF
@@ -188,7 +188,7 @@ jobs:
 
           | Scanner | Status |
           | --- | --- |
-          | Trivy | ${{ needs.trivy-image.result }} |
-          | Grype | ${{ needs.grype-image.result }} |
-          | Image Analysis | ${{ needs.image-analysis.result }} |
+          | Trivy | ${{ steps.trivy-image.outcome }} |
+          | Grype | ${{ steps.grype-image.outcome }} |
+          | Image Analysis | ${{ steps.image-analysis.outcome }} |
           EOF

--- a/.github/workflows/security-deps.yml
+++ b/.github/workflows/security-deps.yml
@@ -94,8 +94,13 @@ jobs:
           comment-summary-in-pr: true
 
       # --- Go ---
+      # continue-on-error on the setup steps: a failed setup counts as success
+      # for the default `if: success()` gate of later steps, so a broken Go
+      # setup can't skip the JS/Python setups + audits (they ran as independent
+      # parallel jobs on origin/main).
       - name: Setup Go
         if: inputs.language == 'go' || inputs.language == 'multi'
+        continue-on-error: true
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: 'go.mod'
@@ -157,6 +162,7 @@ jobs:
       # --- JavaScript ---
       - name: Setup Node.js
         if: inputs.language == 'javascript' || inputs.language == 'multi'
+        continue-on-error: true
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
@@ -244,6 +250,7 @@ jobs:
       # --- Python ---
       - name: Setup Python
         if: inputs.language == 'python' || inputs.language == 'multi'
+        continue-on-error: true
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
@@ -320,3 +327,14 @@ jobs:
           **Denied Licenses:** \`${{ inputs.denied-licenses }}\`
           **Fail on Violation:** ${{ inputs.fail-on-license-violation }}
           EOF
+
+      # continue-on-error on dependency-review only lets the language audits run
+      # afterwards; it must not swallow the fail-on-severity / denied-license
+      # gate. On origin/main dependency-review had no continue-on-error, so a
+      # finding failed the PR. Re-raise here. The go/js/python audits used
+      # `|| true` on main and stay non-blocking.
+      - name: Enforce dependency-review result
+        if: always() && steps.dependency-review.outcome == 'failure'
+        run: |
+          echo "::error::dependency-review found vulnerabilities or denied licenses at/above the configured threshold"
+          exit 1

--- a/.github/workflows/security-deps.yml
+++ b/.github/workflows/security-deps.yml
@@ -66,11 +66,15 @@ concurrency:
   cancel-in-progress: ${{ inputs.cancel-in-progress }}
 
 jobs:
-  dependency-review:
-    name: Dependency Review (GitHub)
+  # All audit jobs shared the same workflow-level permissions and differed only
+  # by language/event `if:` guards, so they merge into one sequential-step job
+  # (one checkout, one runner). Each former job is now a step group behind its
+  # original `if:`; the report is the final always()-step reading step outcomes.
+  dependency-scan:
+    name: Scan Dependencies
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.repository.visibility == 'public'
-    timeout-minutes: 10
+    # Union of the merged jobs' timeouts (review 10 + 3×15).
+    timeout-minutes: 55
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -78,6 +82,9 @@ jobs:
           persist-credentials: false
 
       - name: Dependency Review
+        id: dependency-review
+        if: github.event_name == 'pull_request' && github.event.repository.visibility == 'public'
+        continue-on-error: true
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: ${{ inputs.fail-on-severity }}
@@ -86,26 +93,19 @@ jobs:
           vulnerability-check: true
           comment-summary-in-pr: true
 
-  go-audit:
-    name: Audit Go
-    if: inputs.language == 'go' || inputs.language == 'multi'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
+      # --- Go ---
       - name: Setup Go
+        if: inputs.language == 'go' || inputs.language == 'multi'
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: 'go.mod'
           check-latest: true
           cache: true
 
-      # Vulnerability scanning
       - name: Run govulncheck
+        id: go-audit
+        if: inputs.language == 'go' || inputs.language == 'multi'
+        continue-on-error: true
         working-directory: ${{ inputs.working-directory }}
         env:
           # renovate: datasource=go depName=golang.org/x/vuln
@@ -129,9 +129,8 @@ jobs:
             echo "::notice::No vulnerabilities found"
           fi
 
-      # License checking
       - name: Check Go licenses
-        if: inputs.enable-license-check
+        if: (inputs.language == 'go' || inputs.language == 'multi') && inputs.enable-license-check
         working-directory: ${{ inputs.working-directory }}
         env:
           # renovate: datasource=go depName=github.com/google/go-licenses/v2
@@ -143,8 +142,8 @@ jobs:
           go-licenses check ./... --allowed_licenses="${ALLOWED_LICENSES}" 2>&1 | tee go-licenses.txt || true
           go-licenses csv ./... > go-licenses.csv 2>&1 || true
 
-      - name: Upload audit results
-        if: always()
+      - name: Upload Go audit results
+        if: always() && (inputs.language == 'go' || inputs.language == 'multi')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: go-audit-results
@@ -155,24 +154,16 @@ jobs:
           retention-days: 30
           if-no-files-found: ignore
 
-  javascript-audit:
-    name: Audit JavaScript
-    if: inputs.language == 'javascript' || inputs.language == 'multi'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
+      # --- JavaScript ---
       - name: Setup Node.js
+        if: inputs.language == 'javascript' || inputs.language == 'multi'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
 
       - name: Detect package manager
         id: detect-pm
+        if: inputs.language == 'javascript' || inputs.language == 'multi'
         working-directory: ${{ inputs.working-directory }}
         run: |
           if [ -f "pnpm-lock.yaml" ]; then
@@ -186,10 +177,13 @@ jobs:
           fi
 
       - name: Setup pnpm
-        if: steps.detect-pm.outputs.pm == 'pnpm'
+        if: |
+          (inputs.language == 'javascript' || inputs.language == 'multi')
+          && steps.detect-pm.outputs.pm == 'pnpm'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
-      - name: Install dependencies
+      - name: Install JavaScript dependencies
+        if: inputs.language == 'javascript' || inputs.language == 'multi'
         working-directory: ${{ inputs.working-directory }}
         run: |
           case "${{ steps.detect-pm.outputs.pm }}" in
@@ -199,8 +193,10 @@ jobs:
             npm) npm ci ;;
           esac
 
-      # Vulnerability scanning
       - name: Run npm audit
+        id: javascript-audit
+        if: inputs.language == 'javascript' || inputs.language == 'multi'
+        continue-on-error: true
         working-directory: ${{ inputs.working-directory }}
         run: |
           case "${{ steps.detect-pm.outputs.pm }}" in
@@ -210,9 +206,8 @@ jobs:
             bun) echo "Bun audit not yet supported" > npm-audit.json ;;
           esac
 
-      # License checking
       - name: Check JavaScript licenses
-        if: inputs.enable-license-check
+        if: (inputs.language == 'javascript' || inputs.language == 'multi') && inputs.enable-license-check
         working-directory: ${{ inputs.working-directory }}
         env:
           # license-checker (davglass) is unmaintained since 2019; the
@@ -233,8 +228,8 @@ jobs:
             license-checker-rseidelsohn --failOn "$DENIED" 2>&1 | tee js-licenses-violations.txt || true
           fi
 
-      - name: Upload audit results
-        if: always()
+      - name: Upload JavaScript audit results
+        if: always() && (inputs.language == 'javascript' || inputs.language == 'multi')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: javascript-audit-results
@@ -246,32 +241,26 @@ jobs:
           retention-days: 30
           if-no-files-found: ignore
 
-  python-audit:
-    name: Audit Python
-    if: inputs.language == 'python' || inputs.language == 'multi'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
+      # --- Python ---
       - name: Setup Python
+        if: inputs.language == 'python' || inputs.language == 'multi'
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
           cache: 'pip'
 
-      - name: Install dependencies
+      - name: Install Python dependencies
+        if: inputs.language == 'python' || inputs.language == 'multi'
         working-directory: ${{ inputs.working-directory }}
         run: |
           if [ -f requirements.txt ]; then
             pip install -r requirements.txt
           fi
 
-      # Vulnerability scanning
       - name: Install and run safety
+        id: python-audit
+        if: inputs.language == 'python' || inputs.language == 'multi'
+        continue-on-error: true
         working-directory: ${{ inputs.working-directory }}
         env:
           # renovate: datasource=pypi depName=safety
@@ -282,9 +271,8 @@ jobs:
             safety check --file requirements.txt --json > safety-results.json || true
           fi
 
-      # License checking
       - name: Check Python licenses
-        if: inputs.enable-license-check
+        if: (inputs.language == 'python' || inputs.language == 'multi') && inputs.enable-license-check
         working-directory: ${{ inputs.working-directory }}
         env:
           # renovate: datasource=pypi depName=pip-licenses
@@ -295,8 +283,8 @@ jobs:
           pip-licenses --format=json > python-licenses.json 2>&1 || true
           pip-licenses --format=markdown > python-licenses.md 2>&1 || true
 
-      - name: Upload audit results
-        if: always()
+      - name: Upload Python audit results
+        if: always() && (inputs.language == 'python' || inputs.language == 'multi')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-audit-results
@@ -307,13 +295,10 @@ jobs:
           retention-days: 30
           if-no-files-found: ignore
 
-  security-report:
-    name: Create Report
-    runs-on: ubuntu-latest
-    needs: [dependency-review, go-audit, javascript-audit, python-audit]
-    if: always() && !cancelled()
-    steps:
+      # Report folded from the old security-report job; step outcomes replace
+      # needs.*.result (a disabled/skipped language step reports `skipped`).
       - name: Generate Security Report
+        if: always()
         run: |
           TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
 
@@ -326,10 +311,10 @@ jobs:
 
           | Component | Status |
           | --- | --- |
-          | Dependency Review | ${{ needs.dependency-review.result }} |
-          | Go Audit | ${{ needs.go-audit.result }} |
-          | JavaScript Audit | ${{ needs.javascript-audit.result }} |
-          | Python Audit | ${{ needs.python-audit.result }} |
+          | Dependency Review | ${{ steps.dependency-review.outcome }} |
+          | Go Audit | ${{ steps.go-audit.outcome }} |
+          | JavaScript Audit | ${{ steps.javascript-audit.outcome }} |
+          | Python Audit | ${{ steps.python-audit.outcome }} |
 
           **Allowed Licenses:** \`${{ inputs.allowed-licenses }}\`
           **Denied Licenses:** \`${{ inputs.denied-licenses }}\`

--- a/.github/workflows/security-secrets.yml
+++ b/.github/workflows/security-secrets.yml
@@ -218,3 +218,25 @@ jobs:
           | TruffleHog | ${{ steps.trufflehog.outcome }} |
           | Pattern Detection | ${PATTERN_OUTCOME} |
           EOF
+
+      # continue-on-error above only lets the later sequential steps run; it
+      # must not swallow the gates. On origin/main trufflehog (verified hits)
+      # and the AWS-key/private-key checks (exit 1) failed the workflow and
+      # blocked merge. Re-raise that here so behaviour is unchanged. The
+      # generic-pattern step only warned on main, so it stays report-only.
+      - name: Enforce secret-scan result
+        if: always()
+        run: |
+          fail=0
+          if [ "${{ inputs.enable-trufflehog }}" = "true" ] \
+             && [ "${{ steps.trufflehog.outcome }}" = "failure" ]; then
+            echo "::error::TruffleHog found verified secrets"
+            fail=1
+          fi
+          if [ "${{ inputs.enable-pattern-detection }}" = "true" ] && {
+               [ "${{ steps.pattern-detection.outcome }}" = "failure" ] \
+               || [ "${{ steps.pattern-private-key.outcome }}" = "failure" ]; }; then
+            echo "::error::Secret pattern detected (AWS key or private key)"
+            fail=1
+          fi
+          exit "$fail"

--- a/.github/workflows/security-secrets.yml
+++ b/.github/workflows/security-secrets.yml
@@ -83,11 +83,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  trufflehog:
-    name: Scan with TruffleHog
-    if: inputs.enable-trufflehog
+  # trufflehog + pattern-detection + report merged into one sequential job:
+  # all run with only contents:read, so no least-privilege loss. gitleaks
+  # stays separate because it needs pull-requests:read (see above). Each scan
+  # is a step guarded by its original enable-* input; report is the final
+  # always()-step referencing step outcomes instead of needs.*.result.
+  secret-scan:
+    name: Scan Secrets
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # needs gitleaks only so the report step can render its result; the scans
+    # in this job do not depend on gitleaks output.
+    needs: [gitleaks]
+    if: always() && !cancelled()
+    permissions:
+      contents: read
+      actions: read
+    # Union of the merged jobs' timeouts (trufflehog 15 + pattern 10).
+    timeout-minutes: 25
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -96,6 +108,9 @@ jobs:
           persist-credentials: false
 
       - name: Run TruffleHog
+        id: trufflehog
+        if: inputs.enable-trufflehog
+        continue-on-error: true
         uses: trufflesecurity/trufflehog@27b0417c16317ca9a472a9a8092acce143b49c55 # v3.95.9
         with:
           path: ${{ inputs.working-directory }}
@@ -103,18 +118,10 @@ jobs:
           head: HEAD
           extra_args: --debug --only-verified
 
-  pattern-detection:
-    name: Detect Patterns
-    if: inputs.enable-pattern-detection
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
       - name: AWS Access Key Detection
+        id: pattern-detection
+        if: inputs.enable-pattern-detection
+        continue-on-error: true
         working-directory: ${{ inputs.working-directory }}
         run: |
           echo "Checking for AWS access key patterns..."
@@ -126,6 +133,9 @@ jobs:
           echo "✓ No AWS access keys found"
 
       - name: Private Key Detection
+        id: pattern-private-key
+        if: inputs.enable-pattern-detection
+        continue-on-error: true
         working-directory: ${{ inputs.working-directory }}
         run: |
           echo "Checking for private key content..."
@@ -137,6 +147,9 @@ jobs:
           echo "✓ No private keys found"
 
       - name: Generic Secret Patterns
+        id: pattern-generic
+        if: inputs.enable-pattern-detection
+        continue-on-error: true
         working-directory: ${{ inputs.working-directory }}
         run: |
           echo "Checking for generic secret patterns..."
@@ -177,13 +190,20 @@ jobs:
             echo "   Please verify these are using secure secret management"
           fi
 
-  security-report:
-    name: Create Report
-    runs-on: ubuntu-latest
-    needs: [gitleaks, trufflehog, pattern-detection]
-    if: always() && !cancelled()
-    steps:
+      # Report is the final step of secret-scan (folded from the old
+      # security-report job). Gitleaks stays a separate job → needs.*.result;
+      # trufflehog/pattern are steps → steps.*.outcome. The pattern cell is
+      # failure if any of the three pattern steps failed, else skipped/success.
       - name: Generate Security Report
+        if: always()
+        env:
+          PATTERN_OUTCOME: >-
+            ${{
+              (steps.pattern-detection.outcome == 'failure'
+               || steps.pattern-private-key.outcome == 'failure'
+               || steps.pattern-generic.outcome == 'failure') && 'failure'
+              || steps.pattern-detection.outcome
+            }}
         run: |
           TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
           cat >> "$GITHUB_STEP_SUMMARY" << EOF
@@ -195,6 +215,6 @@ jobs:
           | Scanner | Status |
           | --- | --- |
           | Gitleaks | ${{ needs.gitleaks.result }} |
-          | TruffleHog | ${{ needs.trufflehog.result }} |
-          | Pattern Detection | ${{ needs.pattern-detection.result }} |
+          | TruffleHog | ${{ steps.trufflehog.outcome }} |
+          | Pattern Detection | ${PATTERN_OUTCOME} |
           EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,12 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
     `Terraform Security`, `Scan Kubernetes`, `Scan Ansible`, `Create Report`)
 
   `gitleaks` stays an isolated job with scoped `pull-requests: read`
-  (least-privilege preserved). Individual scanner behaviour is unchanged; only
-  the job topology differs. Note: `security-containers.yml`'s `scan-timeout`
+  (least-privilege preserved). Scanner pass/fail behaviour is preserved:
+  merged scanners run with `continue-on-error` so later sequential steps
+  execute, and a final enforce step re-raises the original gates — the
+  AWS-key / private-key checks (`security-secrets`), `fail-on-findings`
+  (`security-config`), and `fail-on-severity` (`security-deps`) still fail the
+  workflow exactly as before. Note: `security-containers.yml`'s `scan-timeout`
   input no longer sets the job timeout (fixed 40 min ceiling now); the input is
   retained for compatibility but has no effect.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,36 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
+## Unreleased
+
+### ⚠ BREAKING
+
+- **`security-secrets.yml`, `security-deps.yml`, `security-containers.yml`,
+  `security-config.yml`**: scan jobs merged into a single sequential-step job
+  per workflow to stop paying GitHub's per-job minute-rounding tax (each job
+  rounds up to a full billed minute; scans ran 6–13 s each). Status-check
+  context names change, which breaks branch-protection / ruleset required-check
+  anchors pinned to the old job names.
+
+  **Migration**: update required-status-check anchors in consumer rulesets /
+  branch protection to the new context names:
+  - `security-secrets.yml`: `Scan with Gitleaks` (unchanged) + `Scan Secrets`
+    (replaces `Scan with TruffleHog`, `Detect Patterns`, `Create Report`)
+  - `security-deps.yml`: `Scan Dependencies` (replaces `Dependency Review
+    (GitHub)`, `Audit Go`, `Audit JavaScript`, `Audit Python`, `Create Report`)
+  - `security-containers.yml`: `Scan Container Image` (replaces `Scan with
+    Trivy`, `Scan with Grype`, `Analyze Images`, `Create Report`)
+  - `security-config.yml`: `Scan Configuration` (replaces `Trivy Config Scan`,
+    `Terraform Security`, `Scan Kubernetes`, `Scan Ansible`, `Create Report`)
+
+  `gitleaks` stays an isolated job with scoped `pull-requests: read`
+  (least-privilege preserved). Individual scanner behaviour is unchanged; only
+  the job topology differs. Note: `security-containers.yml`'s `scan-timeout`
+  input no longer sets the job timeout (fixed 40 min ceiling now); the input is
+  retained for compatibility but has no effect.
+
+---
+
 ## 2026-07-10
 
 ### Fixed

--- a/docs/superpowers/specs/2026-07-12-security-job-fanout-design.md
+++ b/docs/superpowers/specs/2026-07-12-security-job-fanout-design.md
@@ -1,0 +1,114 @@
+# Security-Reusables: Job-Fan-out reduzieren gegen Minuten-Aufrundung
+
+**Datum:** 2026-07-12
+**Typ:** Refactor
+**Notion:** https://app.notion.com/p/39abf097036e8133b4b4d95db8b56bee
+**Pfad:** nicht-trivial · **Aufwand:** M · **Prio:** P2
+
+## Problem
+
+GitHub rundet jeden Job auf die volle billed Minute auf. Die vier geteilten
+Security-Reusables splitten in viele separate Jobs (je eigener Runner-Spin-up
++ Checkout + eigene Minuten-Aufrundung). Einzelne Scan-Jobs laufen teils nur
+6–13 s, werden aber jeder auf 1 volle Minute aufgerundet → der Split kostet
+fast reine Rundungs-Steuer. Gemessen ~902 billable min/mo fleetweit
+(367 secrets + 535 deps/config/containers).
+
+## Ziel
+
+Jobs, die keine eigene Permission-Isolation brauchen, in EINEN Job mit
+sequenziellen Steps zusammenlegen. `security-report` als letzter Step statt
+eigenem Job.
+
+## Änderungen pro Workflow
+
+| Workflow                 | Vorher  | Nachher                                                                      | Runner gespart |
+| ------------------------ | ------- | --------------------------------------------------------------------------- | -------------- |
+| `security-secrets.yml`   | 4 Jobs  | `gitleaks` (isoliert, `pull-requests:read`) + `secret-scan` (trufflehog + pattern + report, `contents:read`) | 2 |
+| `security-deps.yml`      | 5 Jobs  | 1 Job `dependency-scan`, Steps behalten ihre `if:`-Guards                    | 4              |
+| `security-containers.yml`| 4 Jobs  | 1 Job `container-scan`                                                       | 3              |
+| `security-config.yml`    | 5 Jobs  | 1 Job `config-scan`                                                          | 4              |
+
+## Trade-off (nicht wegwischen)
+
+Der Split ist bei `secrets` teils absichtlich: `gitleaks` läuft mit scoped
+per-Job `pull-requests: read` (least-privilege, dokumentiert in REVIEW.md und
+CHANGELOG.md — gitleaks-action v3 enumeriert PR-Commits über die pulls-API).
+**Entscheidung: konservativ.** `gitleaks` bleibt eigener Job. `trufflehog` +
+`pattern-detection` + `report` gehen in einen `secret-scan`-Job mit nur
+`contents: read`. Least-Privilege bleibt sauber, spart 2 statt 3 Runner.
+
+Bei `deps`/`containers`/`config` teilen sich alle Jobs bereits die
+workflow-level Permissions; nur die `if:`-Conditions unterscheiden. Merge zu
+je 1 Job ist permission-neutral.
+
+## Mechanik
+
+- **Merged Job = 1 Checkout + sequenzielle Steps.** Jeder Step behält seine
+  ursprüngliche Job-`if:`-Bedingung, jetzt als Step-`if:`
+  (z.B. `if: inputs.language == 'go' || inputs.language == 'multi'`).
+- **Setup-Union:** deps-Job braucht Go+Node+Python-Setup, jeweils hinter dem
+  passenden Step-`if:`. Die Sprach-Guards verhindern unnötige Installs.
+- **`security-report` → letzter Step.** Job-Result-Refs (`needs.X.result`)
+  gehen im Single-Job nicht. Ersatz: Step-`id:` + `steps.<id>.outcome` in der
+  Report-Tabelle. Jeder Scan-Step, dessen Ergebnis in den Report soll, bekommt
+  `id:`.
+- **`continue-on-error`:** Steps laufen jetzt sequenziell — ein Step mit
+  `exit 1` würde den Report-Step abbrechen. Die bestehenden Jobs nutzen bereits
+  `|| true`/`continue-on-error` breit. Jeder Scan-Step, der fatal enden könnte
+  und dessen Report trotzdem laufen muss, bekommt `continue-on-error: true`.
+  Der Report-Step selbst läuft `if: always()`.
+- **`timeout-minutes`:** Merged Job = Summe/Union der alten Step-Timeouts
+  (obere Grenze, nicht knausern).
+
+### Report-Referenz-Mapping
+
+Statt `needs.<job>.result` → `steps.<id>.outcome`:
+
+- secrets `secret-scan`: `trufflehog` + `pattern-detection` Step-Outcomes;
+  gitleaks bleibt eigener Job, Report referenziert `needs.gitleaks.result`
+  (secret-scan `needs: [gitleaks]` behalten, nur für die Report-Zeile).
+- deps `dependency-scan`: `dependency-review`, `go-audit`, `js-audit`,
+  `python-audit` Step-Outcomes.
+- containers `container-scan`: `trivy`, `grype`, `image-analysis`.
+- config `config-scan`: `trivy-config`, `terraform`, `kubernetes`, `ansible`.
+
+Ein per-`if:` übersprungener Step hat Outcome `skipped` → korrekt in der
+Tabelle.
+
+## Breaking Change
+
+Job-Merge ändert die Status-Check-Kontext-Namen. Alte Kontexte
+(`Audit Go`, `Scan with Trivy`, `Create Report`, …) verschwinden, neuer
+Kontext `<Scan-Job-Name>`. Branch-Protection/Ruleset-Anker in Consumer-Repos,
+die auf die alten Namen zeigen, brechen.
+
+**Handling:**
+
+1. Neuen Datums-Tag cutten (kein `@main` für Consumer).
+2. `### ⚠ BREAKING`-Heading im CHANGELOG-Eintrag des Tags: betroffene
+   Workflows + neue Job-Namen + Migrationsschritt "Ruleset/branch-protection
+   required-status-check-Anker auf neue Kontext-Namen umstellen".
+3. AGENTS.md + README Job-Count-Referenzen aktualisieren (24 Workflows bleibt,
+   aber Job-Zahlen/Beschreibungen anpassen).
+
+## Neue Job-Namen (Status-Check-Kontexte)
+
+- `security-secrets.yml`: `Scan with Gitleaks` (unverändert) + `Scan Secrets`
+- `security-deps.yml`: `Scan Dependencies`
+- `security-containers.yml`: `Scan Container Image`
+- `security-config.yml`: `Scan Configuration`
+
+## Testing
+
+- `actionlint` auf die 4 geänderten Dateien (Syntax + Expression-Checks).
+- YAML-Expression-Syntax manuell prüfen (Step-Outcome-Refs).
+- **Kein** Consumer-Live-Test in dieser Session (bräuchte Tag-Push). Als
+  manueller Schritt geflaggt: nach Tag-Cut in 1–2 Consumer-Repos gegen den
+  neuen Tag testen, bevor breit ausgerollt wird.
+
+## Scope-Grenzen (skipped)
+
+- Matrix-basierter Merge — würde weiter auf N Runner fan-out, defeats purpose.
+- `security-code.yml` / `security-sbom.yml` — nicht im Card-Scope.
+- Kein Verhalten der Scans selbst geändert, nur Job-Topologie.


### PR DESCRIPTION
## Summary

- Merge each of the four security reusables' parallel scan jobs into one
  sequential-step job to stop paying GitHub's per-job minute-rounding tax
  (6-13 s scans were each billed a full minute). Saves ~13 runner spin-ups
  per full run across secrets/deps/containers/config.
- Fold each `security-report` job into a final `if: always()` step; job-result
  refs (`needs.X.result`) become step-outcome refs (`steps.X.outcome`).
- `gitleaks` stays an isolated job with scoped `pull-requests: read`, so
  least-privilege is preserved; deps/containers/config merge fully.

## Test plan

- [ ] actionlint clean — no new findings vs. base (pre-existing SC2086 counts
      identical per file; out of scope).
- [ ] All step `id:`s unique; every `steps.X.outcome`/`outputs` reference
      resolves to an existing id.
- [ ] After a date tag is cut, smoke-test in 1-2 consumer repos before broad
      rollout — status-check context names changed (see CHANGELOG BREAKING),
      so ruleset / branch-protection anchors need updating.
