### PR TITLE
fix(security-secrets): scope the pattern stage to what it actually checks

### DIFF
--- a/.github/workflows/security-secrets.yml
+++ b/.github/workflows/security-secrets.yml
@@ -19,7 +19,11 @@ on:
       enable-pattern-detection:
         type: boolean
         default: true
-        description: 'Enable custom pattern detection'
+        description: |
+          Enable the key-pattern checks: AWS access keys in
+          `*.tf`/`*.yml`/`*.yaml`/`*.json` and private-key content in
+          `*.pem`/`*.key`. Both fail the job on a hit. This is not a
+          general-purpose secret scanner — gitleaks and TruffleHog cover that.
       file-patterns:
         type: string
         default: '*.tf,*.yml,*.yaml,*.json,*.env.example'
@@ -171,7 +175,7 @@ jobs:
           | --- | --- |
           | Gitleaks | ${{ needs.gitleaks.result }} |
           | TruffleHog | ${{ steps.trufflehog.outcome }} |
-          | Pattern Detection | ${PATTERN_OUTCOME} |
+          | AWS & private key patterns | ${PATTERN_OUTCOME} |
           EOF
 
       # continue-on-error above only lets the later sequential steps run; it

--- a/.github/workflows/security-secrets.yml
+++ b/.github/workflows/security-secrets.yml
@@ -146,62 +146,17 @@ jobs:
           fi
           echo "✓ No private keys found"
 
-      - name: Generic Secret Patterns
-        id: pattern-generic
-        if: inputs.enable-pattern-detection
-        continue-on-error: true
-        working-directory: ${{ inputs.working-directory }}
-        run: |
-          echo "Checking for generic secret patterns..."
-          FOUND_ISSUES=0
-
-          # Check for hardcoded passwords (not in External Secrets)
-          echo "→ Checking for hardcoded passwords..."
-          if grep -r "password:" . \
-            --include="*.yaml" --include="*.yml" \
-            | grep -v "secretKeyRef\|valueFrom\|ExternalSecret\|# Example\|# Template"; then
-            echo "::warning::Potential hardcoded passwords found"
-            FOUND_ISSUES=$((FOUND_ISSUES + 1))
-          fi
-
-          # Check for API keys
-          echo "→ Checking for hardcoded API keys..."
-          if grep -r "apiKey:\|api_key:" . \
-            --include="*.yaml" --include="*.yml" \
-            | grep -v "secretKeyRef\|valueFrom\|ExternalSecret\|# Example\|# Template"; then
-            echo "::warning::Potential hardcoded API keys found"
-            FOUND_ISSUES=$((FOUND_ISSUES + 1))
-          fi
-
-          # Check for tokens
-          echo "→ Checking for hardcoded tokens..."
-          if grep -r "token:" . \
-            --include="*.yaml" --include="*.yml" \
-            | grep -v "secretKeyRef\|valueFrom\|ExternalSecret\|# Example\|# Template\|access_token\|description"; then
-            echo "::warning::Potential hardcoded tokens found"
-            FOUND_ISSUES=$((FOUND_ISSUES + 1))
-          fi
-
-          if [ $FOUND_ISSUES -eq 0 ]; then
-            echo "✓ No hardcoded secrets detected"
-          else
-            echo ""
-            echo "ℹ️  Found $FOUND_ISSUES potential issues"
-            echo "   Please verify these are using secure secret management"
-          fi
-
       # Report is the final step of secret-scan (folded from the old
       # security-report job). Gitleaks stays a separate job → needs.*.result;
       # trufflehog/pattern are steps → steps.*.outcome. The pattern cell is
-      # failure if any of the three pattern steps failed, else skipped/success.
+      # failure if either key-pattern step failed, else skipped/success.
       - name: Generate Security Report
         if: always()
         env:
           PATTERN_OUTCOME: >-
             ${{
               (steps.pattern-detection.outcome == 'failure'
-               || steps.pattern-private-key.outcome == 'failure'
-               || steps.pattern-generic.outcome == 'failure') && 'failure'
+               || steps.pattern-private-key.outcome == 'failure') && 'failure'
               || steps.pattern-detection.outcome
             }}
         run: |
@@ -222,8 +177,7 @@ jobs:
       # continue-on-error above only lets the later sequential steps run; it
       # must not swallow the gates. On origin/main trufflehog (verified hits)
       # and the AWS-key/private-key checks (exit 1) failed the workflow and
-      # blocked merge. Re-raise that here so behaviour is unchanged. The
-      # generic-pattern step only warned on main, so it stays report-only.
+      # blocked merge. Re-raise that here so behaviour is unchanged.
       - name: Enforce secret-scan result
         if: always()
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,14 +211,14 @@ consumers have an escape hatch.
 
 **Purpose**: Comprehensive security scanning (SAST, secrets, dependencies, containers)
 
-| Workflow        | File                        | Description                | Tools                   |
-| --------------- | --------------------------- | -------------------------- | ----------------------- |
-| SAST            | `security-code.yml`         | Static code analysis       | CodeQL (multi-language) |
-| Config Security | `security-config.yml`       | IaC security               | Checkov, Kubeconform    |
-| Dependencies    | `security-deps.yml`         | Dependency vulnerabilities | govulncheck, npm audit  |
-| Secrets         | `security-secrets.yml`      | Secret detection           | Gitleaks, TruffleHog    |
-| Containers      | `security-containers.yml`   | Container scanning         | Trivy, Grype            |
-| Supply Chain    | `security-sbom.yml`         | SBOM & signing             | Cosign, CycloneDX       |
+| Workflow        | File                      | Description                | Tools                              |
+| --------------- | ------------------------- | -------------------------- | ---------------------------------- |
+| SAST            | `security-code.yml`       | Static code analysis       | CodeQL (multi-language)            |
+| Config Security | `security-config.yml`     | IaC security               | Checkov, Kubeconform               |
+| Dependencies    | `security-deps.yml`       | Dependency vulnerabilities | govulncheck, npm audit             |
+| Secrets         | `security-secrets.yml`    | Secret detection           | Gitleaks, TruffleHog, key patterns |
+| Containers      | `security-containers.yml` | Container scanning         | Trivy, Grype                       |
+| Supply Chain    | `security-sbom.yml`       | SBOM & signing             | Cosign, CycloneDX                  |
 
 **Strategy**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,22 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   only, consumer repos are unaffected. `templates/justfile` stays the reference
   template for consumers and is unchanged.
 
+### Changed
+
+- **`security-secrets.yml` — dropped the report-only generic pattern greps.**
+  The `password:`/`apiKey:`/`token:` greps over YAML warned but could never
+  fail the job by design, and in Ansible and GitOps repos they mostly matched
+  variable names next to `secretKeyRef`. No gate is lost — the step could not
+  fail by design, so only warning-level log output disappears. Gitleaks and
+  TruffleHog remain the secret scanners, within their own limits: TruffleHog
+  runs `--only-verified` over the pushed diff, and gitleaks' generic rules are
+  entropy-gated, so a low-entropy hardcoded value is caught by neither. The
+  input name
+  `enable-pattern-detection` and the fail behaviour of the AWS-key and
+  private-key checks are unchanged; its description and the report row now
+  name the two checks that actually run. Consumers scanning before a bump:
+  no action needed.
+
 ---
 
 ## 2026-07-27

--- a/README.md
+++ b/README.md
@@ -86,14 +86,14 @@ All files live in [.github/workflows/](./.github/workflows/).
 
 ### Security — Scanning & Analysis (6)
 
-| File                                                                     | Tools                          |
-| ------------------------------------------------------------------------ | ------------------------------ |
-| [`security-code.yml`](./.github/workflows/security-code.yml)             | CodeQL (multi-language SAST)   |
-| [`security-config.yml`](./.github/workflows/security-config.yml)         | Checkov, kubeconform, kubesec  |
-| [`security-containers.yml`](./.github/workflows/security-containers.yml) | Trivy + Grype                  |
-| [`security-deps.yml`](./.github/workflows/security-deps.yml)             | govulncheck, npm audit, safety |
-| [`security-sbom.yml`](./.github/workflows/security-sbom.yml)             | CycloneDX SBOM generation      |
-| [`security-secrets.yml`](./.github/workflows/security-secrets.yml)       | Gitleaks + TruffleHog          |
+| File                                                                     | Tools                              |
+| ------------------------------------------------------------------------ | ---------------------------------- |
+| [`security-code.yml`](./.github/workflows/security-code.yml)             | CodeQL (multi-language SAST)       |
+| [`security-config.yml`](./.github/workflows/security-config.yml)         | Checkov, kubeconform, kubesec      |
+| [`security-containers.yml`](./.github/workflows/security-containers.yml) | Trivy + Grype                      |
+| [`security-deps.yml`](./.github/workflows/security-deps.yml)             | govulncheck, npm audit, safety     |
+| [`security-sbom.yml`](./.github/workflows/security-sbom.yml)             | CycloneDX SBOM generation          |
+| [`security-secrets.yml`](./.github/workflows/security-secrets.yml)       | Gitleaks, TruffleHog, key patterns |
 
 ### Deploy (2)
 


### PR DESCRIPTION
## Summary

- Remove the `Generic Secret Patterns` step. Its `password:`/`apiKey:`/`token:` greps over YAML warned but could never fail the job by design, and in Ansible and GitOps repos they mostly matched variable names next to `secretKeyRef`. Gitleaks and TruffleHog cover real secrets, so no gate is lost — only log noise.
- Describe `enable-pattern-detection` by what it runs: AWS access keys and private-key content, both hard-failing. The input name is unchanged, so the six consumer repos need no migration.
- Rename the report row to `AWS & private key patterns` and add the key-pattern checks to the workflow catalogue in `README.md` and `AGENTS.md`, which listed only Gitleaks and TruffleHog.

Fail behaviour of `Enforce secret-scan result` is untouched: it never referenced the removed step.

## Test plan

- [ ] `just test` passes locally
- [ ] `yamllint .` clean; workflow still parses as YAML
- [ ] `grep -c "pattern-generic" .github/workflows/security-secrets.yml` is `0`, and the two remaining `steps.pattern-*.outcome` references are unchanged
- [ ] CI green (actionlint and prettier run in CI; both are unavailable in the local sandbox)