### PR TITLE
fix(ci): grant security-events write to SARIF-uploading jobs

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -408,6 +408,7 @@ jobs:
     # Job-level grant: SARIF upload (enable-sarif-upload) needs
     # security-events: write on push events.
     permissions:
+      actions: read
       contents: read
       security-events: write
     needs: [setup, test-and-lint, test-and-lint-postgres]
@@ -507,6 +508,7 @@ jobs:
     # uploading CodeQL results needs security-events: write on push events
     # (public-repo pull_request uploads succeed with a read token).
     permissions:
+      actions: read
       contents: read
       security-events: write
     needs: [setup, test-and-lint, test-and-lint-postgres]

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -405,6 +405,11 @@ jobs:
   security-scan:
     name: Scan Security (${{ matrix.scanner }})
     runs-on: ubuntu-latest
+    # Job-level grant: SARIF upload (enable-sarif-upload) needs
+    # security-events: write on push events.
+    permissions:
+      contents: read
+      security-events: write
     needs: [setup, test-and-lint, test-and-lint-postgres]
     if: >-
       always() &&
@@ -498,6 +503,12 @@ jobs:
   codeql-analysis:
     name: Analyze Code
     runs-on: ubuntu-latest
+    # Job-level grant: the workflow-level default is contents: read, but
+    # uploading CodeQL results needs security-events: write on push events
+    # (public-repo pull_request uploads succeed with a read token).
+    permissions:
+      contents: read
+      security-events: write
     needs: [setup, test-and-lint, test-and-lint-postgres]
     if: >-
       always() &&

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -403,6 +403,11 @@ jobs:
   security-scan:
     name: Security (${{ matrix.scanner }})
     runs-on: ubuntu-latest
+    # Job-level grant: SARIF upload (enable-sarif-upload) needs
+    # security-events: write on push events.
+    permissions:
+      contents: read
+      security-events: write
     needs: [setup, quality-and-test]
     if: inputs.primary && inputs.enable-security-scans && needs.setup.outputs.should-run-security == 'true' && (needs.quality-and-test.result == 'success' || needs.quality-and-test.result == 'skipped')
     timeout-minutes: 15

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -406,6 +406,7 @@ jobs:
     # Job-level grant: SARIF upload (enable-sarif-upload) needs
     # security-events: write on push events.
     permissions:
+      actions: read
       contents: read
       security-events: write
     needs: [setup, quality-and-test]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,37 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
+## 2026-07-22
+
+### Fixed
+
+- **`ci-go.yml`, `ci-js.yml`**: CodeQL and scanner SARIF uploads no longer fail
+  with `Resource not accessible by integration` on `push` events. The
+  workflow-level `permissions: contents: read` downgraded the caller's token
+  for every job — public-repo `pull_request` uploads succeed with a read
+  token, which masked the gap until a consumer ran the pipeline on push
+  (post-merge revalidation). The `codeql-analysis` (ci-go) and `security-scan`
+  (ci-go, ci-js) jobs now carry job-level `actions: read` +
+  `security-events: write`. No input or output changes; callers already
+  granting `security-events: write` need no change.
+
+### Dependencies
+
+- **`actions/setup-node`**: v6.5.0 → v7.0.0 (`sbom-npm/action.yml`,
+  `ci-js.yml`, `deploy-cloudflare-workers.yml`, `e2e-dde.yml`,
+  `e2e-docker.yml`, `release-npm.yml`, `security-code.yml`,
+  `security-deps.yml`).
+- **`anthropics/claude-code-action`**: v1.0.176 → v1.0.177 (`ai-claude.yml`),
+  plus a digest bump on the `v1` ref (`ai-claude-review.yml`).
+
+---
+
 ## 2026-07-21
 
 ### Added
 
 - **`deploy-terraform.yml`, `ops-drift-issue.yml`**: drift issues now show
-  *what* is drifting, and stop growing a duplicate comment every week.
+  _what_ is drifting, and stop growing a duplicate comment every week.
   `deploy-terraform.yml` gains a `drift_summary` output — in drift mode it runs
   `terraform show -json` on the fresh plan and extracts one
   `<action> <address>` line per drifting resource. The extraction reads only
@@ -110,9 +135,9 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   - `security-secrets.yml`: `Scan with Gitleaks` (unchanged) + `Scan Secrets`
     (replaces `Scan with TruffleHog`, `Detect Patterns`, `Create Report`)
   - `security-deps.yml`: `Scan Dependencies` (replaces `Dependency Review
-    (GitHub)`, `Audit Go`, `Audit JavaScript`, `Audit Python`, `Create Report`)
+(GitHub)`, `Audit Go`, `Audit JavaScript`, `Audit Python`, `Create Report`)
   - `security-containers.yml`: `Scan Container Image` (replaces `Scan with
-    Trivy`, `Scan with Grype`, `Analyze Images`, `Create Report`)
+Trivy`, `Scan with Grype`, `Analyze Images`, `Create Report`)
   - `security-config.yml`: `Scan Configuration` (replaces `Trivy Config Scan`,
     `Terraform Security`, `Scan Kubernetes`, `Scan Ansible`, `Create Report`)
 


### PR DESCRIPTION
## Summary

- `ci-go.yml` and `ci-js.yml` declare workflow-level `permissions: contents: read`, which downgrades the caller's token; CodeQL/SARIF uploads then fail on `push` events with `Resource not accessible by integration` (seen in savvy's post-merge revalidation). Public-repo `pull_request` uploads succeed with a read token, which masked the gap.
- Add job-level `security-events: write` to `codeql-analysis` (ci-go) and `security-scan` (ci-go, ci-js) — the jobs that upload SARIF. `security-code.yml` already grants it and is unaffected.

## Test plan

- [ ] CI green
- [ ] After tag cut: re-run savvy `merge.yml` on main — `Go CI Pipeline / Analyze Code` uploads successfully
