### PR TITLE
fix(ci-terraform): bump tflint to v0.64.0

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -119,7 +119,7 @@ jobs:
         uses: terraform-linters/setup-tflint@6e1e0642c0289bd619021bf6b34e3c08ed1e005a # v6.3.0
         with:
           # renovate: datasource=github-releases depName=terraform-linters/tflint
-          tflint_version: 'v0.63.1'
+          tflint_version: 'v0.64.0'
 
       - name: TFLint Init
         working-directory: ${{ inputs.working-directory }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,22 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
+## 2026-07-19
+
+### Fixed
+
+- **`ci-terraform.yml`**: `tflint --init` no longer crashes with
+  `runtime error: invalid memory address or nil pointer dereference` while
+  verifying the terraform plugin's signature attestation. The nil-pointer bug
+  lives in tflint's signature bundle verifier
+  ([terraform-linters/tflint#2591](https://github.com/terraform-linters/tflint/issues/2591))
+  and was triggered by a GitHub backend change, so it hits every run rather
+  than flaking intermittently. tflint v0.61.0–v0.63.1 are all affected;
+  the pin moves to v0.64.0, which upstream released as the fix. Affects every
+  consumer running with `enable-tflint: true`; no input or output changes.
+
+---
+
 ## 2026-07-18
 
 ### Fixed


### PR DESCRIPTION
## Summary

- `tflint --init` crashes with `runtime error: invalid memory address or nil pointer dereference` in the signature bundle verifier, aborting the Lint job for every consumer that sets `enable-tflint: true`.
- Root cause is an upstream nil-pointer bug affecting tflint v0.61.0–v0.63.1, triggered by a GitHub backend change — persistent, not an intermittent flake. Upstream released v0.64.0 as the fix ([terraform-linters/tflint#2591](https://github.com/terraform-linters/tflint/issues/2591)).
- Bumps the `tflint_version` pin in `ci-terraform.yml` from v0.63.1 to v0.64.0 and adds the dated CHANGELOG entry. No input, output, or permission changes.

## Test plan

- [ ] CI green on this PR
- [ ] A consumer repo running `ci-terraform.yml` with `enable-tflint: true` completes the Lint job (verify after the next date tag is cut)