### PR TITLE
ci(ai-claude-review): bump default review model to claude-opus-5

### DIFF
--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -6,7 +6,7 @@ on:
       model:
         type: string
         required: false
-        default: claude-opus-4-8
+        default: claude-opus-5
         description: |
           Claude model id passed to `--model`. Defaults to Opus for the
           deepest review; consumers can override with a cheaper tier
@@ -128,7 +128,7 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           claude_args: |
             --max-turns ${{ steps.mode.outputs.mode == 'first' && '100' || '40' }}
-            --model ${{ inputs.model || 'claude-opus-4-8' }}
+            --model ${{ inputs.model || 'claude-opus-5' }}
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Agent,Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git log:*),Bash(gh api repos/*/pulls/*/comments*),Bash(gh api repos/*/pulls/comments*),Bash(gh api repos/*/pulls/*/comments/*/replies*),Bash(gh api repos/*/pulls/*/reviews*),Bash(gh api repos/*/compare/*),Bash(gh api graphql:*)"
           prompt: |
             REPO: ${{ github.repository }}

--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -10,9 +10,8 @@ on:
         description: |
           Claude model id passed to `--model`. Defaults to Opus for the
           deepest review; consumers can override with a cheaper tier
-          (e.g. claude-sonnet-4-6, claude-haiku-4-5-20251001) to trade
-          review depth for lower CI cost. Undefined on the `pull_request`
-          trigger, where the expression below falls back to the default.
+          (e.g. claude-sonnet-5, claude-haiku-4-5-20251001) to trade
+          review depth for lower CI cost.
       cancel-in-progress:
         type: boolean
         required: false
@@ -128,7 +127,7 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           claude_args: |
             --max-turns ${{ steps.mode.outputs.mode == 'first' && '100' || '40' }}
-            --model ${{ inputs.model || 'claude-opus-5' }}
+            --model ${{ inputs.model }}
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Agent,Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git log:*),Bash(gh api repos/*/pulls/*/comments*),Bash(gh api repos/*/pulls/comments*),Bash(gh api repos/*/pulls/*/comments/*/replies*),Bash(gh api repos/*/pulls/*/reviews*),Bash(gh api repos/*/compare/*),Bash(gh api graphql:*)"
           prompt: |
             REPO: ${{ github.repository }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ### Changed
 
+- **`ai-claude-review.yml`**: default `model` bumped `claude-opus-4-8` →
+  `claude-opus-5` for both review passes. Non-breaking — the `model` input
+  still overrides, and consumers on a cheaper tier are unaffected.
 - **`renovate-base.json`**: `lockFileMaintenance` is now enabled (weekly,
   Monday before 6am) and automerges on green, matching the non-major automerge
   policy. Inherited by all stack presets, so lockfile refreshes land without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,16 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ## 2026-07-26
 
-### Changed
+### ⚠ BREAKING
 
 - **`ai-claude-review.yml`**: default `model` bumped `claude-opus-4-8` →
-  `claude-opus-5` for both review passes. Non-breaking — the `model` input
-  still overrides, and consumers on a cheaper tier are unaffected.
+  `claude-opus-5` for both review passes. Callers that do not set `model`
+  pick this up automatically on the next tag bump — review behaviour and
+  per-PR token cost change accordingly. Migration: pin the previous
+  behaviour with `with: { model: claude-opus-4-8 }`, or set a cheaper tier.
+
+### Changed
+
 - **`renovate-base.json`**: `lockFileMaintenance` is now enabled (weekly,
   Monday before 6am) and automerges on green, matching the non-major automerge
   policy. Inherited by all stack presets, so lockfile refreshes land without


### PR DESCRIPTION
## Summary

- Bump the `ai-claude-review.yml` default `model` from `claude-opus-4-8` to the newly available `claude-opus-5` for both review passes
- **Breaking** per this repo's changelog policy (a default-value change): callers that do not set `model` switch tier on the next tag bump, changing review behaviour and per-PR token cost. Migration: pin `with: { model: claude-opus-4-8 }` or a cheaper tier
- Refresh the cheaper-tier example in the input description to the current `claude-sonnet-5`, and collapse the unreachable `||` fallback (this file is `workflow_call`-only)

## Test plan

- [ ] CI green, local lints green
- [ ] A consumer PR review runs on `claude-opus-5` when no `model` input is set
