### PR TITLE
refactor(justfile): bootstrap actionlint via container fallback

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>sbaerlocher/.github:renovate-base#main"]
+  "extends": ["github>sbaerlocher/.github:renovate-base#main"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track the actionlint container tag used by the justfile lint recipe",
+      "managerFilePatterns": ["/(^|/)justfile$/"],
+      "matchStrings": [
+        "actionlint_image\\s*:=\\s*\"(?<depName>[^:\"]+):(?<currentValue>[^\"@]+)\""
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,37 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   environment variables makes every use a plain quoted `"$VAR"`, so a chart
   path with spaces now works end to end and the expression-injection surface
   on these steps is closed.
+- **`just lint` no longer needs a hand-installed actionlint.** The actionlint
+  call moved into its own `just actionlint` recipe that picks a path by
+  coverage: the local binary when `actionlint` and `shellcheck` are both on
+  `PATH`, otherwise the `rhysd/actionlint` container (which ships shellcheck),
+  and a local-only run with a warning when neither shellcheck nor Docker is
+  available. With no actionlint and no Docker it fails naming both options
+  instead of `command not found`. Renovate tracks the image tag through a
+  custom manager in this repo's own `.github/renovate.json`; the shared
+  `renovate-base.json` preset that consumers extend is untouched. Local-only
+  change — no reusable workflow or action is affected.
+
+  Two shellcheck codes joined the muted list as a result: `SC2002`
+  (`ci-js.yml:350`) and `SC2015` (`deploy-cloudflare-workers.yml:86`). Both are
+  pre-existing and were simply invisible before — actionlint skips its embedded
+  shell checks _silently_ when shellcheck is missing, which every local run
+  without the container did. The container image carries shellcheck, so they
+  surface now. Muted by code rather than by switching the pass off, matching
+  the existing three; fixing them means touching reusables the whole fleet
+  consumes and belongs in its own change. Note that `-ignore` is a regex over
+  the message text, so both mutes are repo-wide and forward-looking rather than
+  pinned to the cited lines.
+
+- **`ci-gitops.yml` — `fleet-paths` is passed through `env:` in every step.**
+  The two fleet-validation steps and the Helm-lint step interpolated
+  `${{ inputs.fleet-paths }}` directly into their `run:` blocks, which CodeQL
+  flags as potential code injection; the two kubeconform steps already used
+  `env: FLEET_PATHS`. All five uses now go through `env:`, so the file is
+  consistent and the recurring Code Scanning alerts at those sites disappear.
+  Not breaking: the value is still expanded unquoted, so the space-separated
+  paths keep the same word-splitting behaviour. The chart loop also moved to
+  `read -r`, matching the equivalent loop in the kubeconform step.
 
 ### Fixed
 
@@ -57,18 +88,6 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   only of spaces or tabs is now trimmed too, where sed left it in place. Not
   breaking for CI — runners are Linux and the sed form worked there; the fix
   matters for anyone reproducing the block locally on macOS.
-
-### Changed
-
-- **`ci-gitops.yml` — `fleet-paths` is passed through `env:` in every step.**
-  The two fleet-validation steps and the Helm-lint step interpolated
-  `${{ inputs.fleet-paths }}` directly into their `run:` blocks, which CodeQL
-  flags as potential code injection; the two kubeconform steps already used
-  `env: FLEET_PATHS`. All five uses now go through `env:`, so the file is
-  consistent and the recurring Code Scanning alerts at those sites disappear.
-  Not breaking: the value is still expanded unquoted, so the space-separated
-  paths keep the same word-splitting behaviour. The chart loop also moved to
-  `read -r`, matching the equivalent loop in the kubeconform step.
 
 ## 2026-08-01
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,19 +45,32 @@ entrypoint is [`just`](https://just.systems), the org-wide command runner —
 run it without arguments to list the recipes:
 
 ```bash
-just lint   # yamllint, Renovate JSON validity, actionlint
-just test   # script self-checks under scripts/tests/
-just fmt    # prettier over Markdown and JSON
+just lint         # yamllint, Renovate JSON validity, actionlint
+just actionlint   # actionlint alone (local binary or container)
+just test         # script self-checks under scripts/tests/
+just fmt          # prettier over Markdown and JSON
 ```
 
 Run `just lint` and `just test` before opening a PR. `fmt` reflows Markdown
 tables repo-wide, so keep its output out of otherwise unrelated changes.
 
-Recipes call `yamllint`, `jq`, `actionlint`, `shellcheck`, and `prettier`
-directly — install those separately, `just` does not vendor them. Without
-`shellcheck` on `PATH`, actionlint skips its embedded shell checks silently
-rather than failing, so `just lint` would pass with less coverage than it
-reports.
+Recipes call `yamllint`, `jq`, and `prettier` directly — install those
+separately, `just` does not vendor them.
+
+`actionlint` is the exception — it needs no manual install. `just actionlint`
+picks a path by coverage rather than by preference:
+
+1. local `actionlint` **and** `shellcheck` on `PATH` — runs locally, fastest
+2. otherwise Docker — runs `rhysd/actionlint`, which ships shellcheck
+3. local `actionlint` without either shellcheck or Docker — runs locally and
+   warns that the shell checks are being skipped
+4. neither `actionlint` nor Docker — fails, naming both options
+
+The container outranks a bare local binary because actionlint needs shellcheck
+for its embedded shell checks and skips them _silently_ without it, so that
+combination would pass with less coverage than it reports. Nothing to opt into:
+install `shellcheck` next to `actionlint` for the fast path, or have Docker
+available and let the recipe pick it.
 
 If `lefthook` is installed, enable local hooks with:
 

--- a/README.md
+++ b/README.md
@@ -270,12 +270,13 @@ its default `false` and rely on artifact uploads instead.
 Local tasks run through [`just`](https://just.systems), the org-wide command
 runner. Run it without arguments to list the recipes:
 
-| Recipe      | What it does                                 |
-| ----------- | -------------------------------------------- |
-| `just`      | List all recipes                             |
-| `just lint` | yamllint, Renovate JSON validity, actionlint |
-| `just test` | Script self-checks under `scripts/tests/`    |
-| `just fmt`  | prettier over Markdown and JSON              |
+| Recipe            | What it does                                               |
+| ----------------- | ---------------------------------------------------------- |
+| `just`            | List all recipes                                           |
+| `just lint`       | yamllint, Renovate JSON validity, actionlint               |
+| `just actionlint` | actionlint alone — local binary or container, by coverage |
+| `just test`       | Script self-checks under `scripts/tests/`                  |
+| `just fmt`        | prettier over Markdown and JSON                            |
 
 There is no `build` or `dev` recipe — this repository ships no build artifact
 and has no dev loop. `templates/justfile` is the reference template consumer

--- a/justfile
+++ b/justfile
@@ -20,14 +20,59 @@ default:
 #   SC2086  37x, deliberately unquoted GitHub expressions in `run:` blocks
 #   SC2044  ci-gitops.yml:191, for-over-find on a config-supplied path
 #   SC2016  ops-drift-issue.yml:134, single quotes around a markdown fence
-# The latter two deserve a fix of their own; touching reusables the whole
+#   SC2002  ci-js.yml:350, useless cat in a pipeline
+#   SC2015  deploy-cloudflare-workers.yml:86, A && B || C read as if-then-else
+# All but SC2086 deserve a fix of their own; touching reusables the whole
 # fleet consumes does not belong in a task-runner change.
+#
+# The last two only appear once shellcheck is actually present — they were
+# invisible while every local run silently skipped the shell checks, which is
+# the gap the container fallback below closes.
+#
+# Note that `-ignore` takes a regex matched against the message text, so every
+# entry is repo-wide and forward-looking, not pinned to the file:line cited
+# above. SC2015 (`A && B || C` is not if-then-else) is a real logic-bug class
+# and is muted here only until the follow-up fix lands. Per-path scoping via
+# `.github/actionlint.yaml` `paths:` is the tool's answer if these outlive it.
+actionlint_ignores := "-ignore 'SC2086' -ignore 'SC2044' -ignore 'SC2016' -ignore 'SC2002' -ignore 'SC2015'"
+
+# actionlint container image, used when the local binary and shellcheck are not
+# both present. Renovate keeps the tag current via a custom manager in this
+# repo's own .github/renovate.json — the shared renovate-base.json preset that
+# consumers extend is deliberately left alone, so this adds no update behaviour
+# anywhere else. Keep the assignment on one line; the manager regex expects it.
+actionlint_image := "rhysd/actionlint:1.7.7"
 
 # lint → static checks over YAML, Renovate presets and workflow definitions
 lint:
     yamllint .
     jq empty renovate.json .github/renovate.json renovate-*.json
-    actionlint -ignore 'SC2086' -ignore 'SC2044' -ignore 'SC2016'
+    just actionlint
+
+# Coverage decides the order, not locality: actionlint needs shellcheck for its
+# embedded shell checks and skips them *silently* without it, so a local binary
+# on a shellcheck-less machine is the weakest of the three paths. The container
+# image ships shellcheck, so it outranks a bare local binary and is only skipped
+# when the local pair is complete.
+
+# actionlint → workflow linting, local binary + shellcheck first, else container
+actionlint:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if command -v actionlint >/dev/null 2>&1 && command -v shellcheck >/dev/null 2>&1; then
+        actionlint {{ actionlint_ignores }}
+    elif command -v docker >/dev/null 2>&1; then
+        command -v actionlint >/dev/null 2>&1 \
+            && echo 'note: shellcheck not on PATH; using the container for full coverage' >&2
+        docker run --rm -v "$PWD:/repo" --workdir /repo {{ actionlint_image }} \
+            {{ actionlint_ignores }}
+    elif command -v actionlint >/dev/null 2>&1; then
+        echo 'warning: shellcheck and docker both missing; actionlint skips its shell checks' >&2
+        actionlint {{ actionlint_ignores }}
+    else
+        echo 'actionlint: needs either actionlint on PATH or docker. See CONTRIBUTING.md.' >&2
+        exit 1
+    fi
 
 # test → run the script self-checks
 test:


### PR DESCRIPTION
## Summary

- `just lint` called `actionlint` without the repo providing it, so the recipe aborted with `command not found` on any machine that had not installed the binary by hand. The call moved into its own `just actionlint` recipe with a container fallback, so it runs on a machine that has only Docker.
- The path is chosen by **coverage, not locality**: actionlint needs `shellcheck` for its embedded shell checks and skips them *silently* without it, so a bare local binary is the weakest option. Order is local-binary-plus-shellcheck → container (ships shellcheck) → local-with-warning → error naming both options.
- Two pre-existing shellcheck findings surface as a result and join the muted list by code, matching the existing three: `SC2002` (`ci-js.yml:350`) and `SC2015` (`deploy-cloudflare-workers.yml:86`). Fixing them means touching reusables the whole fleet consumes and belongs in its own change.
- Renovate tracks the image tag via a custom manager in this repo's own `.github/renovate.json`. The shared `renovate-base.json` that consumers extend is untouched, so this adds no update behaviour anywhere else.

Local-only change — no reusable workflow or composite action is affected.

## Test plan

Each branch exercised by manipulating `PATH` so the named tools are genuinely absent:

- [x] `actionlint` + `shellcheck` present → runs locally, exit 0
- [x] `actionlint` present, `shellcheck` absent, Docker present → uses the **container**, note on stderr, exit 0
- [x] `actionlint` present, neither `shellcheck` nor Docker → runs locally, warns, exit 0
- [x] No `actionlint`, Docker present → container, exit 0
- [x] Neither `actionlint` nor Docker → exit 1, message naming both options
- [x] Failure propagates through the nested call: a deliberately invalid workflow makes `just lint` exit 1; removing it returns it to 0
- [x] `just lint` and `just test` exit 0
- [x] Custom-manager regex verified against the `actionlint_image` line — extracts `rhysd/actionlint` / `1.7.7`