### PR TITLE
refactor(release-helm): reject sed metacharacters in version and digest

### DIFF
--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -97,14 +97,21 @@ jobs:
           VERSION="${INPUT_VERSION#v}"  # Remove 'v' prefix if present
 
           # Guard vor den `sed`-Aufrufen unten: `$VERSION` landet im
-          # s-Ausdruck selbst. Ein `/` beendet ihn vorzeitig, `&` und `\`
-          # sind in der Replacement-Hälfte Metazeichen. Git-Tag-Namen dürfen
-          # Slashes tragen und das `v*`-Filter der Caller schliesst sie nicht
-          # aus. Erster Step im Job, deshalb deckt der Guard auch das zweite,
-          # unabhängige `VERSION="${INPUT_VERSION#v}"` im Package-Step ab.
+          # s-Ausdruck selbst. `/` beendet ihn vorzeitig, `&` und `\` sind in
+          # der Replacement-Hälfte Metazeichen, ein Newline bricht das Script
+          # mit "unterminated s command" ab. Allowlist statt Denylist, damit
+          # die Klasse geschlossen ist. Git-Tag-Namen dürfen Slashes tragen
+          # und das `v*`-Filter der Caller schliesst sie nicht aus.
+          # Dieser Step läuft ohne `if:` und vor dem Package-Step, ein
+          # `exit 1` bricht also den Job ab, bevor das zweite, unabhängige
+          # `VERSION="${INPUT_VERSION#v}"` dort ausgewertet wird.
+          # Der abgelehnte Wert geht per `printf %q` ins Log, nicht in die
+          # `::error::`-Annotation: ein Newline darin würde sonst als neues
+          # Workflow-Kommando geparst.
           case "$VERSION" in
-            *[/\\\&\|]*)
-              echo "::error::version must not contain / \\ & or | (got: $VERSION)"
+            *[!A-Za-z0-9._+-]*)
+              echo "::error::version must match [A-Za-z0-9._+-]+ — rejected, see log"
+              printf 'rejected version: %q\n' "$VERSION"
               exit 1
               ;;
           esac
@@ -130,10 +137,12 @@ jobs:
         run: |
           # Gleicher Guard wie beim Version-Step, hier für den `|`-Delimiter:
           # `docker/build-push-action` liefert immer `sha256:<hex>`, ein
-          # fremder Caller kann den Input aber frei setzen.
+          # fremder Caller kann den Input aber frei setzen. Der leere Fall
+          # ist durch `if: inputs.image-digest != ''` schon ausgeschlossen.
           case "$IMAGE_DIGEST" in
-            *[/\\\&\|]*)
-              echo "::error::image-digest must not contain / \\ & or | (got: $IMAGE_DIGEST)"
+            *[!A-Za-z0-9:]*)
+              echo "::error::image-digest must match [A-Za-z0-9:]+ — rejected, see log"
+              printf 'rejected image-digest: %q\n' "$IMAGE_DIGEST"
               exit 1
               ;;
           esac

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -96,6 +96,19 @@ jobs:
         run: |
           VERSION="${INPUT_VERSION#v}"  # Remove 'v' prefix if present
 
+          # Guard vor den `sed`-Aufrufen unten: `$VERSION` landet im
+          # s-Ausdruck selbst. Ein `/` beendet ihn vorzeitig, `&` und `\`
+          # sind in der Replacement-Hälfte Metazeichen. Git-Tag-Namen dürfen
+          # Slashes tragen und das `v*`-Filter der Caller schliesst sie nicht
+          # aus. Erster Step im Job, deshalb deckt der Guard auch das zweite,
+          # unabhängige `VERSION="${INPUT_VERSION#v}"` im Package-Step ab.
+          case "$VERSION" in
+            *[/\\\&\|]*)
+              echo "::error::version must not contain / \\ & or | (got: $VERSION)"
+              exit 1
+              ;;
+          esac
+
           # Temp-Datei plus `mv` statt `sed -i "…"`: die suffixlose `-i`-Form ist
           # GNU-only. BSD-sed (macOS) liest das Script als Backup-Suffix und
           # bricht mit "invalid command code" ab, ohne die Datei zu ändern.
@@ -115,6 +128,16 @@ jobs:
           CHART_PATH: ${{ inputs.chart-path }}
           IMAGE_DIGEST: ${{ inputs.image-digest }}
         run: |
+          # Gleicher Guard wie beim Version-Step, hier für den `|`-Delimiter:
+          # `docker/build-push-action` liefert immer `sha256:<hex>`, ein
+          # fremder Caller kann den Input aber frei setzen.
+          case "$IMAGE_DIGEST" in
+            *[/\\\&\|]*)
+              echo "::error::image-digest must not contain / \\ & or | (got: $IMAGE_DIGEST)"
+              exit 1
+              ;;
+          esac
+
           # Update values.yaml: clear tag and set digest
           # Temp-Datei plus `mv` statt `sed -i "…"` — GNU-only, siehe Kommentar
           # im Schritt "Update Chart version and appVersion".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,21 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   its embedded shell checks active. No consumer impact — `pull-request.yml` has
   no `workflow_call` trigger, so no repository consumes it and no date tag
   carries the change.
+- **`release-helm.yml` — `version` and `image-digest` are validated before
+  they reach `sed`.** Both values are interpolated into the substitute
+  expression itself, so a `/` (the Chart.yaml call sites), a `|` (the digest
+  call site), a `&` or `\` in the replacement half, or a newline ends the
+  expression early and `sed` aborts with `bad flag in substitute command` or
+  `unterminated s command`. Each of the two steps now rejects its input against
+  an allowlist — `[A-Za-z0-9._+-]` for `version`, `[A-Za-z0-9:]` for
+  `image-digest` — which closes the character class instead of enumerating
+  metacharacters. The rejected value goes to the log via `printf %q` rather
+  than into the `::error::` annotation, so a newline in it cannot be parsed as
+  a further workflow command. No behaviour change for valid inputs: semver tags
+  (including `-rc.1` and `+build.5`) and `sha256:<hex>` digests pass unchanged.
+  Reachable because Git tag names may contain slashes and the callers' `v*` tag
+  filter does not exclude them; as a `workflow_call` reusable, a caller can
+  feed either input from any source.
 - **`release-helm.yml` — GNU-only `sed -i` when patching Chart.yaml and
   values.yaml.** Four in-place edits used the suffixless `sed -i "…"` form,
   which is GNU-only: BSD sed (macOS) reads the script as the backup suffix and


### PR DESCRIPTION
## Summary

- `$VERSION` and `$IMAGE_DIGEST` are interpolated into the `sed` substitute expression itself (three call sites). A `/`, `|`, `&`, backslash or newline in the value ends the expression early and `sed` aborts with `bad flag in substitute command` or `unterminated s command`.
- Adds an allowlist guard to each of the two steps — `[A-Za-z0-9._+-]` for `version`, `[A-Za-z0-9:]` for `image-digest` — which closes the character class instead of enumerating metacharacters. The rejected value goes to the log via `printf %q`, not into the `::error::` annotation, so a newline in it cannot be parsed as a further workflow command.
- Reachable because Git tag names may contain slashes and the callers' `v*` tag filter does not exclude them; as a `workflow_call` reusable, a caller can feed either input from any source.
- No behaviour change for valid inputs — semver tags (including `-rc.1`, `+build.5`) and `sha256:<hex>` digests pass unchanged. Non-breaking, `CHANGELOG.md` updated under the existing `## 2026-08-02` / `### Changed` section.

## Test plan

- [x] `just lint` (yamllint, jq, actionlint with shellcheck) green — no new findings from the `case` blocks
- [x] `just test` green
- [x] Guard patterns verified in `bash` and `sh`: reject `1.0/x`, `1.0\x`, `1.0&x`, `1.0|x`, `1.0 x` and a literal newline; accept `1.0.0`, `1.2.3-rc.1`, `1.0.0+build.5`, `sha256:<hex>`
- [x] Newline case reproduced against `sed` before and after the change
