### PR TITLE
feat(deploy-terraform): expose value-free drift summary for drift issues

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -114,6 +114,12 @@ on:
       drift_detected:
         description: 'Whether drift was detected (drift mode only): true, false, or error'
         value: ${{ jobs.deploy.outputs.drift_detected }}
+      drift_summary:
+        description: |
+          Value-free drift summary (drift mode only): one "<action> <address>"
+          line per drifting resource, capped. Never contains attribute values.
+          Empty string if no drift, not drift mode, or extraction failed.
+        value: ${{ jobs.deploy.outputs.drift_summary }}
     secrets:
       BW_ACCESS_TOKEN:
         required: true
@@ -143,6 +149,7 @@ jobs:
       plan_outcome: ${{ steps.plan.outputs.outcome }}
       apply_outcome: ${{ steps.apply.outputs.outcome }}
       drift_detected: ${{ steps.plan.outputs.drift_detected }}
+      drift_summary: ${{ steps.drift_summary.outputs.summary }}
 
     steps:
       # Fork guard — fail fast BEFORE any checkout or Bitwarden retrieval.
@@ -297,6 +304,54 @@ jobs:
               *) echo "drift_detected=error" >> "$GITHUB_OUTPUT" ;;
             esac
           fi
+
+      # Drift-Summary aus dem frischen Plan ziehen — Position ZWINGEND hier:
+      # die .tfplan liegt noch (Security Cleanup löscht sie am Jobende) und
+      # Terraform ist gegen R2 initialisiert, kein zweites setup/Artefakt nötig.
+      #
+      # LEVEL-A GRENZE (Wert-Freiheit): die jq-Query liest ausschliesslich
+      # .address und .change.actions, fasst .change.before/.after NIE an. Sie
+      # ist ein exaktes Duplikat der Query in scripts/drift-summary.sh — der
+      # Workflow checkt das Consumer-Repo aus, das Skript liegt zur Laufzeit
+      # nicht vor, darum inline. Ändert sich die eine, muss die andere folgen
+      # (Gleichheit von Hand geprüft; scripts/tests/test-drift-summary.sh ist
+      # der Anker der Wert-Freiheit). Nur Drift-Modus (YAGNI). Ein kaputter
+      # Summary darf die Drift-Meldung nie unterdrücken -> Fehler = leerer
+      # String, Step nie fatal.
+      - name: 'Drift Summary Extraction'
+        id: drift_summary
+        if: ${{ inputs.mode == 'drift' && steps.plan.outputs.drift_detected == 'true' }}
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          set +e
+          PLAN_FILE="${{ inputs.environment }}.tfplan"
+          CAP=50
+
+          LINES="$(terraform show -json "$PLAN_FILE" 2>/dev/null | jq -r '
+            .resource_changes // []
+            | map(select((.change.actions // []) != ["no-op"]))
+            | .[]
+            | "\(.change.actions | join("+")) \(.address)"
+          ' 2>/dev/null)"
+
+          SUMMARY=""
+          if [ -n "$LINES" ]; then
+            TOTAL="$(printf '%s\n' "$LINES" | wc -l)"
+            if [ "$TOTAL" -gt "$CAP" ]; then
+              SUMMARY="$(printf '%s\n' "$LINES" | head -n "$CAP")"
+              SUMMARY="$SUMMARY"$'\n'"… $((TOTAL - CAP)) more (truncated)"
+            else
+              SUMMARY="$LINES"
+            fi
+          fi
+
+          DELIM="drift_$(openssl rand -hex 8 2>/dev/null || echo RANDOM$$)"
+          {
+            echo "summary<<${DELIM}"
+            printf '%s\n' "$SUMMARY"
+            echo "${DELIM}"
+          } >> "$GITHUB_OUTPUT"
+          exit 0
 
       - name: 'Plan Artifact Storage'
         if: steps.plan.outputs.outcome != 'error'

--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -329,7 +329,7 @@ jobs:
 
           LINES="$(terraform show -json "$PLAN_FILE" 2>/dev/null | jq -r '
             .resource_changes // []
-            | map(select((.change.actions // []) != ["no-op"]))
+            | map(select((.change.actions // []) != ["no-op"] and (.change.actions // []) != ["read"]))
             | .[]
             | "\(.change.actions | join("+")) \(.address)"
           ' 2>/dev/null)"

--- a/.github/workflows/ops-drift-issue.yml
+++ b/.github/workflows/ops-drift-issue.yml
@@ -16,6 +16,18 @@ on:
         type: string
         required: true
         description: 'URL to the triggering workflow run for issue cross-reference'
+      drift-summary:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Optional value-free drift summary from deploy-terraform.yml's
+          `drift_summary` output: one "<action> <address>" line per drifting
+          resource. When set, the summary is upserted into a marker-delimited
+          block in the issue body, and a comment is added only when the set of
+          drifting addresses changes. Empty default preserves the original
+          behaviour (comment on every run, no summary block). MUST stay
+          value-free — never pass raw plan output here.
       label:
         type: string
         required: false
@@ -71,6 +83,21 @@ jobs:
       issues: write
 
     steps:
+      # Body-Skript nur holen, wenn ein Summary geliefert wird — der leere Pfad
+      # (bestehende Caller ohne drift-summary) braucht keinen Checkout und
+      # verhält sich exakt wie zuvor. `github.action_ref` = Datums-Tag, unter dem
+      # dieser reusable aufgerufen wird; Fallback `main`, falls leer (erster
+      # Live-Lauf verifizieren). Der reusable checkt sonst das Consumer-Repo aus,
+      # nicht diesen Repo — darum expliziter Checkout von sbaerlocher/.github.
+      - name: Checkout body script
+        if: ${{ inputs.drift-summary != '' }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: sbaerlocher/.github
+          ref: ${{ github.action_ref || 'main' }}
+          path: .drift-issue-tooling
+          persist-credentials: false
+
       - name: Upsert drift issue
         env:
           GH_TOKEN: ${{ github.token }}
@@ -80,6 +107,7 @@ jobs:
           WORKFLOW_RUN_URL: ${{ inputs.workflow-run-url }}
           LABEL: ${{ inputs.label }}
           TITLE_TEMPLATE: ${{ inputs.title-template }}
+          DRIFT_SUMMARY: ${{ inputs.drift-summary }}
         run: |
           set -euo pipefail
 
@@ -87,7 +115,7 @@ jobs:
           TITLE="${TITLE//\{environment\}/${ENVIRONMENT}}"
           TIMESTAMP="$(date -u '+%Y-%m-%d %H:%M UTC')"
 
-          BODY=$(cat <<BODY_EOF
+          BASE=$(cat <<BODY_EOF
           ## Terraform Drift Detected
 
           Drift was detected in the **${PROJECT_NAME}** Terraform configuration for environment **${ENVIRONMENT}**.
@@ -109,13 +137,48 @@ jobs:
             --jq ".[] | select(.title == \"${TITLE}\") | .number" \
             | head -1)
 
-          if [ -n "${EXISTING}" ]; then
-            gh issue comment "${EXISTING}" --body "${BODY}"
-            echo "Updated existing drift issue #${EXISTING}"
+          # --- Leerer Pfad: kein Summary -> exakt bisheriges Verhalten. --------
+          if [ -z "${DRIFT_SUMMARY}" ]; then
+            if [ -n "${EXISTING}" ]; then
+              gh issue comment "${EXISTING}" --body "${BASE}"
+              echo "Updated existing drift issue #${EXISTING}"
+            else
+              gh issue create --title "${TITLE}" --body "${BASE}" --label "${LABEL}"
+              echo "Created new drift issue"
+            fi
+            exit 0
+          fi
+
+          # --- Summary-Pfad: Marker-Block upserten, Kommentar nur bei Delta. ---
+          BODY_TOOL=".drift-issue-tooling/scripts/drift-issue-body.sh"
+          BODY="$("$BODY_TOOL" render "$BASE" "$DRIFT_SUMMARY")"
+          NEW_ADDRS="$("$BODY_TOOL" addresses "$BODY")"
+
+          if [ -z "${EXISTING}" ]; then
+            gh issue create --title "${TITLE}" --body "${BODY}" --label "${LABEL}"
+            echo "Created new drift issue with summary block"
+            exit 0
+          fi
+
+          OLD_BODY="$(gh issue view "${EXISTING}" --json body --jq '.body')"
+          OLD_ADDRS="$("$BODY_TOOL" addresses "$OLD_BODY")"
+
+          # Body immer aktualisieren (frischer Timestamp + aktuelle Adressen).
+          gh issue edit "${EXISTING}" --body "${BODY}"
+
+          if [ "$NEW_ADDRS" = "$OLD_ADDRS" ]; then
+            echo "Drift issue #${EXISTING} refreshed, address set unchanged — no comment"
           else
-            gh issue create \
-              --title "${TITLE}" \
-              --body "${BODY}" \
-              --label "${LABEL}"
-            echo "Created new drift issue"
+            DELTA="$(diff <(printf '%s\n' "$OLD_ADDRS") <(printf '%s\n' "$NEW_ADDRS") || true)"
+            gh issue comment "${EXISTING}" --body "$(cat <<CMT_EOF
+          Drifting resource set changed as of ${TIMESTAMP}.
+
+          \`\`\`diff
+          ${DELTA}
+          \`\`\`
+
+          See the issue body for the current drifting resources and [the workflow run](${WORKFLOW_RUN_URL}).
+          CMT_EOF
+          )"
+            echo "Drift issue #${EXISTING} updated, address set changed — comment added"
           fi

--- a/.github/workflows/ops-drift-issue.yml
+++ b/.github/workflows/ops-drift-issue.yml
@@ -83,21 +83,16 @@ jobs:
       issues: write
 
     steps:
-      # Body-Skript nur holen, wenn ein Summary geliefert wird — der leere Pfad
-      # (bestehende Caller ohne drift-summary) braucht keinen Checkout und
-      # verhält sich exakt wie zuvor. `github.action_ref` = Datums-Tag, unter dem
-      # dieser reusable aufgerufen wird; Fallback `main`, falls leer (erster
-      # Live-Lauf verifizieren). Der reusable checkt sonst das Consumer-Repo aus,
-      # nicht diesen Repo — darum expliziter Checkout von sbaerlocher/.github.
-      - name: Checkout body script
-        if: ${{ inputs.drift-summary != '' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: sbaerlocher/.github
-          ref: ${{ github.action_ref || 'main' }}
-          path: .drift-issue-tooling
-          persist-credentials: false
-
+      # Body-Logik ist inline, nicht via Checkout des Skripts. Grund: ein
+      # reusable Workflow hat keinen Kontext, der seinen EIGENEN Aufruf-Ref
+      # exponiert (`github.action_ref` ist in `workflow_call`-Steps leer,
+      # `github.workflow_ref` ist der Caller). Ein Checkout müsste auf `@main`
+      # zurückfallen — mutable Ref für ausführbaren Code, genau was das
+      # Datums-Tag-Pinning verhindern soll. Darum dieselbe Linie wie die
+      # Inline-jq in `deploy-terraform.yml`: die render/addresses-Logik ist ein
+      # Duplikat von scripts/drift-issue-body.sh, das per
+      # scripts/tests/test-drift-issue-body.sh getestete Referenz bleibt.
+      # Ändert sich die eine, muss die andere folgen (Gleichheit von Hand).
       - name: Upsert drift issue
         env:
           GH_TOKEN: ${{ github.token }}
@@ -110,6 +105,39 @@ jobs:
           DRIFT_SUMMARY: ${{ inputs.drift-summary }}
         run: |
           set -euo pipefail
+
+          START='<!-- drift-summary:start -->'
+          END='<!-- drift-summary:end -->'
+
+          # strip_block/render/addresses spiegeln scripts/drift-issue-body.sh.
+          strip_block() {
+            awk -v s="$START" -v e="$END" '
+              $0 == s { skip = 1; next }
+              $0 == e { skip = 0; next }
+              !skip   { print }
+            '
+          }
+          render() { # render <base> <summary>
+            local clean
+            clean="$(printf '%s' "$1" | strip_block)"
+            clean="$(printf '%s\n' "$clean" | sed -e :a -e '/^\n*$/{$d;N;ba}')"
+            if [ -z "$2" ]; then
+              printf '%s\n' "$clean"
+              return
+            fi
+            printf '%s\n\n%s\n\n### Drifting resources\n\n```\n%s\n```\n\n%s\n' \
+              "$clean" "$START" "$2" "$END"
+          }
+          addresses() { # addresses <body>
+            printf '%s' "$1" |
+              awk -v s="$START" -v e="$END" '
+                $0 == s { inb = 1; next }
+                $0 == e { inb = 0; fence = 0; next }
+                inb && $0 == "```" { fence = !fence; next }
+                inb && fence && $0 ~ / / { sub(/^[^ ]+ /, ""); print }
+              ' |
+              sort -u
+          }
 
           TITLE="${TITLE_TEMPLATE//\{project\}/${PROJECT_NAME}}"
           TITLE="${TITLE//\{environment\}/${ENVIRONMENT}}"
@@ -150,9 +178,8 @@ jobs:
           fi
 
           # --- Summary-Pfad: Marker-Block upserten, Kommentar nur bei Delta. ---
-          BODY_TOOL=".drift-issue-tooling/scripts/drift-issue-body.sh"
-          BODY="$("$BODY_TOOL" render "$BASE" "$DRIFT_SUMMARY")"
-          NEW_ADDRS="$("$BODY_TOOL" addresses "$BODY")"
+          BODY="$(render "$BASE" "$DRIFT_SUMMARY")"
+          NEW_ADDRS="$(addresses "$BODY")"
 
           if [ -z "${EXISTING}" ]; then
             gh issue create --title "${TITLE}" --body "${BODY}" --label "${LABEL}"
@@ -161,7 +188,7 @@ jobs:
           fi
 
           OLD_BODY="$(gh issue view "${EXISTING}" --json body --jq '.body')"
-          OLD_ADDRS="$("$BODY_TOOL" addresses "$OLD_BODY")"
+          OLD_ADDRS="$(addresses "$OLD_BODY")"
 
           # Body immer aktualisieren (frischer Timestamp + aktuelle Adressen).
           gh issue edit "${EXISTING}" --body "${BODY}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,28 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
+## 2026-07-21
+
+### Added
+
+- **`deploy-terraform.yml`, `ops-drift-issue.yml`**: drift issues now show
+  *what* is drifting, and stop growing a duplicate comment every week.
+  `deploy-terraform.yml` gains a `drift_summary` output — in drift mode it runs
+  `terraform show -json` on the fresh plan and extracts one
+  `<action> <address>` line per drifting resource. The extraction reads only
+  `.address` and `.change.actions`, never `.change.before`/`.after`, so no
+  attribute value (which can hold provider secrets) ever reaches the summary;
+  a failing extraction yields an empty string and never suppresses the drift
+  signal. `ops-drift-issue.yml` gains an optional `drift-summary` input: when
+  set, it upserts a marker-delimited summary block into the issue body and adds
+  a comment only when the set of drifting addresses changes. Non-breaking —
+  both additions default to empty and preserve today's behaviour for callers
+  that do not wire them (the drift issue still comments on every run without a
+  summary). Consumer wiring in `authentication` follows in a separate PR once a
+  date tag ships these changes.
+
+---
+
 ## 2026-07-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ All files live in [.github/workflows/](./.github/workflows/).
 - [`deploy-cloudflare-workers.yml`](./.github/workflows/deploy-cloudflare-workers.yml)
   — Cloudflare Workers via Wrangler
 - [`deploy-terraform.yml`](./.github/workflows/deploy-terraform.yml)
-  — Terraform plan & apply with Bitwarden secret injection
+  — Terraform plan & apply with Bitwarden secret injection. In drift mode also
+  emits a value-free `drift_summary` output (drifting resource addresses +
+  actions, never attribute values) for `ops-drift-issue.yml`.
 
 ### Release (4)
 
@@ -118,7 +120,10 @@ All files live in [.github/workflows/](./.github/workflows/).
 - [`ops-terraform-report.yml`](./.github/workflows/ops-terraform-report.yml)
   — Render Terraform pipeline report (Step Summary, metadata artifact, notification)
 - [`ops-drift-issue.yml`](./.github/workflows/ops-drift-issue.yml)
-  — Upsert a GitHub issue when Terraform drift is detected
+  — Upsert a GitHub issue when Terraform drift is detected. With the optional
+  `drift-summary` input it maintains a marker-delimited summary block of the
+  drifting resource addresses in the issue body and comments only when that set
+  changes (no summary → unchanged: comment on every run).
 
 ### AI — Private Repos Only (2)
 

--- a/scripts/drift-issue-body.sh
+++ b/scripts/drift-issue-body.sh
@@ -52,13 +52,15 @@ addresses)
   # update->replace derselben Resource nicht als Delta zählt, wenn die
   # Adressmenge gleich bleibt. (Delta = Adressmenge, siehe Konzept.)
   # Nur Zeilen im Code-Fence innerhalb des Blocks zählen — Heading und
-  # Leerzeilen bleiben draussen. Adresse = zweites Feld.
+  # Leerzeilen bleiben draussen. Adresse = alles nach dem ersten Space (die
+  # Aktions-Spalte ist per join("+") space-frei, die Adresse kann Spaces in
+  # for_each-Keys enthalten, z. B. authentik_group.admins["my key"]).
   printf '%s' "$body" |
     awk -v s="$START" -v e="$END" '
         $0 == s { inb = 1; next }
         $0 == e { inb = 0; fence = 0; next }
         inb && $0 == "```" { fence = !fence; next }
-        inb && fence && $2 != "" { print $2 }
+        inb && fence && $0 ~ / / { sub(/^[^ ]+ /, ""); print }
       ' |
     sort -u
   ;;

--- a/scripts/drift-issue-body.sh
+++ b/scripts/drift-issue-body.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Render and inspect the drift-summary block in a GitHub-issue body.
+#
+# The block is delimited by HTML-comment markers so it can be upserted
+# idempotently: re-rendering replaces the block instead of appending a second
+# one (the weekly drift cron would otherwise grow the body unbounded).
+#
+#   drift-issue-body.sh render <base-body> <summary>
+#       -> <base-body> with any existing block stripped and a fresh block
+#          (containing <summary>) appended. If <summary> is empty, the base
+#          body is returned unchanged (no block) — preserves today's behaviour
+#          for callers that pass no summary.
+#
+#   drift-issue-body.sh addresses <body>
+#       -> the sorted, unique resource addresses inside the block, one per
+#          line (empty if no block). The comparison key for delta detection:
+#          sorted so a reordered plan is not mistaken for a change.
+set -euo pipefail
+
+START='<!-- drift-summary:start -->'
+END='<!-- drift-summary:end -->'
+
+# Strip an existing block (markers included) from stdin.
+strip_block() {
+  awk -v s="$START" -v e="$END" '
+    $0 == s { skip = 1; next }
+    $0 == e { skip = 0; next }
+    !skip   { print }
+  '
+}
+
+cmd="${1:-}"
+case "$cmd" in
+render)
+  base="${2:-}"
+  summary="${3:-}"
+  clean="$(printf '%s' "$base" | strip_block)"
+  # Trailing leerzeilen des Basis-Bodys kappen, damit der Abstand stabil ist.
+  clean="$(printf '%s\n' "$clean" | sed -e :a -e '/^\n*$/{$d;N;ba}')"
+  if [ -z "$summary" ]; then
+    printf '%s\n' "$clean"
+    exit 0
+  fi
+  # shellcheck disable=SC2016  # backticks are a literal markdown fence, not command substitution
+  printf '%s\n\n%s\n\n### Drifting resources\n\n```\n%s\n```\n\n%s\n' \
+    "$clean" "$START" "$summary" "$END"
+  ;;
+addresses)
+  body="${2:-}"
+  # Zeilen im Block: "<action> <address>". Adresse = zweites Feld. Sortiert,
+  # eindeutig — die Aktions-Spalte bewusst ignoriert, damit ein Wechsel
+  # update->replace derselben Resource nicht als Delta zählt, wenn die
+  # Adressmenge gleich bleibt. (Delta = Adressmenge, siehe Konzept.)
+  # Nur Zeilen im Code-Fence innerhalb des Blocks zählen — Heading und
+  # Leerzeilen bleiben draussen. Adresse = zweites Feld.
+  printf '%s' "$body" |
+    awk -v s="$START" -v e="$END" '
+        $0 == s { inb = 1; next }
+        $0 == e { inb = 0; fence = 0; next }
+        inb && $0 == "```" { fence = !fence; next }
+        inb && fence && $2 != "" { print $2 }
+      ' |
+    sort -u
+  ;;
+*)
+  echo "usage: drift-issue-body.sh {render <base> <summary>|addresses <body>}" >&2
+  exit 2
+  ;;
+esac

--- a/scripts/drift-summary.sh
+++ b/scripts/drift-summary.sh
@@ -20,11 +20,12 @@ CAP=50
 
 INPUT="$(cat)"
 
-# Alle Aktionen ausser reinem ["no-op"]. Replace ist ["delete","create"] und
-# bleibt drin. Nur .address + .change.actions werden gelesen.
+# Echte Änderungen: no-op (kein Drift) und read (aufgeschobene
+# Data-Source-Reads, keine Konfig-Drift, nur Rauschen) rausfiltern. Replace ist
+# ["delete","create"] und bleibt drin. Nur .address + .change.actions gelesen.
 LINES="$(printf '%s' "$INPUT" | jq -r '
   .resource_changes // []
-  | map(select((.change.actions // []) != ["no-op"]))
+  | map(select((.change.actions // []) != ["no-op"] and (.change.actions // []) != ["read"]))
   | .[]
   | "\(.change.actions | join("+")) \(.address)"
 ' 2>/dev/null)" || LINES=""

--- a/scripts/drift-summary.sh
+++ b/scripts/drift-summary.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Extract a value-free drift summary from `terraform show -json <plan>`.
+#
+# Reads the plan JSON on stdin, writes one line per drifting resource to
+# stdout: "<action> <address>" (e.g. "update authentik_group.admins").
+#
+# LEVEL-A GRENZE (Wert-Freiheit): die jq-Query liest ausschliesslich
+# `.address` und `.change.actions`. Sie fasst `.change.before`/`.after`
+# NIE an, damit kein Attributwert (der Secrets enthalten kann, siehe
+# TF_VAR_authentik_token) je in ein GitHub-Issue gelangt. Wer die Query
+# erweitert, bricht zuerst Assertion 3 in test-drift-summary.sh.
+#
+# no-op-Resourcen (kein echter Drift) werden herausgefiltert. Der Output ist
+# bei CAP Zeilen gedeckelt (Job-Output-Limit 1 MB). Fehler in `jq` oder
+# kaputter Input -> leerer Output, Exit 0: ein kaputter Summary darf die
+# Drift-Meldung selbst nie unterdrücken.
+set -uo pipefail
+
+CAP=50
+
+INPUT="$(cat)"
+
+# Alle Aktionen ausser reinem ["no-op"]. Replace ist ["delete","create"] und
+# bleibt drin. Nur .address + .change.actions werden gelesen.
+LINES="$(printf '%s' "$INPUT" | jq -r '
+  .resource_changes // []
+  | map(select((.change.actions // []) != ["no-op"]))
+  | .[]
+  | "\(.change.actions | join("+")) \(.address)"
+' 2>/dev/null)" || LINES=""
+
+# Leerer Plan / kaputter Input -> leerer Output, Exit 0.
+[ -z "$LINES" ] && exit 0
+
+TOTAL="$(printf '%s\n' "$LINES" | wc -l)"
+if [ "$TOTAL" -gt "$CAP" ]; then
+  printf '%s\n' "$LINES" | head -n "$CAP"
+  printf '… %d more (truncated)\n' "$((TOTAL - CAP))"
+else
+  printf '%s\n' "$LINES"
+fi
+
+exit 0

--- a/scripts/tests/fixtures/plan-drift.json
+++ b/scripts/tests/fixtures/plan-drift.json
@@ -1,0 +1,67 @@
+{
+  "format_version": "1.2",
+  "resource_changes": [
+    {
+      "address": "authentik_group.admins",
+      "type": "authentik_group",
+      "name": "admins",
+      "change": {
+        "actions": ["update"],
+        "before": {
+          "name": "admins",
+          "attributes": "SUPERSECRET_TOKEN_abc123_LEAKME"
+        },
+        "after": {
+          "name": "admins",
+          "attributes": "SUPERSECRET_TOKEN_def456_LEAKME"
+        }
+      }
+    },
+    {
+      "address": "authentik_application.grafana",
+      "type": "authentik_application",
+      "name": "grafana",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "meta_launch_url": "https://grafana.example",
+          "client_secret": "sk_live_LEAKME_9f8e7d6c"
+        }
+      }
+    },
+    {
+      "address": "authentik_provider_oauth2.grafana",
+      "type": "authentik_provider_oauth2",
+      "name": "grafana",
+      "change": {
+        "actions": ["delete"],
+        "before": {
+          "client_id": "CLIENT_ID_LEAKME",
+          "client_secret": "OLD_SECRET_LEAKME_1a2b3c"
+        },
+        "after": null
+      }
+    },
+    {
+      "address": "authentik_flow.unchanged",
+      "type": "authentik_flow",
+      "name": "unchanged",
+      "change": {
+        "actions": ["no-op"],
+        "before": {"name": "unchanged", "token": "NOOP_SECRET_LEAKME"},
+        "after": {"name": "unchanged", "token": "NOOP_SECRET_LEAKME"}
+      }
+    },
+    {
+      "address": "authentik_group.replaced",
+      "type": "authentik_group",
+      "name": "replaced",
+      "change": {
+        "actions": ["delete", "create"],
+        "before": {"name": "replaced", "secret": "REPLACE_BEFORE_LEAKME"},
+        "after": {"name": "replaced", "secret": "REPLACE_AFTER_LEAKME"}
+      }
+    }
+  ]
+}

--- a/scripts/tests/fixtures/plan-drift.json
+++ b/scripts/tests/fixtures/plan-drift.json
@@ -62,6 +62,27 @@
         "before": {"name": "replaced", "secret": "REPLACE_BEFORE_LEAKME"},
         "after": {"name": "replaced", "secret": "REPLACE_AFTER_LEAKME"}
       }
+    },
+    {
+      "address": "data.authentik_user.lookup",
+      "type": "authentik_user",
+      "name": "lookup",
+      "mode": "data",
+      "change": {
+        "actions": ["read"],
+        "before": null,
+        "after": {"username": "svc", "token": "READ_SECRET_LEAKME"}
+      }
+    },
+    {
+      "address": "authentik_group.spaced[\"my key\"]",
+      "type": "authentik_group",
+      "name": "spaced",
+      "change": {
+        "actions": ["update"],
+        "before": {"name": "spaced", "secret": "SPACE_BEFORE_LEAKME"},
+        "after": {"name": "spaced", "secret": "SPACE_AFTER_LEAKME"}
+      }
     }
   ]
 }

--- a/scripts/tests/test-drift-issue-body.sh
+++ b/scripts/tests/test-drift-issue-body.sh
@@ -54,4 +54,19 @@ ADDRS_R="$("$SCRIPT" addresses "$BODY_R")"
 EMPTY_ADDRS="$("$SCRIPT" addresses "$BASE")"
 [ -z "$EMPTY_ADDRS" ] || fail "addresses on body without block must be empty"
 
+# 5 — Adresse mit Space (for_each-String-Key) wird vollständig extrahiert, nicht
+# am ersten Space abgeschnitten (sonst kollabieren zwei Adressen unter sort -u
+# und ein Delta wird verschluckt).
+SPACED='update authentik_group.admins["my key"]
+update authentik_group.admins["other key"]'
+BODY_S="$("$SCRIPT" render "$BASE" "$SPACED")"
+ADDRS_S="$("$SCRIPT" addresses "$BODY_S")"
+EXP_S='authentik_group.admins["my key"]
+authentik_group.admins["other key"]'
+[ "$ADDRS_S" = "$EXP_S" ] || fail "spaced addresses truncated:
+got:
+$ADDRS_S
+want:
+$EXP_S"
+
 echo "PASS: drift-issue-body.sh"

--- a/scripts/tests/test-drift-issue-body.sh
+++ b/scripts/tests/test-drift-issue-body.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Self-check for scripts/drift-issue-body.sh — plain bash asserts, no framework.
+# Run: scripts/tests/test-drift-issue-body.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../drift-issue-body.sh"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+SUMMARY="update authentik_group.admins
+create authentik_application.grafana"
+
+BASE="## Terraform Drift Detected
+
+Some intro text.
+
+**Triggered:** 2026-07-20 07:14 UTC"
+
+# render <base-body> <summary> -> body with marker block appended.
+BODY1="$("$SCRIPT" render "$BASE" "$SUMMARY")"
+echo "$BODY1" | grep -q '<!-- drift-summary:start -->' || fail "start marker missing"
+echo "$BODY1" | grep -q '<!-- drift-summary:end -->' || fail "end marker missing"
+echo "$BODY1" | grep -q 'authentik_group.admins' || fail "summary content missing"
+
+# 1 — IDEMPOTENZ: re-render über einen Body, der den Block schon hat, ersetzt
+# ihn, dupliziert ihn nicht (sonst wächst der Body bei wöchentlichem Cron).
+BODY2="$("$SCRIPT" render "$BODY1" "$SUMMARY")"
+COUNT="$(echo "$BODY2" | grep -c '<!-- drift-summary:start -->')"
+[ "$COUNT" -eq 1 ] || fail "marker block duplicated on re-render (got $COUNT)"
+
+# 2 — addresses <body> -> sortierte, eindeutige Adressliste aus dem Block.
+ADDRS="$("$SCRIPT" addresses "$BODY1")"
+EXPECTED="authentik_application.grafana
+authentik_group.admins"
+[ "$ADDRS" = "$EXPECTED" ] || fail "addresses not sorted/extracted correctly:
+got:
+$ADDRS
+want:
+$EXPECTED"
+
+# 3 — REIHENFOLGE-UNABHÄNGIGKEIT: gleiche Adressen in anderer Summary-Reihenfolge
+# -> identische addresses-Ausgabe (sonst falsches Delta bei jedem Cron).
+SUMMARY_REORDERED="create authentik_application.grafana
+update authentik_group.admins"
+BODY_R="$("$SCRIPT" render "$BASE" "$SUMMARY_REORDERED")"
+ADDRS_R="$("$SCRIPT" addresses "$BODY_R")"
+[ "$ADDRS" = "$ADDRS_R" ] || fail "address extraction depends on order"
+
+# 4 — leerer Block (kein Drift-Summary) -> addresses leer.
+EMPTY_ADDRS="$("$SCRIPT" addresses "$BASE")"
+[ -z "$EMPTY_ADDRS" ] || fail "addresses on body without block must be empty"
+
+echo "PASS: drift-issue-body.sh"

--- a/scripts/tests/test-drift-summary.sh
+++ b/scripts/tests/test-drift-summary.sh
@@ -24,6 +24,14 @@ if echo "$OUT" | grep -q 'authentik_flow.unchanged'; then
   fail "no-op resource must be filtered out"
 fi
 
+# 2b — data-source read (aufgeschoben) ist kein Drift, muss gefiltert sein.
+if echo "$OUT" | grep -q 'data.authentik_user.lookup'; then
+  fail "read data source must be filtered out"
+fi
+
+# 2c — Adresse mit Space (for_each-String-Key) bleibt vollständig erhalten.
+echo "$OUT" | grep -qF 'authentik_group.spaced["my key"]' || fail "spaced address truncated/missing"
+
 # 3 — WERT-FREIHEIT (Anker der Level-A-Grenze): kein Attributwert aus
 # before/after darf im Output landen. Failt zuerst, wenn die Query je
 # .change.before/.after anfasst.

--- a/scripts/tests/test-drift-summary.sh
+++ b/scripts/tests/test-drift-summary.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Self-check for scripts/drift-summary.sh — plain bash asserts, no framework.
+# Run: scripts/tests/test-drift-summary.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../drift-summary.sh"
+FIXTURE="$HERE/fixtures/plan-drift.json"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# 1 — driftende Adressen erscheinen mit Aktion, no-op wird gefiltert.
+OUT="$(cat "$FIXTURE" | "$SCRIPT")"
+echo "$OUT" | grep -q 'authentik_group.admins' || fail "update address missing"
+echo "$OUT" | grep -q 'authentik_application.grafana' || fail "create address missing"
+echo "$OUT" | grep -q 'authentik_provider_oauth2.grafana' || fail "delete address missing"
+echo "$OUT" | grep -q 'authentik_group.replaced' || fail "replace address missing"
+
+# 2 — no-op darf nicht im Summary stehen (kein echter Drift).
+if echo "$OUT" | grep -q 'authentik_flow.unchanged'; then
+  fail "no-op resource must be filtered out"
+fi
+
+# 3 — WERT-FREIHEIT (Anker der Level-A-Grenze): kein Attributwert aus
+# before/after darf im Output landen. Failt zuerst, wenn die Query je
+# .change.before/.after anfasst.
+if echo "$OUT" | grep -q 'LEAKME'; then
+  fail "attribute value from before/after leaked into output"
+fi
+
+# 4 — Deckelung: viele Resourcen -> Output <= 50 Zeilen + Hinweiszeile.
+BIG="$(jq -n '{resource_changes: [range(80) | {address: ("authentik_group.g\(.)"), change: {actions: ["update"]}}]}' |
+  "$SCRIPT")"
+LINES="$(echo "$BIG" | wc -l)"
+[ "$LINES" -le 51 ] || fail "output not capped (got $LINES lines)"
+echo "$BIG" | grep -qi 'truncat\|more\|weitere' || fail "cap notice missing when truncated"
+
+# 5 — kaputter Input -> Exit 0, leerer/harmloser Output (Summary darf die
+# Drift-Meldung nie unterdrücken).
+set +e
+echo 'not json {{{' | "$SCRIPT" >/dev/null 2>&1
+RC=$?
+set -e
+[ "$RC" -eq 0 ] || fail "broken input must exit 0 (got $RC)"
+
+# 6 — leerer Plan (keine changes) -> leerer Output, Exit 0.
+EMPTY="$(echo '{"resource_changes": []}' | "$SCRIPT")"
+[ -z "$EMPTY" ] || fail "empty plan must yield empty output"
+
+echo "PASS: drift-summary.sh"


### PR DESCRIPTION
## Summary

- `deploy-terraform.yml` gains a `drift_summary` output: in drift mode it runs `terraform show -json` on the fresh plan and emits one `<action> <address>` line per drifting resource. The extraction reads only `.address` and `.change.actions`, never `.change.before`/`.after`, so no attribute value (which can hold provider secrets) reaches the summary; a failing extraction yields an empty string and never suppresses the drift signal.
- `ops-drift-issue.yml` gains an optional `drift-summary` input: when set it upserts a marker-delimited summary block into the issue body and comments only when the set of drifting addresses changes. Empty default preserves today's behaviour (comment on every run, no block).
- New `scripts/drift-summary.sh` and `scripts/drift-issue-body.sh` with plain-bash self-checks. A fixture with deliberate secret values in `before`/`after` anchors the value-freedom assertion — extending the query to touch attribute values fails that test first.
- Non-breaking: both additions default to empty. Consumer wiring follows in a separate `authentication` PR once a date tag ships these changes.

## Test plan

- [x] `scripts/tests/test-drift-summary.sh` — value-freedom, no-op filtering, 50-line cap, exit 0 on broken input
- [x] `scripts/tests/test-drift-issue-body.sh` — marker idempotency, sorted order-independent address extraction, empty-block handling
- [x] End-to-end simulation: extraction → render → addresses → delta detection, value-free body confirmed
- [ ] CI green
- [ ] `actionlint` (manual — not wired in this repo)