### PR TITLE
feat(templates): add just runner reference template

### DIFF
--- a/templates/justfile
+++ b/templates/justfile
@@ -11,9 +11,10 @@
 #                      test:coverage, ...) stay in pnpm/go and are not mirrored
 #                      as just recipes.
 #
-# The five standard verbs below are the guaranteed common denominator across
-# every repo: default, dev, build, test, lint, fmt. Repos add their own recipes
-# on top; these five keep their names and meaning everywhere.
+# The five standard task verbs below — dev, build, test, lint, fmt — are the
+# guaranteed common denominator across every repo, plus default to list them.
+# Repos add their own recipes on top; these keep their names and meaning
+# everywhere.
 #
 # Delegation pattern: each recipe shows both the dde-backed and the native form.
 # Keep the line that fits the repo, delete the other.
@@ -24,7 +25,7 @@ default:
 
 # dev → start the local dev loop
 dev:
-    # dde project:start        # dde-backed runtime (containers up, watchers)
+    # dde project:up           # dde-backed runtime (containers up, watchers)
     pnpm dev                   # native toolchain fallback
 
 # build → produce the deployable/build artifact

--- a/templates/justfile
+++ b/templates/justfile
@@ -1,0 +1,48 @@
+# Reference justfile — org-wide task-runner standard for sbaerlocher repos.
+#
+# Runner layering (do not collapse these into one another):
+#   1. dde project:*   Runtime layer, priority 1, untouched (containers, db,
+#                      migrations, observability, mailpit, shell). just delegates
+#                      to dde where a project uses it, never replaces it.
+#   2. just <verb>     Task entrypoint. The same verbs mean the same thing in
+#                      every repo. This file is that contract.
+#   3. pnpm / go /     Toolchain underneath, called *by* just, never a peer
+#      wrangler         runner. Toolchain-specific scripts (check:watch,
+#                      test:coverage, ...) stay in pnpm/go and are not mirrored
+#                      as just recipes.
+#
+# The five standard verbs below are the guaranteed common denominator across
+# every repo: default, dev, build, test, lint, fmt. Repos add their own recipes
+# on top; these five keep their names and meaning everywhere.
+#
+# Delegation pattern: each recipe shows both the dde-backed and the native form.
+# Keep the line that fits the repo, delete the other.
+
+# default → list available recipes
+default:
+    @just --list
+
+# dev → start the local dev loop
+dev:
+    # dde project:start        # dde-backed runtime (containers up, watchers)
+    pnpm dev                   # native toolchain fallback
+
+# build → produce the deployable/build artifact
+build:
+    # dde project:exec pnpm build
+    pnpm build
+
+# test → run the test suite
+test:
+    # dde project:exec pnpm test
+    pnpm test
+
+# lint → static checks
+lint:
+    # dde project:exec pnpm lint
+    pnpm lint
+
+# fmt → format sources in place
+fmt:
+    # dde project:exec pnpm fmt
+    pnpm fmt


### PR DESCRIPTION
## Summary

- Add `templates/justfile` as the org-wide task-runner reference: five common verbs (`default`, `dev`, `build`, `test`, `lint`, `fmt`) with the same meaning across repos.
- Document the runner layering — `dde` runtime, `just` task entrypoint, pnpm/go/wrangler toolchain underneath — with both dde-backed and native delegation forms shown per recipe.
- Template only; per-repo justfile rollout is tracked separately.

## Test plan

- [ ] `just --list` parses the template (6 recipes)
- [ ] CI green