### PR TITLE
ci(workflows): enforce core-file suite in .github repo

### DIFF
--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -1,8 +1,6 @@
 name: AI - Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
   workflow_call:
     inputs:
       model:
@@ -43,9 +41,9 @@ permissions:
   contents: read
 
 concurrency:
-  # Dual-trigger workflow: `inputs.*` is undefined on `pull_request:` and
-  # only populated under `workflow_call:`. Expressions below fall back to
-  # the original hardcoded behaviour when inputs are missing.
+  # Reusable library: reached only via `workflow_call:`, so `inputs.*` is
+  # always defined. The `github.event.pull_request.number` fallback still
+  # covers callers triggered outside a PR context (e.g. workflow_dispatch).
   group: >-
     claude-review-${{ github.event.pull_request.number || github.run_id }}${{
       inputs.concurrency-suffix && format('-{0}', inputs.concurrency-suffix) || ''

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,32 @@
+name: Merge to Main
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write # Tag-Push
+
+jobs:
+  date-tag:
+    name: Cut Date Tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Create date tag if absent
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG=$(date -u +%Y-%m-%d)
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "Tag $TAG exists, nothing to do."
+            exit 0
+          fi
+          git tag "$TAG"
+          git push origin "$TAG"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,27 @@
+name: Pull Request
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+  id-token: write
+  security-events: write
+  actions: read
+
+jobs:
+  claude-review:
+    name: Claude Code Review
+    uses: ./.github/workflows/ai-claude-review.yml
+    secrets: inherit
+
+  code-scan:
+    name: Code Scanning
+    uses: ./.github/workflows/security-code.yml
+    with:
+      languages: '["actions"]'
+    secrets: inherit

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -1,0 +1,22 @@
+name: Weekly Security
+
+on:
+  schedule:
+    - cron: '0 2 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  config:
+    name: Config Security
+    uses: ./.github/workflows/security-config.yml
+    secrets: inherit
+
+  secrets:
+    name: Secret Scanning
+    uses: ./.github/workflows/security-secrets.yml
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Add `pull-request.yml` as an event hull that calls the `ai-claude-review` reusable via local path (`./.github/workflows/...`) plus a CodeQL Actions scan (`security-code.yml`, `languages: ["actions"]`), so the repo reviews and scans its own PRs like any consumer.
- Strip the `pull_request` trigger from `ai-claude-review.yml`, leaving only `workflow_call` — it becomes a pure reusable library. Without this in the same PR both paths fire and every PR is double-reviewed.
- Add `merge.yml` to cut the daily `YYYY-MM-DD` tag idempotently on push to `main` (previously tagged by hand), `contents: write` scoped only to that job.
- Add `weekly-security.yml` running `security-config` and `security-secrets` in parallel on a Monday `0 2 * * 1` cron.

Local-path self-reference (not a date tag) is deliberate: a repo calling its own reusable by tag tests an already-released version of itself, so in-PR changes to the reusable would not take effect. The SHA-pin rule targets third-party actions.

Ruleset alignment (`required_status_checks`, `count=1`, bot bypass) is a follow-up outside this PR — the repo currently carries no required checks, so this cut has no anchor risk.

## Test plan

- [ ] YAML parses for all four files; no file carries both `pull_request` and `workflow_call`
- [ ] On this PR: `Claude Code Review` and `Code Scanning (Actions)` run, no double review
- [ ] After merge: verify `merge.yml` cuts today's date tag (new automation)