### PR TITLE
chore(ci): allow OFL-1.1 in ci-js and ci-go license gates

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -540,4 +540,4 @@ jobs:
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: moderate
-          allow-licenses: Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MIT, 0BSD, MPL-2.0, CC-BY-4.0, CC0-1.0, LicenseRef-scancode-google-patent-license-golang, BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang
+          allow-licenses: Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MIT, 0BSD, MPL-2.0, CC-BY-4.0, CC0-1.0, OFL-1.1, LicenseRef-scancode-google-patent-license-golang, BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -534,7 +534,7 @@ jobs:
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: moderate
-          allow-licenses: Apache-2.0, BSD-2-Clause, BSD-2-Clause-Views, BSD-3-Clause, ISC, MIT, 0BSD, LGPL-2.1+, MPL-2.0, BlueOak-1.0.0, CC-BY-4.0, CC0-1.0, LicenseRef-scancode-google-patent-license-golang, BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang, BSD-2-Clause AND BSD-2-Clause-Views
+          allow-licenses: Apache-2.0, BSD-2-Clause, BSD-2-Clause-Views, BSD-3-Clause, ISC, MIT, 0BSD, LGPL-2.1+, MPL-2.0, BlueOak-1.0.0, CC-BY-4.0, CC0-1.0, OFL-1.1, LicenseRef-scancode-google-patent-license-golang, BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang, BSD-2-Clause AND BSD-2-Clause-Views
 
   summary:
     name: Create Summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ## Unreleased
 
+### Changed
+
+- **`ci-js.yml`, `ci-go.yml`**: add `OFL-1.1` to the `dependency-review-action`
+  `allow-licenses` list, matching the `security-deps.yml` default so fonts and
+  icon sets under the SIL Open Font License pass across all license gates. Not
+  breaking — widening an allow-list can only make previously-failing checks
+  pass.
+
 ---
 
 ## 2026-07-13


### PR DESCRIPTION
## Summary

- Add `OFL-1.1` to the `dependency-review-action` `allow-licenses` list in both `ci-js.yml` and `ci-go.yml`
- These lists are separate from the `security-deps.yml` default (#223); this brings all three license gates in line so SIL Open Font License deps pass everywhere

## Test plan

- [ ] CI green on this PR
- [ ] Consumers pick it up after the next date tag is cut
