### PR TITLE
refactor(ci): gate heavy jobs behind the fast lint/validate job

### DIFF
--- a/.github/workflows/ci-ansible.yml
+++ b/.github/workflows/ci-ansible.yml
@@ -128,6 +128,9 @@ jobs:
   lint:
     name: Lint
     if: ${{ inputs.enable-ansible-lint }}
+    # Gate behind validation: a failed syntax check aborts before ansible-lint
+    # spends a runner. validation is unconditional, so plain needs is enough.
+    needs: validation
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -165,6 +168,8 @@ jobs:
   yamllint:
     name: YAML Lint
     if: ${{ inputs.enable-yamllint }}
+    # Gate behind validation so a syntax failure aborts before yamllint runs.
+    needs: validation
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -150,7 +150,13 @@ jobs:
 
   validate-fleet-configs:
     name: Validate Fleet Configurations
-    if: inputs.enable-fleet-validation
+    # Gate behind validate-yaml. The gate is conditional (enable-yaml-lint), so
+    # the always()/!failure()/!cancelled() guard runs this job when the gate
+    # succeeds OR is skipped, and blocks only on a gate failure.
+    needs: [validate-yaml]
+    if: >-
+      always() && !failure() && !cancelled()
+      && inputs.enable-fleet-validation
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -208,7 +214,10 @@ jobs:
 
   validate-gitrepo:
     name: Validate GitRepo Configuration
-    if: inputs.enable-gitrepo-validation
+    needs: [validate-yaml]
+    if: >-
+      always() && !failure() && !cancelled()
+      && inputs.enable-gitrepo-validation
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -251,7 +260,10 @@ jobs:
 
   validate-helm:
     name: Validate Helm Charts
-    if: inputs.enable-helm-lint
+    needs: [validate-yaml]
+    if: >-
+      always() && !failure() && !cancelled()
+      && inputs.enable-helm-lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -297,7 +309,10 @@ jobs:
 
   validate-helm-template:
     name: Validate Rendered Helm Output
-    if: inputs.enable-helm-template-validation
+    needs: [validate-yaml]
+    if: >-
+      always() && !failure() && !cancelled()
+      && inputs.enable-helm-template-validation
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -377,7 +392,10 @@ jobs:
 
   validate-kubernetes:
     name: Validate Kubernetes Manifests
-    if: inputs.enable-k8s-validation
+    needs: [validate-yaml]
+    if: >-
+      always() && !failure() && !cancelled()
+      && inputs.enable-k8s-validation
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -419,7 +437,10 @@ jobs:
 
   check-documentation:
     name: Check Documentation
-    if: inputs.enable-docs-check
+    needs: [validate-yaml]
+    if: >-
+      always() && !failure() && !cancelled()
+      && inputs.enable-docs-check
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -102,6 +102,10 @@ jobs:
   lint:
     name: Lint
     if: ${{ inputs.enable-tflint }}
+    # Gate behind validation: a failed terraform validate/fmt aborts before
+    # tflint spends a runner. validation is unconditional, so plain needs is
+    # enough — a validation failure skips this job.
+    needs: validation
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -130,6 +134,8 @@ jobs:
 
   trivy:
     name: Vulnerability Scanning
+    # Gate behind validation so a broken config fails fast before the scan runs.
+    needs: validation
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,23 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   input no longer sets the job timeout (fixed 40 min ceiling now); the input is
   retained for compatibility but has no effect.
 
+### Changed
+
+- **`ci-terraform.yml`, `ci-ansible.yml`, `ci-gitops.yml`**: expensive jobs now
+  wait for the cheap lint/validate job via `needs:`, so a lint failure aborts
+  before the heavy jobs burn minutes.
+  - `ci-terraform.yml`: `lint` + `trivy` gain `needs: validation`.
+  - `ci-ansible.yml`: `lint` + `yamllint` gain `needs: validation`.
+  - `ci-gitops.yml`: the six non-gate jobs gain `needs: [validate-yaml]` with an
+    `always() && !failure() && !cancelled()` guard, so they still run when the
+    (conditional) gate is skipped but stop when it fails.
+
+  **Not breaking**: no job names change, so required-status-check anchors stay
+  valid. Behaviour note: a heavy job that previously reported `failure`
+  independently now reports `skipped` when the gate fails, and successful runs
+  are slightly slower (gate first, then heavy). `ci-go.yml` / `ci-js.yml`
+  already gate their heavy jobs; unchanged.
+
 ---
 
 ## 2026-07-10

--- a/docs/superpowers/specs/2026-07-12-ci-lint-gate-design.md
+++ b/docs/superpowers/specs/2026-07-12-ci-lint-gate-design.md
@@ -1,0 +1,93 @@
+# Lint/Fast-Checks vor Heavy-Jobs in ci-*-Reusables gaten
+
+**Datum:** 2026-07-12
+**Typ:** Refactor
+**Notion:** https://app.notion.com/p/39abf097036e81d099f6c430062282f5
+**Pfad:** nicht-trivial · **Aufwand:** M · **Prio:** P2
+
+## Problem
+
+In den geteilten `ci-*.yml`-Reusables laufen teure Jobs (Security-Scan, CodeQL,
+Terraform-Plan/Trivy, Ansible-Lint, Helm-Render/Kubeconform) teils parallel zu
+oder unabhängig von einem billigen Lint/Format/Validate. Ein Lint-Fehler stoppt
+den teuren Job nicht früh → verschwendete Minuten. Aus dem Minuten-Audit
+(Massnahme 2): failed+cancelled Runs zogen fleetweit ~433 min/mo Compute.
+
+## Ziel
+
+Teure Jobs erst NACH einem schnellen Gate laufen lassen (`needs:`). Lint-Fehler
+bricht früh ab, statt dass ein teurer Job parallel durchläuft und eh verworfen
+wird.
+
+## Änderungen pro Workflow
+
+| Workflow           | Änderung                                                                 |
+| ------------------ | ----------------------------------------------------------------------- |
+| `ci-go.yml`        | Keine — `security-scan` + `codeql-analysis` gaten bereits (`needs: [setup, test-and-lint, test-and-lint-postgres]`). |
+| `ci-js.yml`        | Keine — `security-scan` gatet bereits (`needs: [setup, quality-and-test]`). |
+| `ci-terraform.yml` | `lint` + `trivy` bekommen `needs: validation`.                          |
+| `ci-ansible.yml`   | `lint` + `yamllint` bekommen `needs: validation`.                        |
+| `ci-gitops.yml`    | Alle 6 Nicht-Gate-Jobs bekommen `needs: [validate-yaml]` + Guard-`if:`.  |
+
+## Zwei needs-Muster
+
+**terraform / ansible — plain `needs`:** Der `validation`-Job ist
+unbedingt (kein `if:`). `needs: validation` reicht: bricht `validation`, werden
+die abhängigen Jobs übersprungen. `lint` behält sein bestehendes
+`if: inputs.enable-*`.
+
+**gitops — `needs` + always()-Guard:** Der Gate-Job `validate-yaml` ist
+bedingt (`if: inputs.enable-yaml-lint`). Plain `needs` würde die abhängigen
+Jobs mit-skippen, wenn das Gate *deaktiviert* ist. Guard:
+
+```yaml
+needs: [validate-yaml]
+if: >-
+  always() && !failure() && !cancelled()
+  && inputs.enable-<eigenes-flag>
+```
+
+Läuft, wenn das Gate **success** ODER **skipped** ist; blockt nur bei Gate-
+**failure**. Jeder Job behält sein eigenes `enable-*` im selben `if:`.
+
+Betroffene gitops-Jobs (alle ausser `validate-yaml` und `summary`):
+`validate-fleet-configs`, `validate-gitrepo`, `validate-helm`,
+`validate-helm-template`, `validate-kubernetes`, `check-documentation`.
+`summary` behält sein bestehendes `needs: [...]` + `if: always()`.
+
+## go/js: warum keine Änderung
+
+`dependency-review` in ci-go (Zeile 528) und ci-js (Zeile 521) hat kein
+`needs:` — läuft parallel. Es ist aber **kein Heavy-Job**: reine
+`dependency-review-action`, PR-only + public-only, kein Build/Scan-Compute. Das
+Card-Ziel sind die teuren Jobs (Security-Scan, CodeQL), die bereits gegatet
+sind. `dependency-review` zu gaten fügt nur Wall-Clock für einen ohnehin
+billigen Check hinzu → bewusst ungegatet gelassen (YAGNI).
+
+## Status-Checks / BREAKING
+
+Es ändern sich **keine Job-Namen**, nur `needs:` (+ bei gitops die `if:`-
+Guards). Status-Check-Kontext-Namen bleiben stabil → **keine** Ruleset-/
+Branch-Protection-Anker-Migration nötig. Damit ist das **kein** Breaking Change
+im CHANGELOG-Sinn → regulärer Datums-Tag, kein `⚠ BREAKING`.
+
+Verhaltensänderung (nicht-breaking, dokumentieren): Ein Run, der vorher einen
+Heavy-Job unabhängig als `failure` zeigte, zeigt ihn jetzt `skipped`, wenn das
+Gate vorher failt. Erfolgreiche Runs werden sequenziell etwas langsamer
+(Gate zuerst, dann Heavy) — Trade-off gegen die Minuten-Ersparnis bei
+Fehlläufen.
+
+## Testing
+
+- `actionlint` auf ci-terraform, ci-ansible, ci-gitops (Syntax +
+  needs-Referenzen + Expression-Guards).
+- Verifizieren, dass go/js-Heavy-Jobs weiterhin voll gegatet sind (nur Lesen).
+- **Kein** Consumer-Live-Test in dieser Session (bräuchte Tag-Push). Manueller
+  Schritt: nach Tag-Cut in 1–2 Consumer-Repos testen.
+
+## Scope-Grenzen (skipped)
+
+- Dedizierter `gate`-Job in gitops — grösserer Umbau, `validate-yaml`-Name
+  würde sich ändern (mehr BREAKING). `needs`+Guard ist der kleinere Eingriff.
+- go/js-Code-Änderungen — Heavy-Jobs bereits gegatet.
+- Keine Änderung an Job-Logik, nur Abhängigkeits-Topologie.


### PR DESCRIPTION
## Summary

- Gate the expensive CI jobs behind the cheap lint/validate job via `needs:`,
  so a lint failure aborts before heavy jobs burn minutes (minute-audit
  Massnahme 2 — failed/cancelled runs drew ~433 min/mo fleet-wide).
  - `ci-terraform.yml`: `lint` + `trivy` gain `needs: validation`.
  - `ci-ansible.yml`: `lint` + `yamllint` gain `needs: validation`.
  - `ci-gitops.yml`: the six non-gate jobs gain `needs: [validate-yaml]` with an
    `always() && !failure() && !cancelled()` guard, so they still run when the
    conditional gate is skipped but stop when it fails.
- `ci-go.yml` / `ci-js.yml` already gate their heavy jobs (security-scan,
  codeql); no change.

Not breaking: no job names change, so required-status-check anchors stay valid.
Trade-off: successful runs are slightly slower (gate first, then heavy).

## Test plan

- [ ] actionlint clean — no new findings vs. base (pre-existing shellcheck
      counts identical per file; out of scope).
- [ ] Job-dependency graph verified: all `needs:` targets exist, no cycles, the
      gitops guard runs on gate success/skip and blocks on gate failure.
- [ ] After a date tag is cut, smoke-test in 1-2 consumer repos.
