### PR TITLE
docs(changelog): add missing entries for four release tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,13 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   name the two checks that actually run. Consumers scanning before a bump:
   no action needed.
 
+### Dependencies
+
+- **GitHub Actions**: `docker/login-action` → v4.6.0, plus digest bumps in
+  `ci-gitops.yml`, `e2e-dde.yml`, `release-npm.yml` and `security-sbom.yml`.
+  The inner `sbaerlocher/.github` refs in the `project` composite action and
+  the reusables moved to `2026-07-29`.
+
 ---
 
 ## 2026-07-29
@@ -97,7 +104,7 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ## 2026-07-28
 
-### Changed
+### ⚠ BREAKING
 
 - **Renovate presets — automerge scope widened.** The stability rules for
   `node`, `typescript`, `pnpm` (`renovate-js.json`), Terraform Core and the
@@ -164,7 +171,7 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ### Dependencies
 
-- **GitHub Actions**: batched updates across reusables (`#245`, `#246`, `#247`).
+- **GitHub Actions**: batched updates across reusables (`#246`, `#247`).
 - **`actions/setup-go`**: → v7.
 - **`anthropics/claude-code-action`**: → v1.0.181.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,21 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
-## 2026-07-27
+## 2026-07-29
+
+### Changed
+
+- **Dependencies.** GitHub Actions digest bumps across `ai-claude.yml`,
+  `ci-ansible.yml`, `ci-gitops.yml`, `e2e-dde.yml`, `release-docker.yml`,
+  `release-npm.yml`, `security-code.yml`, `security-config.yml`,
+  `security-deps.yml`, `security-sbom.yml`, `security-secrets.yml` and the
+  `project` composite action, including `actions/setup-python` v6 → v7. The
+  inner `sbaerlocher/.github` ref in `project/action.yml` moved to
+  `2026-07-28`. No inputs, outputs or defaults changed.
+
+---
+
+## 2026-07-28
 
 ### Changed
 
@@ -106,6 +120,15 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   language-version bump through. To keep a package fully manual in one repo,
   re-add a rule with `automerge: false` and no `matchUpdateTypes` in that
   repo's own `renovate.json`.
+
+---
+
+## 2026-07-27
+
+### Changed
+
+- **Dependencies.** `docker/login-action` bumped to v4.5.0. No inputs,
+  outputs or defaults changed.
 
 ---
 
@@ -144,6 +167,17 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 - **GitHub Actions**: batched updates across reusables (`#245`, `#246`, `#247`).
 - **`actions/setup-go`**: → v7.
 - **`anthropics/claude-code-action`**: → v1.0.181.
+
+---
+
+## 2026-07-23
+
+### Changed
+
+- **Dependencies.** GitHub Actions digest bumps across `ai-claude-review.yml`,
+  `ai-claude.yml`, `ci-gitops.yml`, `e2e-dde.yml`, `release-npm.yml`,
+  `security-sbom.yml` and the `project` composite action. No inputs, outputs
+  or defaults changed.
 
 ---
 
@@ -1469,6 +1503,24 @@ edit` / branch-ruleset bootstrap script. Neither doc is being relocated
   - `packages: write` is now only granted to the `sign-container` job
   - Workflow-level permissions reduced to `contents: write` and `id-token: write`
   - Maintains full functionality for container image signing and SBOM attachment
+
+---
+
+## 2026-02-19
+
+### Fixed
+
+- **`security-code.yml`**: `paths-ignore` in the CodeQL configuration was
+  written as a newline-separated string, which CodeQL does not accept.
+  Converted to a YAML array so the exclusions apply.
+
+### Changed
+
+- **Dependencies.** GitHub Actions digest bumps across `ai-claude-review.yml`,
+  `ai-claude.yml`, `ci-go.yml`, `ci-js.yml`, `ci-terraform.yml`,
+  `helm-test.yml`, `release-docker.yml`, `security-code.yml`,
+  `security-config.yml`, `security-containers.yml` and
+  `security-secrets.yml`.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `## 2026-07-29`, `## 2026-07-28`, `## 2026-07-23` and `## 2026-02-19` — four tags that existed with no matching changelog heading.
- Re-dates the Renovate automerge entry from `2026-07-27` to `2026-07-28`. Its commit (`8c32b7e`) is not contained in the `2026-07-27` tag; the earliest tag carrying it is `2026-07-28`. The now-freed `2026-07-27` heading documents what that tag actually shipped. The entry also moves from `Changed` to `⚠ BREAKING` — it describes a default-behaviour change, which lines 12–16 define as breaking, and re-dating it means anyone who already scanned `2026-07-27` would otherwise never revisit it.
- Drops `#245` from the `2026-07-26` dependency list: its earliest containing tag is `2026-07-23`, so the new entry there would have documented it twice.
- Documents the `#259` dependency bumps under `2026-08-01`, a heading that existed with no matching content.
- Motivation: the "Breaking changes & support policy" section declares the changelog the single source of truth to scan before bumping a tag. With no entry for the newest tags, that check silently returned nothing for the version consumers currently pin.

## Test plan

- [x] Every date tag now has a matching heading: `comm -23 <(git tag | grep -E '^20..-..-..$' | sort) <(grep -oE '^## 20..-..-..' CHANGELOG.md | sed 's/^## //' | sort)` returns empty.
- [x] Headings are strictly descending and free of duplicates.
- [x] Tag attribution verified per entry via `git tag --contains <commit>` rather than merge timestamps.
- [x] `just lint` and `just test` pass; Prettier reports no formatting drift.
