### PR TITLE
fix(ci-gitops): treat a missing gitrepos/production.yaml as nothing to validate

### DIFF
--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -236,14 +236,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check GitRepo exists
+      - name: Report missing GitRepo configuration
+        if: hashFiles('gitrepos/production.yaml') == ''
         run: |
-          if [ ! -f "gitrepos/production.yaml" ]; then
-            echo "ERROR: gitrepos/production.yaml not found!"
-            exit 1
-          fi
+          echo "::notice::gitrepos/production.yaml not found - skipping GitRepo validation"
 
       - name: Validate GitRepo paths
+        if: hashFiles('gitrepos/production.yaml') != ''
         run: |
           echo "Validating GitRepo paths..."
           ERRORS=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,22 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ## 2026-08-02
 
+### Fixed
+
+- **`ci-gitops.yml` no longer fails when `gitrepos/production.yaml` is
+  absent.** The GitRepo existence step exited 1 on a missing file, and
+  `enable-gitrepo-validation` defaults to `true` — so every GitOps consumer
+  whose Fleet `GitRepo` resources live elsewhere (provisioned by Ansible, for
+  example) stayed permanently red unless it opted out explicitly. Absence now
+  means "nothing to validate": the step reports it with a `::notice::` and
+  `Validate GitRepo paths` is gated on
+  `hashFiles('gitrepos/production.yaml') != ''`, matching how
+  `validate-kubernetes` in the same file already reports having no manifests
+  to check. Not breaking — repositories carrying the file see no change,
+  repositories without it go from red to green, and existing
+  `enable-gitrepo-validation: false` opt-outs keep working. Consumers can drop
+  those opt-out lines once they bump to a tag containing this change.
+
 ### Added
 
 - **Parity self-check for the inline body logic in `ops-drift-issue.yml`.**


### PR DESCRIPTION
## Summary

- `validate-gitrepo` failed hard when `gitrepos/production.yaml` was missing, while `enable-gitrepo-validation` defaults to `true` — every GitOps consumer whose Fleet `GitRepo` resources are managed outside the repo was permanently red unless it set an explicit opt-out.
- Absence is now "nothing to validate": `Check GitRepo exists` emits a `::notice::` and `Validate GitRepo paths` is gated on `hashFiles('gitrepos/production.yaml') != ''`. Same treatment a missing `.yamllint.yml` already gets in this file.
- Not breaking. Repositories carrying the file are unaffected, repositories without it go from red to green, and existing `enable-gitrepo-validation: false` opt-outs keep working — they can be dropped in a follow-up once consumers bump their date tag.

## Test plan

- [ ] `just lint` (yamllint, jq, actionlint incl. shellcheck) green
- [ ] `just test` green
- [ ] CI green