### PR TITLE
test(drift-issue): enforce parity between workflow copy and script

### DIFF
--- a/.github/workflows/ops-drift-issue.yml
+++ b/.github/workflows/ops-drift-issue.yml
@@ -92,7 +92,10 @@ jobs:
       # Inline-jq in `deploy-terraform.yml`: die render/addresses-Logik ist ein
       # Duplikat von scripts/drift-issue-body.sh, das per
       # scripts/tests/test-drift-issue-body.sh getestete Referenz bleibt.
-      # Ändert sich die eine, muss die andere folgen (Gleichheit von Hand).
+      # Ändert sich die eine, muss die andere folgen — die Gleichheit prüft
+      # scripts/tests/test-drift-issue-parity.sh, das den Funktions-Block hier
+      # aus dem YAML zieht und gegen das Skript laufen lässt. Nicht mehr von
+      # Hand: genau diese Kopie war zweimal auseinandergelaufen.
       - name: Upsert drift issue
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,6 +14,28 @@ permissions:
   actions: read
 
 jobs:
+  # `just lint` and `just test` hung on no trigger at all, so the script
+  # self-checks never ran in CI. actionlint comes from the container fallback
+  # in the justfile (the runner has Docker), which also brings shellcheck —
+  # a bare binary would skip the embedded shell checks silently.
+  checks:
+    name: Lint and Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install just and yamllint
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y just
+          pip install yamllint
+
+      - name: Lint
+        run: just lint
+
+      - name: Test
+        run: just test
+
   claude-review:
     name: Claude Code Review
     uses: ./.github/workflows/ai-claude-review.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,28 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ## 2026-08-02
 
+### Added
+
+- **Parity self-check for the inline body logic in `ops-drift-issue.yml`.**
+  The workflow keeps its own copy of `strip_block`/`render`/`addresses` from
+  `scripts/drift-issue-body.sh` — deliberately, since a reusable workflow has
+  no context exposing its own call ref and a checkout would have to fall back
+  to a mutable `@main`. The contract was "Gleichheit von Hand" and it drifted
+  twice unnoticed: the script moved to portable `awk` while the inline copy
+  kept the GNU-only `sed` idiom. `scripts/tests/test-drift-issue-parity.sh`
+  now extracts the function block from the workflow YAML (parsed, so there is
+  no hardcoded line range to go stale), sources it, and compares its output
+  against the script over the same inputs. Behaviour-based rather than
+  textual, so indentation and comment churn do not produce false failures.
+
 ### Changed
 
+- **`pull-request.yml` now runs `just lint` and `just test`.** Both hung on no
+  trigger at all — the workflow started only `ai-claude-review.yml` and
+  `security-code.yml`, so the script self-checks never ran in CI and even an
+  existing test could not have failed the build. actionlint comes from the
+  justfile's container fallback, which also brings shellcheck; a bare local
+  binary would skip the embedded shell checks silently.
 - **`release-helm.yml` — GNU-only `sed -i` when patching Chart.yaml and
   values.yaml.** Four in-place edits used the suffixless `sed -i "…"` form,
   which is GNU-only: BSD sed (macOS) reads the script as the backup suffix and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,10 @@ just test         # script self-checks under scripts/tests/
 just fmt          # prettier over Markdown and JSON
 ```
 
-Run `just lint` and `just test` before opening a PR. `fmt` reflows Markdown
-tables repo-wide, so keep its output out of otherwise unrelated changes.
+Run `just lint` and `just test` before opening a PR — the `Lint and Test` job
+in `pull-request.yml` runs both again, so a local failure is a CI failure.
+`fmt` reflows Markdown tables repo-wide, so keep its output out of otherwise
+unrelated changes.
 
 Recipes call `yamllint`, `jq`, and `prettier` directly — install those
 separately, `just` does not vendor them.

--- a/justfile
+++ b/justfile
@@ -82,6 +82,7 @@ actionlint:
 test:
     scripts/tests/test-drift-summary.sh
     scripts/tests/test-drift-issue-body.sh
+    scripts/tests/test-drift-issue-parity.sh
 
 # fmt → format Markdown and JSON in place
 fmt:

--- a/scripts/tests/test-drift-issue-parity.sh
+++ b/scripts/tests/test-drift-issue-parity.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Parity check: the inline render/addresses copy in ops-drift-issue.yml must
+# behave exactly like scripts/drift-issue-body.sh.
+#
+# The workflow keeps its own copy on purpose (a reusable workflow cannot check
+# out its own ref — see the comment above the `Upsert drift issue` step), and
+# the contract there says "Gleichheit von Hand". That hand-sync drifted twice
+# and both times was caught by eye. This closes it.
+#
+# Behaviour-based, not textual: the workflow's `run:` block is extracted from
+# the YAML (not by a hardcoded line range, which goes stale on the next edit),
+# its function definitions are sourced, and the same inputs go through both
+# implementations. Comparing outputs catches semantic drift while ignoring
+# indentation and comment churn.
+#
+# Run: scripts/tests/test-drift-issue-parity.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+SCRIPT="$REPO/scripts/drift-issue-body.sh"
+WORKFLOW="$REPO/.github/workflows/ops-drift-issue.yml"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+command -v python3 >/dev/null 2>&1 || fail "python3 required to parse the workflow YAML"
+
+# Pull the `run:` body of the Upsert step out of the workflow. PyYAML resolves
+# the block scalar, so the result is already de-indented shell.
+RUN_BLOCK="$(
+  python3 - "$WORKFLOW" <<'PY'
+import sys, yaml
+
+with open(sys.argv[1]) as fh:
+    doc = yaml.safe_load(fh)
+
+for job in doc.get("jobs", {}).values():
+    for step in job.get("steps", []):
+        if step.get("name") == "Upsert drift issue":
+            sys.stdout.write(step["run"])
+            sys.exit(0)
+
+sys.exit("step 'Upsert drift issue' not found in workflow")
+PY
+)" || fail "could not extract the workflow run block"
+
+# Keep only the leading definition part: everything up to the first line that
+# is neither a function definition nor inside one. The step continues with `gh`
+# calls that need a token and a live repo; sourcing those would be a network
+# call, not a unit test.
+DEFS="$(
+  printf '%s\n' "$RUN_BLOCK" | awk '
+    /^TITLE=/ { exit }
+    { print }
+  '
+)"
+
+printf '%s\n' "$DEFS" | grep -q '^strip_block()' || fail "strip_block missing from extracted workflow block"
+printf '%s\n' "$DEFS" | grep -q '^render()' || fail "render missing from extracted workflow block"
+printf '%s\n' "$DEFS" | grep -q '^addresses()' || fail "addresses missing from extracted workflow block"
+
+# Source the workflow copy into this shell. `set -euo pipefail` inside the
+# block is harmless — the test already runs under it.
+# shellcheck disable=SC1091  # sourcing generated content by design
+source /dev/stdin <<<"$DEFS"
+
+BASE="## Terraform Drift Detected
+
+Some intro text.
+
+**Triggered:** 2026-07-20 07:14 UTC"
+
+SUMMARY="update authentik_group.admins
+create authentik_application.grafana"
+
+# Cases mirror the behaviour classes test-drift-issue-body.sh pins on the
+# script: plain render, idempotent re-render, empty summary, trailing
+# whitespace, spaced for_each keys, and address extraction with/without block.
+run_case() { # run_case <name> <base> <summary>
+  local name="$1" base="$2" summary="$3"
+  local script_body workflow_body script_addrs workflow_addrs
+
+  script_body="$("$SCRIPT" render "$base" "$summary")"
+  workflow_body="$(render "$base" "$summary")"
+  [ "$script_body" = "$workflow_body" ] || fail "render drifted for case '$name':
+script:
+$script_body
+workflow:
+$workflow_body"
+
+  script_addrs="$("$SCRIPT" addresses "$script_body")"
+  workflow_addrs="$(addresses "$workflow_body")"
+  [ "$script_addrs" = "$workflow_addrs" ] || fail "addresses drifted for case '$name':
+script:
+$script_addrs
+workflow:
+$workflow_addrs"
+}
+
+# 1 — plain render over a clean base body.
+run_case "plain" "$BASE" "$SUMMARY"
+
+# 2 — re-render over a body that already carries the block (idempotency path
+# through strip_block).
+BODY_WITH_BLOCK="$("$SCRIPT" render "$BASE" "$SUMMARY")"
+run_case "re-render" "$BODY_WITH_BLOCK" "$SUMMARY"
+
+# 3 — empty summary takes the early-return branch, no block appended.
+run_case "empty summary" "$BASE" ""
+
+# 4 — trailing whitespace-only lines exercise the awk trailing-blank trim, the
+# exact spot where the GNU-sed idiom lived when the two copies last diverged.
+run_case "trailing whitespace" "$BASE
+
+   " "$SUMMARY"
+
+# 5 — for_each keys with spaces must survive the address split in both copies.
+run_case "spaced addresses" "$BASE" 'update authentik_group.admins["my key"]
+update authentik_group.admins["other key"]'
+
+# 6 — addresses over a body without a block is empty in both copies.
+SCRIPT_EMPTY="$("$SCRIPT" addresses "$BASE")"
+WORKFLOW_EMPTY="$(addresses "$BASE")"
+[ "$SCRIPT_EMPTY" = "$WORKFLOW_EMPTY" ] || fail "addresses on block-less body drifted:
+script: '$SCRIPT_EMPTY'
+workflow: '$WORKFLOW_EMPTY'"
+[ -z "$WORKFLOW_EMPTY" ] || fail "addresses on block-less body must be empty"
+
+echo "PASS: ops-drift-issue.yml <-> drift-issue-body.sh parity"


### PR DESCRIPTION
## Summary

- `ops-drift-issue.yml` keeps an inline copy of `strip_block`/`render`/`addresses` from `scripts/drift-issue-body.sh` (a reusable workflow cannot check out its own ref). The contract was "Gleichheit von Hand" and drifted twice, both times caught by eye — PR #260 moved the script to portable `awk` while the inline copy kept the GNU-only `sed` idiom.
- New `scripts/tests/test-drift-issue-parity.sh` extracts the function block from the workflow YAML (parsed, not a hardcoded line range that goes stale), sources it, and compares output against the script over the same inputs. Behaviour-based, so indentation and comment churn do not trip it.
- Wires `just lint` and `just test` into `pull-request.yml`, which previously ran only claude-review and code-scan — without this, even an existing test would never fail CI.
- Updates the now-stale "Gleichheit von Hand" comment and the CONTRIBUTING note, since both are enforced from here on.

## Test plan

- [x] `just test` green — all three self-checks pass
- [x] `just lint` green (yamllint, `jq`, actionlint via container, which also brings shellcheck)
- [x] Negative check: reverting the inline copy's trailing-blank trim to the GNU-only `sed` idiom fails the new test on the `trailing whitespace` case — the exact drift class from #260/#264
- [x] Negative check: changing only the inline heading text fails on the `plain` case
- [ ] CI green