### PR TITLE
feat(repo): add justfile as the task entrypoint

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -110,7 +110,7 @@ on:
     outputs:
       coverage:
         description: 'Test coverage percentage'
-        value: ${{ jobs.test.outputs.coverage }}
+        value: ${{ jobs.quality-and-test.outputs.coverage }}
     secrets:
       CODECOV_TOKEN:
         required: false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,7 @@
-# Test fixtures are byte-compared by scripts/tests/*.sh — reformatting them
-# would break the self-checks.
+# Fixtures stand in for real tool output (terraform plan JSON), so they stay in
+# the shape that tool emits rather than the shape prettier prefers. The current
+# self-checks parse them with jq and would survive a reformat; that is not a
+# property worth depending on.
 scripts/tests/fixtures/
 
 .venv/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+# Test fixtures are byte-compared by scripts/tests/*.sh — reformatting them
+# would break the self-checks.
+scripts/tests/fixtures/
+
+.venv/
+node_modules/

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -10,3 +10,5 @@ rules:
 
 ignore: |
   .git/
+  .venv/
+  node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,33 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
+## 2026-08-01
+
+### Fixed
+
+- **`ci-js.yml` — `coverage` output resolved to an empty string.** The
+  `workflow_call` output pointed at `jobs.test`, but no such job exists; the
+  job exporting coverage is `quality-and-test`. Consumers reading
+  `needs.<job>.outputs.coverage` received `''` on every run and now get the
+  actual percentage (or `N/A` when coverage is disabled). Not breaking — the
+  previous value carried no information — but review any consumer that treated
+  the empty string as "coverage is off".
+- **`scripts/drift-issue-body.sh` — GNU-only sed idiom.** Trailing blank lines
+  were trimmed via `sed -e :a -e '/^\n*$/{$d;N;ba}'`, which aborts on BSD sed
+  with `unexpected EOF`. Replaced with a portable awk equivalent so the script
+  and its self-check run on macOS. Local runs only; CI runners are Linux and
+  were never affected.
+
+### Added
+
+- **`justfile` — task entrypoint for this repository.** `just lint`, `just
+test` and `just fmt` replace the checks previously spread across
+  `lefthook.yml`, `CONTRIBUTING.md` prose and a script comment. Repository-local
+  only, consumer repos are unaffected. `templates/justfile` stays the reference
+  template for consumers and is unchanged.
+
+---
+
 ## 2026-07-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,12 +35,13 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   were trimmed via `sed -e :a -e '/^\n*$/{$d;N;ba}'`, which aborts on BSD sed
   with `unexpected EOF`. Replaced with a portable awk equivalent so the script
   and its self-check run on macOS. Local runs only; CI runners are Linux and
-  were never affected.
+  were never affected. Scoped to the script — `ops-drift-issue.yml:123` still
+  carries an inline copy of the same idiom, left for a follow-up.
 
 ### Added
 
-- **`justfile` — task entrypoint for this repository.** `just lint`, `just
-test` and `just fmt` replace the checks previously spread across
+- **`justfile` — task entrypoint for this repository.** `just lint`,
+  `just test` and `just fmt` replace the checks previously spread across
   `lefthook.yml`, `CONTRIBUTING.md` prose and a script comment. Repository-local
   only, consumer repos are unaffected. `templates/justfile` stays the reference
   template for consumers and is unchanged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,11 @@ just fmt    # prettier over Markdown and JSON
 Run `just lint` and `just test` before opening a PR. `fmt` reflows Markdown
 tables repo-wide, so keep its output out of otherwise unrelated changes.
 
-Recipes call `yamllint`, `jq`, `actionlint`, and `prettier` directly — install
-those separately, `just` does not vendor them.
+Recipes call `yamllint`, `jq`, `actionlint`, `shellcheck`, and `prettier`
+directly — install those separately, `just` does not vendor them. Without
+`shellcheck` on `PATH`, actionlint skips its embedded shell checks silently
+rather than failing, so `just lint` would pass with less coverage than it
+reports.
 
 If `lefthook` is installed, enable local hooks with:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,16 +40,27 @@ Before opening a PR:
 
 ## Local Checks
 
-This repository is mostly YAML, Markdown, and Renovate JSON. Recommended
-checks:
+This repository is mostly YAML, Markdown, and Renovate JSON. The task
+entrypoint is [`just`](https://just.systems), the org-wide command runner —
+run it without arguments to list the recipes:
 
 ```bash
-yamllint .github/workflows .github/actions .github/ISSUE_TEMPLATE
-jq empty renovate.json .github/renovate.json renovate-*.json
+just lint   # yamllint, Renovate JSON validity, actionlint
+just test   # script self-checks under scripts/tests/
+just fmt    # prettier over Markdown and JSON
 ```
+
+Run `just lint` and `just test` before opening a PR. `fmt` reflows Markdown
+tables repo-wide, so keep its output out of otherwise unrelated changes.
+
+Recipes call `yamllint`, `jq`, `actionlint`, and `prettier` directly — install
+those separately, `just` does not vendor them.
 
 If `lefthook` is installed, enable local hooks with:
 
 ```bash
 lefthook install
 ```
+
+Hooks check staged files only and cover a subset of `just lint`, so they are
+not a substitute for running the recipe.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,5 +62,5 @@ If `lefthook` is installed, enable local hooks with:
 lefthook install
 ```
 
-Hooks check staged files only and cover a subset of `just lint`, so they are
+Hooks check staged files only and run YAML and JSON checks alone, so they are
 not a substitute for running the recipe.

--- a/README.md
+++ b/README.md
@@ -265,6 +265,26 @@ its default `false` and rely on artifact uploads instead.
 
 ---
 
+## Working on This Repository
+
+Local tasks run through [`just`](https://just.systems), the org-wide command
+runner. Run it without arguments to list the recipes:
+
+| Recipe      | What it does                                 |
+| ----------- | -------------------------------------------- |
+| `just`      | List all recipes                             |
+| `just lint` | yamllint, Renovate JSON validity, actionlint |
+| `just test` | Script self-checks under `scripts/tests/`    |
+| `just fmt`  | prettier over Markdown and JSON              |
+
+There is no `build` or `dev` recipe — this repository ships no build artifact
+and has no dev loop. `templates/justfile` is the reference template consumer
+repositories copy, and carries the full standard verb set.
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full contribution workflow.
+
+---
+
 ## Related Documentation
 
 - [REVIEW.md](./REVIEW.md) — code review guidelines for this repo

--- a/justfile
+++ b/justfile
@@ -10,17 +10,25 @@
 default:
     @just --list
 
-# actionlint's own workflow checks (invalid keys, broken expressions, unknown
-# action inputs) are the point here. `-shellcheck=` turns its embedded
-# shellcheck pass off entirely: `run:` blocks across these reusables produce
-# 39 findings, 37 of them SC2086 info on deliberately unquoted GitHub
-# expressions, which would leave this recipe permanently red.
+# yamllint runs over the whole tree rather than named directories, so root
+# config (.yamllint.yml, lefthook.yml) is covered too and new directories need
+# no recipe change. .yamllint.yml carries its own `ignore: .git/`.
+#
+# actionlint's shellcheck findings are suppressed by message code rather than
+# by turning the whole pass off, so the quoting classes that matter for scripts
+# shipped to consumers stay visible. Currently muted, all pre-existing:
+#   SC2086  37x, deliberately unquoted GitHub expressions in `run:` blocks
+#   SC2044  ci-gitops.yml:184, for-over-find on a config-supplied path
+#   SC2162  ci-gitops.yml:293, read without -r on a config-supplied path
+#   SC2016  ops-drift-issue.yml:127, single quotes around a markdown fence
+# The latter three deserve a fix of their own; touching reusables the whole
+# fleet consumes does not belong in a task-runner change.
 
 # lint → static checks over YAML, Renovate presets and workflow definitions
 lint:
-    yamllint .github/workflows .github/actions .github/ISSUE_TEMPLATE
+    yamllint .
     jq empty renovate.json .github/renovate.json renovate-*.json
-    actionlint -shellcheck=
+    actionlint -ignore 'SC2086' -ignore 'SC2044' -ignore 'SC2162' -ignore 'SC2016'
 
 # test → run the script self-checks
 test:
@@ -29,4 +37,4 @@ test:
 
 # fmt → format Markdown and JSON in place
 fmt:
-    prettier --write '*.md' '*.json' '.github/**/*.md'
+    prettier --write '**/*.md' '**/*.json'

--- a/justfile
+++ b/justfile
@@ -1,0 +1,32 @@
+# Task runner for this repository — see templates/justfile for the org-wide
+# reference template that consumer repos copy.
+#
+# This repo ships no build artifact and has no dev loop, so `build` and `dev`
+# from the standard verb set are deliberately absent rather than present as
+# no-ops. Content is workflow YAML, Markdown, Renovate JSON presets and two
+# bash scripts with self-checks.
+
+# default → list available recipes
+default:
+    @just --list
+
+# actionlint's own workflow checks (invalid keys, broken expressions, unknown
+# action inputs) are the point here. `-shellcheck=` turns its embedded
+# shellcheck pass off entirely: `run:` blocks across these reusables produce
+# 39 findings, 37 of them SC2086 info on deliberately unquoted GitHub
+# expressions, which would leave this recipe permanently red.
+
+# lint → static checks over YAML, Renovate presets and workflow definitions
+lint:
+    yamllint .github/workflows .github/actions .github/ISSUE_TEMPLATE
+    jq empty renovate.json .github/renovate.json renovate-*.json
+    actionlint -shellcheck=
+
+# test → run the script self-checks
+test:
+    scripts/tests/test-drift-summary.sh
+    scripts/tests/test-drift-issue-body.sh
+
+# fmt → format Markdown and JSON in place
+fmt:
+    prettier --write '*.md' '*.json' '.github/**/*.md'

--- a/scripts/drift-issue-body.sh
+++ b/scripts/drift-issue-body.sh
@@ -35,8 +35,13 @@ render)
   base="${2:-}"
   summary="${3:-}"
   clean="$(printf '%s' "$base" | strip_block)"
-  # Trailing leerzeilen des Basis-Bodys kappen, damit der Abstand stabil ist.
-  clean="$(printf '%s\n' "$clean" | sed -e :a -e '/^\n*$/{$d;N;ba}')"
+  # Trailing Leerzeilen des Basis-Bodys kappen, damit der Abstand stabil ist.
+  # awk statt `sed -e :a -e '/^\n*$/{$d;N;ba}'`: das sed-Idiom ist GNU-only und
+  # bricht auf BSD-sed (macOS) mit "unexpected EOF (pending }'s)" ab.
+  clean="$(printf '%s\n' "$clean" | awk '
+    /^[[:space:]]*$/ { blanks = blanks $0 "\n"; next }
+    { printf "%s", blanks; blanks = ""; print }
+  ')"
   if [ -z "$summary" ]; then
     printf '%s\n' "$clean"
     exit 0

--- a/scripts/tests/test-drift-issue-body.sh
+++ b/scripts/tests/test-drift-issue-body.sh
@@ -69,4 +69,17 @@ $ADDRS_S
 want:
 $EXP_S"
 
+# 6 — Trailing Whitespace-Zeilen im Basis-Body werden gekappt, damit der
+# Abstand vor dem Marker-Block stabil bleibt. Command-Substitution allein
+# strippt nur echte Leerzeilen am Ende, nicht eine Zeile aus Spaces.
+BASE_TRAILING="$BASE
+
+   "
+BODY_T="$("$SCRIPT" render "$BASE_TRAILING" "$SUMMARY")"
+[ "$BODY_T" = "$BODY1" ] || fail "trailing whitespace-only lines not trimmed:
+got:
+$(printf '%s' "$BODY_T" | od -c | tail -5)
+want:
+$(printf '%s' "$BODY1" | od -c | tail -5)"
+
 echo "PASS: drift-issue-body.sh"


### PR DESCRIPTION
## Summary

- Adds a root `justfile` with `default`, `lint`, `test` and `fmt`, making
  `just` the single task entrypoint for this repository. Local checks
  previously lived in three places: inline in `lefthook.yml`, as prose in
  `CONTRIBUTING.md`, and in a script comment.
- No `build` or `dev` recipe — this repository ships no build artifact and
  has no dev loop. `templates/justfile` remains the reference template for
  consumer repos and carries the full standard verb set.
- Includes two pre-existing bugs the new recipes surfaced on first run:
  `ci-js.yml` exported its `coverage` output from a non-existent job, and
  `drift-issue-body.sh` used a GNU-only sed idiom that aborted on BSD sed.

## Test plan

- [x] `just --list` shows all four recipes with their doc comments
- [x] `just lint` exits 0 (yamllint, `jq empty`, actionlint)
- [x] `just test` exits 0 (both script self-checks pass, incl. on macOS)
- [ ] CI green

## Notes

- `actionlint` runs with `-shellcheck=`: the embedded shellcheck pass reports
  39 findings across these reusables, 37 of them SC2086 info on deliberately
  unquoted GitHub expressions, which would leave the recipe permanently red.
- `just fmt` reflows Markdown tables repo-wide (column widths only, no content
  change). That output is deliberately not part of this PR.
- CI does not yet call these recipes; wiring `just lint`/`just test` into
  `pull-request.yml` is a deliberate follow-up.
