### PR TITLE
chore(renovate): automerge lockfile maintenance updates

### DIFF
--- a/renovate-base.json
+++ b/renovate-base.json
@@ -77,7 +77,9 @@
     }
   ],
   "lockFileMaintenance": {
-    "enabled": false
+    "enabled": true,
+    "automerge": true,
+    "schedule": ["before 6am on monday"]
   },
   "vulnerabilityAlerts": {
     "enabled": true,


### PR DESCRIPTION
## Summary

- Enable weekly `lockFileMaintenance` (Monday before 6am) and automerge it, so lockfile-only refreshes land without manual review.
- Inherited by all stack presets (js/go/docker/terraform/kubernetes extend `renovate-base`), so it applies org-wide.

## Test plan

- [ ] CI green
- [ ] After a new date tag, a lockfile-maintenance PR opens and automerges on green in a consumer repo