### PR TITLE
refactor(release-helm): replace GNU-only sed -i with a portable form

### DIFF
--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -88,46 +88,62 @@ jobs:
           version: ${{ inputs.helm-version }}
 
       - name: Update Chart version and appVersion
+        env:
+          # Inputs als Environment statt via `${{ }}` in den Script-Body: so
+          # parst bash die Werte als Daten, nicht als Shell-Quelltext.
+          CHART_PATH: ${{ inputs.chart-path }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          VERSION="${{ inputs.version }}"
-          VERSION="${VERSION#v}"  # Remove 'v' prefix if present
+          VERSION="${INPUT_VERSION#v}"  # Remove 'v' prefix if present
 
           # Temp-Datei plus `mv` statt `sed -i "…"`: die suffixlose `-i`-Form ist
           # GNU-only. BSD-sed (macOS) liest das Script als Backup-Suffix und
           # bricht mit "invalid command code" ab, ohne die Datei zu ändern.
-          CHART="${{ inputs.chart-path }}/Chart.yaml"
-          sed "s/^version:.*/version: $VERSION/" "$CHART" > "$CHART.tmp" && mv "$CHART.tmp" "$CHART"
-          sed "s/^appVersion:.*/appVersion: \"$VERSION\"/" "$CHART" > "$CHART.tmp" && mv "$CHART.tmp" "$CHART"
+          # Temp-Datei unter $RUNNER_TEMP, damit ein sed-Fehler keine `.tmp`
+          # im Chart-Verzeichnis liegen lässt, die `helm package` mitpackt.
+          CHART="$CHART_PATH/Chart.yaml"
+          TMP="$RUNNER_TEMP/Chart.yaml"
+          sed "s/^version:.*/version: $VERSION/" "$CHART" > "$TMP" && mv "$TMP" "$CHART"
+          sed "s/^appVersion:.*/appVersion: \"$VERSION\"/" "$CHART" > "$TMP" && mv "$TMP" "$CHART"
 
           echo "Updated Chart.yaml:"
-          grep -E "(version|appVersion):" ${{ inputs.chart-path }}/Chart.yaml
+          grep -E "(version|appVersion):" "$CHART"
 
       - name: Update values.yaml with image digest
         if: inputs.image-digest != ''
+        env:
+          CHART_PATH: ${{ inputs.chart-path }}
+          IMAGE_DIGEST: ${{ inputs.image-digest }}
         run: |
-          DIGEST="${{ inputs.image-digest }}"
-
           # Update values.yaml: clear tag and set digest
           # Temp-Datei plus `mv` statt `sed -i "…"` — GNU-only, siehe Kommentar
           # im Schritt "Update Chart version and appVersion".
-          VALUES="${{ inputs.chart-path }}/values.yaml"
-          sed 's/^  tag:.*/  tag: ""/' "$VALUES" > "$VALUES.tmp" && mv "$VALUES.tmp" "$VALUES"
-          sed "s|^  digest:.*|  digest: \"$DIGEST\"|" "$VALUES" > "$VALUES.tmp" && mv "$VALUES.tmp" "$VALUES"
+          VALUES="$CHART_PATH/values.yaml"
+          TMP="$RUNNER_TEMP/values.yaml"
+          sed 's/^  tag:.*/  tag: ""/' "$VALUES" > "$TMP" && mv "$TMP" "$VALUES"
+          sed "s|^  digest:.*|  digest: \"$IMAGE_DIGEST\"|" "$VALUES" > "$TMP" && mv "$TMP" "$VALUES"
 
           echo "Updated values.yaml:"
-          grep -A 3 "^image:" ${{ inputs.chart-path }}/values.yaml
+          grep -A 3 "^image:" "$VALUES"
 
       - name: Package and publish Helm chart
+        env:
+          CHART_PATH: ${{ inputs.chart-path }}
+          CHART_NAME: ${{ inputs.chart-name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          REGISTRY: ${{ inputs.registry }}
+          REGISTRY_PATH: ${{ inputs.registry-path }}
+          REGISTRY_TOKEN: ${{ secrets.registry-token }}
+          REGISTRY_USERNAME: ${{ secrets.registry-username || github.actor }}
         run: |
           # Package chart
-          helm package ${{ inputs.chart-path }} --destination .
+          helm package "$CHART_PATH" --destination .
 
           # Login to registry
-          echo "${{ secrets.registry-token }}" | helm registry login "${{ inputs.registry }}" --username "${{ secrets.registry-username || github.actor }}" --password-stdin
+          echo "$REGISTRY_TOKEN" | helm registry login "$REGISTRY" --username "$REGISTRY_USERNAME" --password-stdin
 
           # Push chart
-          VERSION="${{ inputs.version }}"
-          VERSION="${VERSION#v}"
-          helm push "${{ inputs.chart-name }}-$VERSION.tgz" "oci://${{ inputs.registry }}/${{ inputs.registry-path }}"
+          VERSION="${INPUT_VERSION#v}"
+          helm push "$CHART_NAME-$VERSION.tgz" "oci://$REGISTRY/$REGISTRY_PATH"
 
           echo "✅ Helm chart published successfully"

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -92,8 +92,12 @@ jobs:
           VERSION="${{ inputs.version }}"
           VERSION="${VERSION#v}"  # Remove 'v' prefix if present
 
-          sed -i "s/^version:.*/version: $VERSION/" ${{ inputs.chart-path }}/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"$VERSION\"/" ${{ inputs.chart-path }}/Chart.yaml
+          # Temp-Datei plus `mv` statt `sed -i "…"`: die suffixlose `-i`-Form ist
+          # GNU-only. BSD-sed (macOS) liest das Script als Backup-Suffix und
+          # bricht mit "invalid command code" ab, ohne die Datei zu ändern.
+          CHART="${{ inputs.chart-path }}/Chart.yaml"
+          sed "s/^version:.*/version: $VERSION/" "$CHART" > "$CHART.tmp" && mv "$CHART.tmp" "$CHART"
+          sed "s/^appVersion:.*/appVersion: \"$VERSION\"/" "$CHART" > "$CHART.tmp" && mv "$CHART.tmp" "$CHART"
 
           echo "Updated Chart.yaml:"
           grep -E "(version|appVersion):" ${{ inputs.chart-path }}/Chart.yaml
@@ -104,8 +108,11 @@ jobs:
           DIGEST="${{ inputs.image-digest }}"
 
           # Update values.yaml: clear tag and set digest
-          sed -i 's/^  tag:.*/  tag: ""/' ${{ inputs.chart-path }}/values.yaml
-          sed -i "s|^  digest:.*|  digest: \"$DIGEST\"|" ${{ inputs.chart-path }}/values.yaml
+          # Temp-Datei plus `mv` statt `sed -i "…"` — GNU-only, siehe Kommentar
+          # im Schritt "Update Chart version and appVersion".
+          VALUES="${{ inputs.chart-path }}/values.yaml"
+          sed 's/^  tag:.*/  tag: ""/' "$VALUES" > "$VALUES.tmp" && mv "$VALUES.tmp" "$VALUES"
+          sed "s|^  digest:.*|  digest: \"$DIGEST\"|" "$VALUES" > "$VALUES.tmp" && mv "$VALUES.tmp" "$VALUES"
 
           echo "Updated values.yaml:"
           grep -A 3 "^image:" ${{ inputs.chart-path }}/values.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,18 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   substitutions. No behaviour change on CI — the job pins
   `runs-on: ubuntu-latest` and the GNU form worked there; this removes the trap
   for anyone reproducing the steps locally on macOS or moving the job to a
-  macOS runner. The chart paths are now quoted, so a chart path containing
-  spaces no longer word-splits.
+  macOS runner. Temp files are written under `$RUNNER_TEMP`, so a failed `sed`
+  cannot leave a stray `.tmp` in the chart directory for `helm package` to
+  archive.
+- **`release-helm.yml` — `chart-path`, `version`, `image-digest` and the
+  registry inputs now reach the scripts via `env:`.** They were interpolated
+  into the `run:` body as `${{ … }}`, which splices the value into the shell
+  source before bash parses it — a chart path containing a quote or `$(…)`
+  was executable, and one containing a space word-split at the `grep` and
+  `helm package` call sites, failing the step under `bash -e`. Passing them as
+  environment variables makes every use a plain quoted `"$VAR"`, so a chart
+  path with spaces now works end to end and the expression-injection surface
+  on these steps is closed.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ## 2026-08-02
 
+### Changed
+
+- **`release-helm.yml` — GNU-only `sed -i` when patching Chart.yaml and
+  values.yaml.** Four in-place edits used the suffixless `sed -i "…"` form,
+  which is GNU-only: BSD sed (macOS) reads the script as the backup suffix and
+  aborts with `invalid command code`, leaving the file untouched. Replaced with
+  a portable temp-file-plus-`mv` form; `yq` was not introduced for four
+  substitutions. No behaviour change on CI — the job pins
+  `runs-on: ubuntu-latest` and the GNU form worked there; this removes the trap
+  for anyone reproducing the steps locally on macOS or moving the job to a
+  macOS runner. The chart paths are now quoted, so a chart path containing
+  spaces no longer word-splits.
+
 ### Fixed
 
 - **`ops-drift-issue.yml` — GNU-only sed idiom in the inline `render()`.** The


### PR DESCRIPTION
## Summary

- The four in-place edits to `Chart.yaml` and `values.yaml` used the suffixless `sed -i "…"` form, which is GNU-only. BSD sed reads the script as the backup suffix and aborts with `invalid command code`, leaving the file unpatched. Replaced with a portable temp-file-plus-`mv` form — `yq` was not introduced for four substitutions, and `sed -i ''` would only have flipped the breakage to GNU.
- `chart-path`, `version`, `image-digest` and the registry inputs now reach the scripts via `env:` instead of `${{ … }}` interpolation. This came out of review: quoting only the `sed` calls left the sibling `grep` and `helm package` sites taking the path bare, so a chart path with spaces still failed the step under `bash -e` *after* the substitutions had run. The `env:` form fixes that and closes the expression-injection surface on these steps (a path containing `$(…)` was previously spliced in as executable source).
- Temp files are written under `$RUNNER_TEMP`, so a failed `sed` cannot leave a stray `.tmp` in the chart directory for `helm package` to archive.
- No behaviour change on CI: the job pins `runs-on: ubuntu-latest`, where the GNU form worked.

## Test plan

- [x] Reproduced the old failure on BSD sed: `sed: 1: "Chart.yaml": invalid command code C`, exit 1, file untouched.
- [x] Ran both `run:` blocks as rendered, on BSD sed, against fixture charts — asserted `version`, `appVersion`, `tag` and `digest` all land correctly, `description: versioned demo` is left alone, and no `.tmp` survives in the chart directory.
- [x] Spaced chart path: reproduced the pre-fix failure (`grep: verify/my: No such file or directory`, step exit 2), then confirmed the `env:` form runs end to end at exit 0.
- [x] Injection check: the old interpolated form executed a `$(…)` payload in the path; the `env:` form treats it as literal data.
- [x] `just lint` (yamllint, jq, actionlint) and `just test` green.
- [ ] CI green.