### PR TITLE
fix(workflows): replace bash-4-only mapfile with a portable read loop

### DIFF
--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -452,6 +452,10 @@ jobs:
           # the moment it runs outside ubuntu-latest. The explicit `manifests=()`
           # also keeps `${#manifests[@]}` defined under `set -u` when the find
           # produces no output.
+          # Newline-delimited rather than the `-print0` form used for fleet.yaml
+          # above: the path segment filter is a `grep -E`, which would need
+          # `grep -zE` to stay NUL-clean. Manifest paths come from the repo tree,
+          # so only a newline in a filename would break this — spaces are safe.
           manifests=()
           while IFS= read -r manifest; do
             manifests+=("$manifest")

--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -447,7 +447,15 @@ jobs:
           set -euo pipefail
           echo "Validating Kubernetes manifests with kubeconform..."
 
-          mapfile -t manifests < <(
+          # Read loop instead of `mapfile -t`: mapfile is a bash-4 builtin and
+          # macOS still ships bash 3.2 as /bin/bash, so the block would break
+          # the moment it runs outside ubuntu-latest. The explicit `manifests=()`
+          # also keeps `${#manifests[@]}` defined under `set -u` when the find
+          # produces no output.
+          manifests=()
+          while IFS= read -r manifest; do
+            manifests+=("$manifest")
+          done < <(
             find ${FLEET_PATHS} \( -name '*.yaml' -o -name '*.yml' \) \
               ! -name 'fleet.yaml' \
               | grep -E '/(templates|manifests)/' \

--- a/.github/workflows/security-config.yml
+++ b/.github/workflows/security-config.yml
@@ -251,7 +251,13 @@ jobs:
           # Match the same scope the gating step established (find-manifests above):
           # only files under */templates/*. This avoids feeding kubesec non-manifest
           # YAML like Chart.yaml, values.yaml, kustomization.yaml or CI configs.
-          mapfile -t manifests < <(
+          # Read loop instead of `mapfile -t`: mapfile is a bash-4 builtin and
+          # macOS still ships bash 3.2 as /bin/bash, so the block would break
+          # the moment it runs outside ubuntu-latest.
+          manifests=()
+          while IFS= read -r manifest; do
+            manifests+=("$manifest")
+          done < <(
             find . -type f \( -name '*.yaml' -o -name '*.yml' \) -path '*/templates/*'
           )
           if [ ${#manifests[@]} -eq 0 ]; then

--- a/.github/workflows/security-config.yml
+++ b/.github/workflows/security-config.yml
@@ -253,12 +253,13 @@ jobs:
           # YAML like Chart.yaml, values.yaml, kustomization.yaml or CI configs.
           # Read loop instead of `mapfile -t`: mapfile is a bash-4 builtin and
           # macOS still ships bash 3.2 as /bin/bash, so the block would break
-          # the moment it runs outside ubuntu-latest.
+          # the moment it runs outside ubuntu-latest. NUL-delimited like the
+          # fleet.yaml loop in ci-gitops.yml, so no filename can split a path.
           manifests=()
-          while IFS= read -r manifest; do
+          while IFS= read -r -d '' manifest; do
             manifests+=("$manifest")
           done < <(
-            find . -type f \( -name '*.yaml' -o -name '*.yml' \) -path '*/templates/*'
+            find . -type f \( -name '*.yaml' -o -name '*.yml' \) -path '*/templates/*' -print0
           )
           if [ ${#manifests[@]} -eq 0 ]; then
             echo "::notice::No Kubernetes manifests found under */templates/*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,16 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   Reachable because Git tag names may contain slashes and the callers' `v*` tag
   filter does not exclude them; as a `workflow_call` reusable, a caller can
   feed either input from any source.
+- **`security-config.yml` and `ci-gitops.yml` — bash-4-only `mapfile` when
+  collecting manifests.** The kubesec and kubeconform steps built their
+  `manifests` array with `mapfile -t`, a bash 4 builtin. macOS still ships bash
+  3.2 as `/bin/bash`, where the call dies with `command not found` and the step
+  scans nothing. Replaced with the portable `while IFS= read -r … done < <(…)`
+  form, which keeps the loop in the current shell so the array survives. The
+  explicit `manifests=()` init also keeps `${#manifests[@]}` defined under the
+  `set -euo pipefail` in `ci-gitops.yml` when `find` returns nothing. Same
+  latent-portability class as the `release-helm.yml` `sed -i` fix below; no
+  behaviour change on CI, since both jobs pin `runs-on: ubuntu-latest`.
 - **`release-helm.yml` — GNU-only `sed -i` when patching Chart.yaml and
   values.yaml.** Four in-place edits used the suffixless `sed -i "…"` form,
   which is GNU-only: BSD sed (macOS) reads the script as the backup suffix and


### PR DESCRIPTION
## Summary

- `mapfile -t` is a bash 4 builtin; macOS still ships bash 3.2 as `/bin/bash`, so the kubesec block in `security-config.yml` and the kubeconform block in `ci-gitops.yml` would fail with `command not found` outside `ubuntu-latest`. Both now use the portable `while IFS= read -r` loop.
- The explicit `manifests=()` init keeps `${#manifests[@]}` defined under the `set -euo pipefail` in `ci-gitops.yml`, where an unset array would otherwise trip `nounset` on an empty find result.
- Same latent-portability class as the GNU-only `sed -i` fix in `release-helm.yml`; no behaviour change on the current runners.

## Test plan

- [x] `just lint` green (yamllint, jq, actionlint incl. its shellcheck pass)
- [x] `just test` green (drift-summary, drift-issue-body, parity)
- [x] Idiom verified under real bash 3.2.57 on macOS: filenames with spaces preserved, empty find result yields `count=0` without tripping `set -u`
- [ ] CI green