### PR TITLE
fix(ci): set up Go before CodeQL init and allow toolchain fetch

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -506,11 +506,28 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
 
+    env:
+      # Let Go fetch the toolchain pinned in go.mod instead of failing when the
+      # Go on PATH is older (GOTOOLCHAIN defaults to local). Applies to the
+      # extractor, autobuild and analyze steps alike.
+      GOTOOLCHAIN: auto
+
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
+      # Must run before codeql-action/init: the Go extractor is configured at
+      # init time and otherwise picks up the Go bundled with the CodeQL
+      # release, which can be older than the version go.mod requires.
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: ${{ inputs.go-version }}
+          check-latest: true
+          cache: true
+          cache-dependency-path: go.sum
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0

--- a/.github/workflows/security-code.yml
+++ b/.github/workflows/security-code.yml
@@ -81,6 +81,13 @@ jobs:
       matrix:
         language: ${{ fromJSON(inputs.languages) }}
 
+    env:
+      # Let Go fetch the toolchain pinned in go.mod instead of failing when the
+      # Go on PATH is older (GOTOOLCHAIN defaults to local). Applies to the
+      # extractor, autobuild and analyze steps alike. No-op for non-Go
+      # languages.
+      GOTOOLCHAIN: auto
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -99,6 +106,16 @@ jobs:
             done
             echo "CODEQL_CONFIG_EOF"
           } >> "$GITHUB_OUTPUT"
+
+      # Must run before codeql-action/init: the Go extractor is configured at
+      # init time and otherwise picks up the Go bundled with the CodeQL
+      # release, which can be older than the version go.mod requires.
+      - name: Setup Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: ${{ inputs.go-version }}
+          cache: true
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
@@ -133,13 +150,6 @@ jobs:
         with:
           node-version-file: ${{ inputs.node-version-file }}
           cache: ${{ steps.detect-pm.outputs.manager }}
-
-      - name: Setup Go
-        if: matrix.language == 'go'
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version: ${{ inputs.go-version }}
-          cache: true
 
       - name: Setup Python
         if: matrix.language == 'python'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ## Unreleased
 
+### Fixed
+
+- **`security-code.yml`, `ci-go.yml`**: CodeQL-on-Go analysis no longer fails
+  extraction when `go.mod` requires a newer Go than the CodeQL bundle ships
+  (`go.mod requires go >= X (running go Y, GOTOOLCHAIN=local)`). The Go
+  extractor is configured by `codeql-action/init`, so `setup-go` now runs
+  before that step (`security-code.yml` ran it after; `ci-go.yml`'s CodeQL job
+  had none at all and used the bundled Go), and both jobs set
+  `GOTOOLCHAIN: auto` so Go may fetch the toolchain pinned in `go.mod`. Affects
+  every Go consumer of these workflows; no input, output, or permission
+  changes. The job-wide env is a no-op for non-Go matrix legs.
+
 ---
 
 ## 2026-07-13


### PR DESCRIPTION
## Summary

- The Go extractor is configured by `codeql-action/init` and picked up the Go bundled with the CodeQL release. When `go.mod` requires a newer version than the bundle ships, extraction fails with `go.mod requires go >= X (running go Y, GOTOOLCHAIN=local)`.
- `security-code.yml` already ran `setup-go`, but *after* `init` — too late for the extractor. Moved it ahead of `init`.
- `ci-go.yml`'s CodeQL job had no `setup-go` at all and ran purely on bundled Go. Added it.
- Set `GOTOOLCHAIN=auto` job-wide in both, so Go may fetch the toolchain pinned in `go.mod` (extractor, autobuild and analyze alike).

Opened as draft: this is a reusable workflow, so the change affects every Go consumer in the org, not a single repo.

## Test plan

- [ ] CI green on this PR
- [ ] Re-run a consumer's nightly `Analyze Code (go)` (e.g. a repo whose `go.mod` requires a Go newer than the CodeQL bundle) and confirm extraction succeeds
- [ ] Confirm non-Go languages (javascript-typescript, python) still analyze unchanged — `GOTOOLCHAIN` is a no-op there