### PR TITLE
feat(ai-claude-review): expose turn and timeout budgets as inputs

### DIFF
--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -12,6 +12,34 @@ on:
           deepest review; consumers can override with a cheaper tier
           (e.g. claude-sonnet-5, claude-haiku-4-5-20251001) to trade
           review depth for lower CI cost.
+      max-turns-first:
+        type: number
+        required: false
+        default: 100
+        description: |
+          Turn budget for the initial review, passed to `--max-turns`. The
+          first pass reads the whole diff, so it needs the larger budget.
+          Expected to be a positive integer.
+      max-turns-followup:
+        type: number
+        required: false
+        default: 40
+        description: |
+          Turn budget for follow-up reviews. The default assumes a follow-up
+          only inspects the delta since the last review; raise it for PRs
+          whose follow-ups still span many files, where exhausting the
+          budget aborts the run before it can submit its closing review.
+          Expected to be a positive integer. Raising this past what fits in
+          `timeout-minutes` just trades the turn wall for the clock wall —
+          raise both together.
+      timeout-minutes:
+        type: number
+        required: false
+        default: 30
+        description: |
+          Job-level timeout in minutes. Binds independently of the turn
+          budgets: a run cancelled here dies before it can submit its
+          closing review, same visible failure as exhausting `--max-turns`.
       cancel-in-progress:
         type: boolean
         required: false
@@ -67,7 +95,7 @@ jobs:
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
       contents: read
       pull-requests: write
@@ -126,7 +154,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           claude_args: |
-            --max-turns ${{ steps.mode.outputs.mode == 'first' && '100' || '40' }}
+            --max-turns ${{ steps.mode.outputs.mode == 'first' && format('{0}', inputs.max-turns-first) || format('{0}', inputs.max-turns-followup) }}
             --model ${{ inputs.model }}
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Agent,Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git log:*),Bash(gh api repos/*/pulls/*/comments*),Bash(gh api repos/*/pulls/comments*),Bash(gh api repos/*/pulls/*/comments/*/replies*),Bash(gh api repos/*/pulls/*/reviews*),Bash(gh api repos/*/compare/*),Bash(gh api graphql:*)"
           prompt: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,23 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   `lefthook.yml`, `CONTRIBUTING.md` prose and a script comment. Repository-local
   only, consumer repos are unaffected. `templates/justfile` stays the reference
   template for consumers and is unchanged.
+- **`ai-claude-review.yml` — review budgets are now configurable.** New
+  optional `max-turns-first` (default `100`), `max-turns-followup`
+  (default `40`) and `timeout-minutes` (default `30`) inputs. All three
+  were previously hard-coded, so a consumer could not raise them without
+  forking the workflow. Defaults match the previous values — no behaviour
+  change unless a caller sets them.
+
+  **When to raise `max-turns-followup`:** the `40` default assumes a
+  follow-up only inspects the delta since the last review. On a PR whose
+  follow-up still spans many changed files, the budget can run out before
+  the review submits its closing verdict — the job then fails after having
+  posted its inline comments, and the stale `CHANGES_REQUESTED` from the
+  first pass keeps blocking the merge.
+
+  **Raise `timeout-minutes` alongside it.** The two limits bind
+  independently and produce the same visible failure, so lifting only the
+  turn budget just trades the turn wall for the clock wall.
 
 ---
 


### PR DESCRIPTION
## Summary

- `ai-claude-review.yml` hard-coded both its turn budgets
  (`--max-turns ${{ mode == 'first' && '100' || '40' }}`) and its
  `timeout-minutes: 30`, so a consumer could not raise either without
  forking the workflow. All three are now optional inputs:
  `max-turns-first` (`100`), `max-turns-followup` (`40`) and
  `timeout-minutes` (`30`).
- Every default matches the previous literal, so no caller changes
  behaviour by bumping the date tag.
- Separate turn inputs rather than one: the follow-up budget is the one
  that runs out in practice, and raising it should not also widen the
  initial pass.
- The turn budgets and the timeout bind independently and fail the same
  visible way, so both descriptions point at each other.

Found while shipping `sbaerlocher/infrastructure#328` (23 files, 568 changed
lines). Its follow-up review posted both of its inline comments and then the
job failed ~7 seconds later, before it could submit the closing review — so
the stale `CHANGES_REQUESTED` from the first pass kept blocking the merge
even though every finding had been addressed. The `40` default assumes a
follow-up only inspects the delta since the last review; that assumption
does not hold when the follow-up still spans many files.

Raising the defaults is deliberately left out of this PR — that is a
separate decision, and this change is what makes it adjustable at all.

## Test plan

- [ ] `actionlint .github/workflows/ai-claude-review.yml` — clean
- [ ] `yamllint -c .yamllint.yml` — clean
- [ ] `prettier --check` on both changed files — clean
- [ ] Verify the rendered `--max-turns` resolves to `100` / `40` in a real
      run (`actionlint` validates the expression statically, not its runtime
      value)
- [ ] CI green
