### PR TITLE
chore(security-deps): allow OFL-1.1 license org-wide

### DIFF
--- a/.github/workflows/security-deps.yml
+++ b/.github/workflows/security-deps.yml
@@ -24,7 +24,7 @@ on:
         description: 'Enable license compliance checking'
       allowed-licenses:
         type: string
-        default: 'Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,MIT,0BSD,CC0-1.0'
+        default: 'Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,MIT,0BSD,CC0-1.0,OFL-1.1'
         description: 'Comma-separated list of allowed licenses'
       denied-licenses:
         type: string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,9 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   - `security-secrets.yml`: `Scan with Gitleaks` (unchanged) + `Scan Secrets`
     (replaces `Scan with TruffleHog`, `Detect Patterns`, `Create Report`)
   - `security-deps.yml`: `Scan Dependencies` (replaces `Dependency Review
-(GitHub)`, `Audit Go`, `Audit JavaScript`, `Audit Python`, `Create Report`)
+    (GitHub)`, `Audit Go`, `Audit JavaScript`, `Audit Python`, `Create Report`)
   - `security-containers.yml`: `Scan Container Image` (replaces `Scan with
-Trivy`, `Scan with Grype`, `Analyze Images`, `Create Report`)
+    Trivy`, `Scan with Grype`, `Analyze Images`, `Create Report`)
   - `security-config.yml`: `Scan Configuration` (replaces `Trivy Config Scan`,
     `Terraform Security`, `Scan Kubernetes`, `Scan Ansible`, `Create Report`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,9 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   - `security-secrets.yml`: `Scan with Gitleaks` (unchanged) + `Scan Secrets`
     (replaces `Scan with TruffleHog`, `Detect Patterns`, `Create Report`)
   - `security-deps.yml`: `Scan Dependencies` (replaces `Dependency Review
-    (GitHub)`, `Audit Go`, `Audit JavaScript`, `Audit Python`, `Create Report`)
+(GitHub)`, `Audit Go`, `Audit JavaScript`, `Audit Python`, `Create Report`)
   - `security-containers.yml`: `Scan Container Image` (replaces `Scan with
-    Trivy`, `Scan with Grype`, `Analyze Images`, `Create Report`)
+Trivy`, `Scan with Grype`, `Analyze Images`, `Create Report`)
   - `security-config.yml`: `Scan Configuration` (replaces `Trivy Config Scan`,
     `Terraform Security`, `Scan Kubernetes`, `Scan Ansible`, `Create Report`)
 
@@ -54,6 +54,10 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ### Changed
 
+- **`security-deps.yml`**: add `OFL-1.1` to the default `allowed-licenses` so
+  fonts and icon sets under the SIL Open Font License no longer fail dependency
+  license checks. Not breaking — widening an allow-list can only make
+  previously-failing checks pass.
 - **`ci-terraform.yml`, `ci-ansible.yml`, `ci-gitops.yml`**: expensive jobs now
   wait for the cheap lint/validate job via `needs:`, so a lint failure aborts
   before the heavy jobs burn minutes.


### PR DESCRIPTION
## Summary

- Add `OFL-1.1` to the default `allowed-licenses` list in `security-deps.yml`
- Fonts and icon sets ship under the SIL Open Font License; dependency license checks no longer flag them across consumer repos

## Test plan

- [ ] CI green on this PR
- [ ] Consumers pick it up after the next date tag is cut
