### PR TITLE
refactor(ci-gitops): pass fleet-paths through env instead of direct interpolation

### DIFF
--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -72,7 +72,10 @@ on:
         required: false
         default: true
       fleet-paths:
-        description: 'Space-separated paths to search for fleet.yaml files'
+        description: |
+          Space-separated paths to search for fleet.yaml files.
+          Expanded unquoted so the separate paths survive word splitting —
+          pass static caller configuration only, never event-controlled data.
         type: string
         required: false
         default: 'platform applications'
@@ -166,9 +169,11 @@ jobs:
           persist-credentials: false
 
       - name: Check fleet.yaml files exist
+        env:
+          FLEET_PATHS: ${{ inputs.fleet-paths }}
         run: |
-          echo "Checking for fleet.yaml files in: ${{ inputs.fleet-paths }}"
-          FLEET_FILES=$(find ${{ inputs.fleet-paths }} -name "fleet.yaml" 2>/dev/null | wc -l)
+          echo "Checking for fleet.yaml files in: ${FLEET_PATHS}"
+          FLEET_FILES=$(find ${FLEET_PATHS} -name "fleet.yaml" 2>/dev/null | wc -l)
           echo "Found $FLEET_FILES fleet.yaml files"
 
           if [ "$FLEET_FILES" -eq 0 ]; then
@@ -177,11 +182,13 @@ jobs:
           fi
 
       - name: Validate fleet.yaml structure
+        env:
+          FLEET_PATHS: ${{ inputs.fleet-paths }}
         run: |
           echo "Validating fleet.yaml files..."
           ERRORS=0
 
-          for file in $(find ${{ inputs.fleet-paths }} -name "fleet.yaml" 2>/dev/null); do
+          for file in $(find ${FLEET_PATHS} -name "fleet.yaml" 2>/dev/null); do
             echo "Checking $file..."
 
             if ! grep -q "defaultNamespace:" "$file"; then
@@ -286,11 +293,13 @@ jobs:
             ${{ runner.os }}-helm-
 
       - name: Lint Helm Charts
+        env:
+          FLEET_PATHS: ${{ inputs.fleet-paths }}
         run: |
-          echo "Linting Helm charts in: ${{ inputs.fleet-paths }}"
+          echo "Linting Helm charts in: ${FLEET_PATHS}"
           ERRORS=0
 
-          for dir in $(echo "${{ inputs.fleet-paths }}" | tr ' ' '\n' | while read p; do echo "$p"/*; done); do
+          for dir in $(echo "${FLEET_PATHS}" | tr ' ' '\n' | while read -r p; do echo "$p"/*; done); do
             if [ -f "$dir/Chart.yaml" ]; then
               echo "Linting $dir..."
               if ! helm lint "$dir"; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,18 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   breaking for CI — runners are Linux and the sed form worked there; the fix
   matters for anyone reproducing the block locally on macOS.
 
+### Changed
+
+- **`ci-gitops.yml` — `fleet-paths` is passed through `env:` in every step.**
+  The two fleet-validation steps and the Helm-lint step interpolated
+  `${{ inputs.fleet-paths }}` directly into their `run:` blocks, which CodeQL
+  flags as potential code injection; the two kubeconform steps already used
+  `env: FLEET_PATHS`. All five uses now go through `env:`, so the file is
+  consistent and the recurring Code Scanning alerts at those sites disappear.
+  Not breaking: the value is still expanded unquoted, so the space-separated
+  paths keep the same word-splitting behaviour. The chart loop also moved to
+  `read -r`, matching the equivalent loop in the kubeconform step.
+
 ## 2026-08-01
 
 ### Fixed

--- a/justfile
+++ b/justfile
@@ -18,17 +18,16 @@ default:
 # by turning the whole pass off, so the quoting classes that matter for scripts
 # shipped to consumers stay visible. Currently muted, all pre-existing:
 #   SC2086  37x, deliberately unquoted GitHub expressions in `run:` blocks
-#   SC2044  ci-gitops.yml:184, for-over-find on a config-supplied path
-#   SC2162  ci-gitops.yml:293, read without -r on a config-supplied path
+#   SC2044  ci-gitops.yml:191, for-over-find on a config-supplied path
 #   SC2016  ops-drift-issue.yml:134, single quotes around a markdown fence
-# The latter three deserve a fix of their own; touching reusables the whole
+# The latter two deserve a fix of their own; touching reusables the whole
 # fleet consumes does not belong in a task-runner change.
 
 # lint → static checks over YAML, Renovate presets and workflow definitions
 lint:
     yamllint .
     jq empty renovate.json .github/renovate.json renovate-*.json
-    actionlint -ignore 'SC2086' -ignore 'SC2044' -ignore 'SC2162' -ignore 'SC2016'
+    actionlint -ignore 'SC2086' -ignore 'SC2044' -ignore 'SC2016'
 
 # test → run the script self-checks
 test:


### PR DESCRIPTION
## Summary

- The fleet-validation and Helm-lint steps in `ci-gitops.yml` interpolated `inputs.fleet-paths` directly into their `run:` blocks; CodeQL repeatedly flags those sites as potential code injection.
- Two sibling steps in the same file (`Render charts and validate with kubeconform`, and the kubeconform manifest scan) already pass the value via `env: FLEET_PATHS`. This makes the remaining three steps consistent with that pattern, so all five uses of the input now go through `env:`.
- Also switches the chart loop to `read -r`, matching the equivalent loop in the kubeconform step.

No behaviour change: the value is still expanded unquoted, so the space-separated paths keep word-splitting as before.

## Test plan

- [x] `yamllint .github/workflows/ci-gitops.yml` clean
- [x] YAML parses (`yaml.safe_load`)
- [x] `rg 'inputs\.fleet-paths'` shows all five occurrences are now `env:` assignments, none inside a `run:` block
- [x] Verified under `bash` that `find ${FLEET_PATHS} -name fleet.yaml` and the `Chart.yaml` loop resolve the same paths as the previous direct-interpolation form
- [ ] CI green