### PR TITLE
refactor(ci-gitops): pass yamllint settings through env

### DIFF
--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -137,18 +137,21 @@ jobs:
         run: pip install yamllint
 
       - name: Validate YAML files
+        env:
+          STRICT: ${{ inputs.yaml-lint-strict }}
+          YAMLLINT_CONFIG_ARG: ${{ hashFiles('.yamllint.yml') != '' && '-c .yamllint.yml' || '' }}
         run: |
           set -euo pipefail
           if [ ! -f .yamllint.yml ]; then
             echo "::warning::.yamllint.yml not found - using default config"
           fi
           # -print0 / xargs -0 to survive paths with spaces
-          if [ "${{ inputs.yaml-lint-strict }}" = "true" ]; then
+          if [ "$STRICT" = "true" ]; then
             find . \( -name '*.yaml' -o -name '*.yml' \) -print0 \
-              | xargs -0 yamllint ${{ hashFiles('.yamllint.yml') != '' && '-c .yamllint.yml' || '' }} -f parsable
+              | xargs -0 yamllint ${YAMLLINT_CONFIG_ARG} -f parsable
           else
             find . \( -name '*.yaml' -o -name '*.yml' \) -print0 \
-              | xargs -0 yamllint ${{ hashFiles('.yamllint.yml') != '' && '-c .yamllint.yml' || '' }} -f parsable || true
+              | xargs -0 yamllint ${YAMLLINT_CONFIG_ARG} -f parsable || true
           fi
 
   validate-fleet-configs:

--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -139,6 +139,8 @@ jobs:
       - name: Validate YAML files
         env:
           STRICT: ${{ inputs.yaml-lint-strict }}
+          # Unquoted at the call sites below so `-c <file>` splits into two
+          # argv words; keep it that way. Value is a build-time constant.
           YAMLLINT_CONFIG_ARG: ${{ hashFiles('.yamllint.yml') != '' && '-c .yamllint.yml' || '' }}
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ### Changed
 
+- **`ci-gitops.yml` — `yaml-lint-strict` and the yamllint config argument now
+  reach the shell via `env:`.** The *Validate YAML files* step interpolated
+  `${{ inputs.yaml-lint-strict }}` and the `hashFiles('.yamllint.yml')`
+  expression directly into its `run:` block, which produces recurring CodeQL
+  "potential code injection" findings and diverged from the `env:` pattern the
+  fleet and k8s validation steps in the same file already use. Both values now
+  travel as `STRICT` and `YAMLLINT_CONFIG_ARG`. No consumer impact: the input
+  contract is untouched and both the strict and non-strict branches invoke
+  yamllint exactly as before.
 - **Pull requests now run `just lint` and `just test` in CI.** A new
   `local-checks` job in `pull-request.yml` calls the same recipes
   `CONTRIBUTING.md` tells contributors to run, so there is one lint definition


### PR DESCRIPTION
## Summary

- The `Validate YAML files` step interpolated `inputs.yaml-lint-strict` and the `hashFiles('.yamllint.yml')` expression directly into its shell, which produces recurring CodeQL "potential code injection" findings.
- Both values now travel through `env:` (`STRICT`, `YAMLLINT_CONFIG_ARG`) and are read as shell variables, matching the pattern the fleet and k8s validation steps in this workflow already use.
- Behaviour is unchanged: same strict/non-strict branches, same yamllint invocation.

## Test plan

- [x] `just lint` (yamllint, jq over the Renovate presets, actionlint) passes
- [x] `just test` passes
- [ ] CI green on this PR