### PR TITLE
docs: correct stale last-updated dates and workflow count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 **Repository Type**: Centralized Workflow Repository
 **Purpose**: Provide reusable GitHub Actions workflows for all sbaerlocher projects
 **Visibility**: Public
-**Last Updated**: 2026-05-03
+**Last Updated**: 2026-07-18
 
 ---
 
@@ -556,7 +556,7 @@ Ensure lock files are committed:
 ```text
 .github/
 ├── .github/
-│   ├── workflows/           # 22 reusable workflows + 1 internal self-test
+│   ├── workflows/           # 24 reusable workflows + 1 internal self-test
 │   │   ├── ai-*.yml        # AI workflows
 │   │   ├── ci-*.yml        # CI workflows
 │   │   ├── deploy-*.yml    # Deploy workflows
@@ -687,5 +687,5 @@ Ensure lock files are committed:
 
 ---
 
-**Last Updated**: 2026-05-03
+**Last Updated**: 2026-07-18
 **Version**: 1.4.0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ each workflow by date tag and let Renovate keep them current.
 
 - **Model:** rolling release with date tags (`YYYY-MM-DD`)
 - **Total workflows:** 24
-- **Last updated:** 2026-05-03
+- **Last updated:** 2026-07-18
 
 See [AGENTS.md](./AGENTS.md) for AI-agent context.
 


### PR DESCRIPTION
## Summary

- Correct the `Last Updated` fields in `AGENTS.md` and `README.md`: both claimed `2026-05-03`, while the files last changed `2026-06-17` and `2026-05-17` respectively.
- Fix the repository-structure comment in `AGENTS.md`, which undercounted reusable workflows as 22. The actual count is 24 reusable + 1 internal self-test = 25 files, verified per prefix (ai 2, ci 5, deploy 2, e2e 2, ops 3, release 4, security 6, test 1).

The `Total Workflows: 24` lines in both files were already correct and are untouched; all three counts now agree.

## Test plan

- [ ] `ls .github/workflows/*.yml | wc -l` returns 25, matching "24 reusable + 1 internal self-test"
- [ ] CI green (markdownlint / prettier)
