### PR TITLE
fix(renovate): scope stability automerge blocks to breaking update types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,34 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
+## 2026-07-27
+
+### Changed
+
+- **Renovate presets — automerge scope widened.** The stability rules for
+  `node`, `typescript`, `pnpm` (`renovate-js.json`), Terraform Core and the
+  critical providers (`renovate-terraform.json`), the critical platform Helm
+  charts (`renovate-kubernetes.json`) and the Go runtime (`renovate-go.json`)
+  set `automerge: false` **without** `matchUpdateTypes`, so they gated every
+  update type instead of only the breaking ones their descriptions describe.
+  Renovate therefore never enabled auto-merge on those PRs, the ruleset's
+  Renovate bypass never applied, and each one needed a manual approval.
+  Each rule is now split: grouping, release age, priority and labels keep
+  matching every update type, and a second rule carries `automerge: false`
+  scoped to the breaking types only.
+
+  **Consumers scanning before a bump:** critical Terraform providers and
+  critical platform Helm charts now automerge **patch** bumps unattended
+  where they previously waited for a manual merge. `minimumReleaseAge`
+  (7 days) still applies. Terraform Core and the Go runtime gate
+  `major` + `minor`, because neither has left major `1` — gating on `major`
+  alone would never match and would have let a state-format or
+  language-version bump through. To keep a package fully manual in one repo,
+  re-add a rule with `automerge: false` and no `matchUpdateTypes` in that
+  repo's own `renovate.json`.
+
+---
+
 ## 2026-07-26
 
 ### ⚠ BREAKING

--- a/renovate-go.json
+++ b/renovate-go.json
@@ -5,15 +5,21 @@
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   "packageRules": [
     {
-      "description": "Go version updates - higher stability",
+      "description": "Go version updates - higher stability. Grouping, release age and priority apply to every update type; the automerge decision is split out below.",
       "matchManagers": ["gomod"],
       "matchDepTypes": ["golang"],
       "groupName": "Go version",
       "semanticCommitScope": "go",
       "minimumReleaseAge": "14 days",
-      "automerge": false,
       "labels": ["go", "golang-version"],
       "prPriority": 20
+    },
+    {
+      "description": "Go runtime major/minor - manual merge. Go has no v2, so every toolchain release is a 1.x minor and gating on major alone would never match. A minor (1.25 -> 1.26) changes the language version selected by the go directive (e.g. loop variable scoping in 1.22) and re-runs gomodTidy and gomodUpdateImportPaths against the new toolchain. Patch (1.25.11 -> 1.25.12) falls through to the base non-major automerge rule and never needs an approval.",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "matchUpdateTypes": ["major", "minor"],
+      "automerge": false
     },
     {
       "description": "Go ecosystem packages - golang.org/x, go.uber.org",

--- a/renovate-js.json
+++ b/renovate-js.json
@@ -4,25 +4,36 @@
   "extends": ["github>sbaerlocher/.github:renovate-base#main"],
   "packageRules": [
     {
-      "description": "Node.js version updates - higher stability",
+      "description": "Node.js version updates - higher stability. Grouping, release age and priority apply to every update type; only the automerge decision is split out below.",
       "matchManagers": ["nvm"],
       "matchPackageNames": ["node"],
       "groupName": "Node.js",
       "semanticCommitScope": "node",
       "minimumReleaseAge": "14 days",
-      "automerge": false,
       "prPriority": 20,
       "labels": ["nodejs"]
     },
     {
-      "description": "TypeScript - manual review for breaking changes",
+      "description": "Node.js major - manual merge. Restates the inherited base major gate rather than adding a new one; kept explicit because the reason is Node-specific: a runtime major (22 -> 24) can break the CI runners and the Wrangler runtime. Patch/minor (22.0.1 -> 22.0.2) fall through to the base non-major automerge rule, so Renovate self-merges them via the ruleset bypass and they never need an approval.",
+      "matchManagers": ["nvm"],
+      "matchPackageNames": ["node"],
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    },
+    {
+      "description": "TypeScript - grouping, release age and priority for every update type; the automerge decision is split out below.",
       "matchPackageNames": ["typescript"],
       "groupName": "TypeScript",
       "semanticCommitScope": "typescript",
-      "automerge": false,
       "prPriority": 5,
       "minimumReleaseAge": "7 days",
       "labels": ["typescript"]
+    },
+    {
+      "description": "TypeScript major - manual merge. Restates the inherited base major gate; kept explicit because a TS major additionally breaks the type-checker wrappers, which is why the dependencyDashboardApproval rule below holds the PR back entirely. Patch/minor automerge on green.",
+      "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["major"],
+      "automerge": false
     },
     {
       "description": "Code quality tools - ESLint, typescript-eslint and Prettier (must bump together due to peer deps). separateMultipleMajor: false collapses groupSlug from major-N-code-quality-tools to major-code-quality-tools so co-dependent majors share one branch/PR.",
@@ -146,14 +157,20 @@
       "separateMultipleMajor": false
     },
     {
-      "description": "Group pnpm package manager",
+      "description": "Group pnpm package manager - grouping, release age and priority for every update type; the automerge decision is split out below.",
       "matchManagers": ["npm"],
       "matchPackageNames": ["pnpm"],
       "groupName": "pnpm",
       "semanticCommitScope": "pnpm",
-      "automerge": false,
       "prPriority": 5,
       "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "pnpm major - manual merge. Restates the inherited base major gate; kept explicit because a package-manager major breaks `install` itself, which runs before every CI check, and the preset lands in all consumer repos at once. Patch/minor (11.15.0 -> 11.15.1) fall through to the base non-major automerge rule and never need an approval.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["pnpm"],
+      "matchUpdateTypes": ["major"],
+      "automerge": false
     },
     {
       "description": "Group @types packages",

--- a/renovate-kubernetes.json
+++ b/renovate-kubernetes.json
@@ -46,7 +46,7 @@
       "semanticCommitScope": "kustomize"
     },
     {
-      "description": "Critical platform charts - extra stability",
+      "description": "Critical platform charts - extra stability. Release age, priority and labels apply to every update type; the automerge decision is split out below.",
       "matchManagers": ["helm-values", "helmfile"],
       "matchPackageNames": [
         "cert-manager",
@@ -60,9 +60,25 @@
         "vault"
       ],
       "minimumReleaseAge": "7 days",
-      "automerge": false,
       "prPriority": 5,
       "labels": ["platform", "critical"]
+    },
+    {
+      "description": "Critical platform charts major/minor - manual merge. These charts carry CRDs and cluster-wide controllers where a minor can already ship a CRD schema change, so minor stays manual too. Patch falls through to the base non-major automerge rule and never needs an approval.",
+      "matchManagers": ["helm-values", "helmfile"],
+      "matchPackageNames": [
+        "cert-manager",
+        "external-secrets",
+        "ingress-nginx",
+        "metallb",
+        "longhorn",
+        "prometheus-stack",
+        "loki",
+        "grafana",
+        "vault"
+      ],
+      "matchUpdateTypes": ["major", "minor"],
+      "automerge": false
     }
   ],
   "customManagers": [

--- a/renovate-terraform.json
+++ b/renovate-terraform.json
@@ -25,15 +25,21 @@
       "enabled": false
     },
     {
-      "description": "Terraform Core version updates - higher stability",
+      "description": "Terraform Core version updates - higher stability. Grouping, release age and priority apply to every update type; the automerge decision is split out below.",
       "matchManagers": ["terraform-version"],
       "matchPackageNames": ["hashicorp/terraform"],
       "groupName": "Terraform Core",
       "semanticCommitScope": "terraform",
       "minimumReleaseAge": "14 days",
-      "automerge": false,
       "labels": ["terraform-core"],
       "prPriority": 20
+    },
+    {
+      "description": "Terraform Core major/minor - manual merge. Terraform has been on major 1 since 2021, so every feature release is a 1.x minor and gating on major alone would never match. A minor (1.15 -> 1.16) can bump the state format version, which is a one-way change that reverting the PR does not undo once apply has run. Patch (1.15.7 -> 1.15.8) falls through to the base non-major automerge rule and never needs an approval.",
+      "matchManagers": ["terraform-version"],
+      "matchPackageNames": ["hashicorp/terraform"],
+      "matchUpdateTypes": ["major", "minor"],
+      "automerge": false
     },
     {
       "description": "Group Terraform Providers by patch/minor",
@@ -57,7 +63,7 @@
       "semanticCommitScope": "providers"
     },
     {
-      "description": "Critical providers - extra stability",
+      "description": "Critical providers - extra stability. Release age, priority and labels apply to every update type; the automerge decision is split out below.",
       "matchManagers": ["terraform"],
       "matchDatasources": ["terraform-provider"],
       "matchPackageNames": [
@@ -69,9 +75,23 @@
         "integrations/github"
       ],
       "minimumReleaseAge": "7 days",
-      "automerge": false,
       "prPriority": 5,
       "labels": ["terraform", "critical-provider"]
+    },
+    {
+      "description": "Critical providers major/minor - manual merge. These providers touch live infrastructure and a minor can already change resource semantics or add a forced replacement, so minor stays manual too. Patch falls through to the base non-major automerge rule and never needs an approval.",
+      "matchManagers": ["terraform"],
+      "matchDatasources": ["terraform-provider"],
+      "matchPackageNames": [
+        "hashicorp/aws",
+        "hashicorp/azurerm",
+        "hashicorp/google",
+        "hetznercloud/hcloud",
+        "cloudflare/cloudflare",
+        "integrations/github"
+      ],
+      "matchUpdateTypes": ["major", "minor"],
+      "automerge": false
     },
     {
       "description": "Terraform Modules updates",


### PR DESCRIPTION
## Summary

- The stability rules for `node`, `typescript`, `pnpm`, Terraform Core, critical Terraform providers, critical platform Helm charts and the Go runtime all set `automerge: false` **without** `matchUpdateTypes`, so they gated every update type instead of only the breaking ones their descriptions describe ("higher stability", "extra stability", "manual review for breaking changes").
- Consequence: Renovate never enabled auto-merge on those PRs, so the ruleset's Renovate bypass never applied and each one needed a manual approval. Across six consumer repos that accounts for 188 manually merged Renovate PRs, most of them patch bumps like `terraform 1.15.6 -> 1.15.7` or `pnpm 11.15.0 -> 11.15.1`.
- Each rule is now split in two: the grouping, release age, priority and label settings keep matching every update type, and a second rule carries `automerge: false` scoped to the breaking types only. This mirrors the pattern `renovate-go.json` already used for `golang.org/x/**`.
- Toolchain and runtime rules gate `major` only. Critical Terraform providers and platform Helm charts gate `major` **and** `minor`, since a provider minor can change resource semantics and a chart minor can ship a CRD schema change; only patch flows automatically there.
- The pre-1.0 rule in `renovate-base.json` (`major` + `minor`) is untouched, so `0.x` packages keep their stricter gate.

## Test plan

- [x] All five presets parse as valid JSON
- [x] `renovate-config-validator` passes against all five presets
- [x] No `automerge: false` rule remains without an explicit `matchUpdateTypes`
- [ ] CI green
- [ ] After a new date tag: confirm a patch bump for one gated package self-merges without an approval
