### PR TITLE
chore(release): cut 2026-07-13 tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ## Unreleased
 
+---
+
+## 2026-07-13
+
 ### ⚠ BREAKING
 
 - **`security-secrets.yml`, `security-deps.yml`, `security-containers.yml`,


### PR DESCRIPTION
## Summary

- Promote the `## Unreleased` entries to a dated `## 2026-07-13` section, cutting the new rolling-release tag
- Covers the scan-job merge (breaking), heavy-job gating, and the `OFL-1.1` allow-list addition already on `main`

## Test plan

- [ ] CI green on this PR
- [ ] Tag `2026-07-13` pushed after merge; Renovate propagates the bump to consumers
