### PR TITLE
refactor(ops-drift-issue): replace GNU-only sed idiom with portable awk

### DIFF
--- a/.github/workflows/ops-drift-issue.yml
+++ b/.github/workflows/ops-drift-issue.yml
@@ -120,7 +120,13 @@ jobs:
           render() { # render <base> <summary>
             local clean
             clean="$(printf '%s' "$1" | strip_block)"
-            clean="$(printf '%s\n' "$clean" | sed -e :a -e '/^\n*$/{$d;N;ba}')"
+            # Trailing Leerzeilen des Basis-Bodys kappen, damit der Abstand stabil ist.
+            # awk statt `sed -e :a -e '/^\n*$/{$d;N;ba}'`: das sed-Idiom ist GNU-only und
+            # bricht auf BSD-sed (macOS) mit "unexpected EOF (pending }'s)" ab.
+            clean="$(printf '%s\n' "$clean" | awk '
+              /^[[:space:]]*$/ { blanks = blanks $0 "\n"; next }
+              { printf "%s", blanks; blanks = ""; print }
+            ')"
             if [ -z "$2" ]; then
               printf '%s\n' "$clean"
               return

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,21 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
+## 2026-08-02
+
+### Fixed
+
+- **`ops-drift-issue.yml` — GNU-only sed idiom in the inline `render()`.** The
+  workflow carries an inline copy of `scripts/drift-issue-body.sh`, and the
+  copy still trimmed trailing blank lines via
+  `sed -e :a -e '/^\n*$/{$d;N;ba}'` — the same GNU-only idiom the script shed
+  on 2026-08-01, which aborts on BSD sed with `unexpected EOF`. Replaced with
+  the identical portable awk equivalent, so script and workflow agree again.
+  Side effect of the awk form, matching the script: a trailing line consisting
+  only of spaces or tabs is now trimmed too, where sed left it in place. Not
+  breaking for CI — runners are Linux and the sed form worked there; the fix
+  matters for anyone reproducing the block locally on macOS.
+
 ## 2026-08-01
 
 ### Fixed
@@ -35,8 +50,8 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   were trimmed via `sed -e :a -e '/^\n*$/{$d;N;ba}'`, which aborts on BSD sed
   with `unexpected EOF`. Replaced with a portable awk equivalent so the script
   and its self-check run on macOS. Local runs only; CI runners are Linux and
-  were never affected. Scoped to the script — `ops-drift-issue.yml:123` still
-  carries an inline copy of the same idiom, left for a follow-up.
+  were never affected. Scoped to the script — the inline copy in
+  `ops-drift-issue.yml` was left for a follow-up and landed on 2026-08-02.
 
 ### Added
 

--- a/justfile
+++ b/justfile
@@ -20,7 +20,7 @@ default:
 #   SC2086  37x, deliberately unquoted GitHub expressions in `run:` blocks
 #   SC2044  ci-gitops.yml:184, for-over-find on a config-supplied path
 #   SC2162  ci-gitops.yml:293, read without -r on a config-supplied path
-#   SC2016  ops-drift-issue.yml:127, single quotes around a markdown fence
+#   SC2016  ops-drift-issue.yml:134, single quotes around a markdown fence
 # The latter three deserve a fix of their own; touching reusables the whole
 # fleet consumes does not belong in a task-runner change.
 


### PR DESCRIPTION
## Summary

- `ops-drift-issue.yml` carries an inline copy of `scripts/drift-issue-body.sh`, and the copy still trimmed trailing blank lines with `sed -e :a -e '/^\n*$/{$d;N;ba}'`. That idiom is GNU-only and aborts on BSD sed with `unexpected EOF (pending }'s)`, so the block could not be reproduced locally on macOS. The script itself shed the idiom on 2026-08-01; this closes the follow-up the CHANGELOG named.
- Replaced with the identical portable awk form the script already uses, so the two implementations agree again. Side effect, matching the script: a trailing line of only spaces or tabs is now trimmed too, where sed left it in place. CI runners are Linux and were never affected.
- Also refreshed the stale `SC2016 ops-drift-issue.yml:127` line reference in the `justfile` comment (the fence moved to :134) and added the dated CHANGELOG entry.

## Test plan

Note: `pull-request.yml` runs only `ai-claude-review.yml` and `security-code.yml` — `just lint` and `just test` are not wired into any workflow, so the local verification below is the only functional check this change gets.

- [x] `scripts/tests/test-drift-issue-body.sh` and `test-drift-summary.sh` pass
- [x] Extracted the workflow's inline `render()`/`addresses()` and diffed them against the script across 6 input shapes (plain, empty summary, trailing blanks, trailing whitespace-only, spaced `for_each` keys, empty base) plus idempotent re-render — 14/14 identical
- [x] Compared the old sed form against the new awk form directly: identical on every input except a trailing whitespace-only line, which awk trims and sed left — the intended divergence, matching the script
- [x] `yamllint .` clean, `jq empty` on the Renovate presets clean, workflow YAML parses and the `run:` block passes `bash -n`

