### PR TITLE
docs(agents): state workflow counts as file/reusable/internal split

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,11 @@ directly impacting the CI/CD pipelines of multiple projects.
 
 **Current Statistics**:
 
-- **Total Workflows**: 24 reusable workflows (see [.github/workflows/](./.github/workflows/))
-- **Categories**: CI (5), Security (6), Deploy (2), Release (4), Operations (3), AI (2), E2E (2)
+- **Total Workflows**: 28 files in [.github/workflows/](./.github/workflows/) — 24 reusable
+  (`workflow_call`) plus 4 internal workflows that run only in this repo
+  (`merge.yml`, `pull-request.yml`, `test-actions-dde.yml`, `weekly-security.yml`)
+- **Reusable Categories**: CI (5), Security (6), Deploy (2), Release (4), Operations (3),
+  AI (2), E2E (2)
 - **Consumers**: applications, infrastructure, authentication, observability, functions,
   sbaerlocher.ch, tsmetrics, and more
 
@@ -296,14 +299,17 @@ swaps `compose-file` / `compose-profile` for `project-directory` /
 `wait-url`. Linux-only (`dde system:install` requires Docker, which hosted
 macOS runners don't ship).
 
-### Internal Self-Tests (1)
+### Internal Workflows (4)
 
-**Purpose**: Smoke-test composite actions in this repo when their sources
-change. Not reusable from consumer repos.
+**Purpose**: This repository's own CI and release plumbing. None of these
+carry a `workflow_call` trigger — they are not reusable from consumer repos.
 
-| Workflow         | File                     | Description                            |
-| ---------------- | ------------------------ | -------------------------------------- |
-| Test dde actions | `test-actions-dde.yml`   | Smoke-test `setup-dde` on Linux/macOS  |
+| Workflow         | File                     | Description                                  |
+| ---------------- | ------------------------ | -------------------------------------------- |
+| Test dde actions | `test-actions-dde.yml`   | Smoke-test `setup-dde` on Linux/macOS        |
+| Pull Request     | `pull-request.yml`       | `just lint` + `just test` on PRs to `main`   |
+| Merge to Main    | `merge.yml`              | Cuts the `YYYY-MM-DD` date tag on push       |
+| Weekly Security  | `weekly-security.yml`    | Scheduled config + secret self-scan (Mon)    |
 
 ---
 
@@ -556,7 +562,7 @@ Ensure lock files are committed:
 ```text
 .github/
 ├── .github/
-│   ├── workflows/           # 24 reusable workflows + 1 internal self-test
+│   ├── workflows/           # 28 files: 24 reusable + 4 internal
 │   │   ├── ai-*.yml        # AI workflows
 │   │   ├── ci-*.yml        # CI workflows
 │   │   ├── deploy-*.yml    # Deploy workflows
@@ -564,7 +570,10 @@ Ensure lock files are committed:
 │   │   ├── ops-*.yml       # Operations workflows
 │   │   ├── release-*.yml   # Release workflows
 │   │   ├── security-*.yml  # Security workflows
-│   │   └── test-*.yml      # Internal self-tests (NOT reusable)
+│   │   ├── test-*.yml      # Internal self-tests (NOT reusable)
+│   │   ├── merge.yml       # Internal: cuts the date tag on push to main
+│   │   ├── pull-request.yml # Internal: lint + test on this repo's PRs
+│   │   └── weekly-security.yml # Internal: scheduled self-scan
 │   ├── ISSUE_TEMPLATE/     # Org-default issue forms
 │   ├── CODEOWNERS          # Repository owners
 │   ├── pull_request_template.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ### Added
 
+- **Drift check for the workflow counts stated in the docs.** Three places
+  carried a count and no two agreed: `AGENTS.md` said "24 reusable workflows"
+  in one section and "24 reusable + 1 internal self-test" in another, while the
+  GitHub repo description said "27 production-ready workflows". The tree holds
+  28 files — 24 with a `workflow_call` trigger, 4 internal. `AGENTS.md` is the
+  first file an agent reads, so a wrong count there seeds wrong assumptions for
+  a whole session. The docs now state the file/reusable/internal split and name
+  the four internal workflows, and `scripts/tests/test-workflow-counts.sh`
+  (wired into `just test`) derives all three numbers from `.github/workflows/`
+  and fails when the docs disagree. Classification parses the `on:` mapping
+  rather than grepping for the bare token, which also appears in prose
+  comments, and covers both `.yml` and `.yaml`. No consumer impact —
+  documentation and a repo-local test only.
 - **Parity self-check for the inline body logic in `ops-drift-issue.yml`.**
   The workflow keeps its own copy of `strip_block`/`render`/`addresses` from
   `scripts/drift-issue-body.sh` — deliberately, since a reusable workflow has

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Centralized CI/CD building blocks for all repositories under
 each workflow by date tag and let Renovate keep them current.
 
 - **Model:** rolling release with date tags (`YYYY-MM-DD`)
-- **Total workflows:** 24
+- **Reusable workflows:** 24 (plus 4 internal to this repo)
 - **Last updated:** 2026-07-18
 
 See [AGENTS.md](./AGENTS.md) for AI-agent context.

--- a/justfile
+++ b/justfile
@@ -83,6 +83,7 @@ test:
     scripts/tests/test-drift-summary.sh
     scripts/tests/test-drift-issue-body.sh
     scripts/tests/test-drift-issue-parity.sh
+    scripts/tests/test-workflow-counts.sh
 
 # fmt → format Markdown and JSON in place
 fmt:

--- a/scripts/tests/test-workflow-counts.sh
+++ b/scripts/tests/test-workflow-counts.sh
@@ -44,7 +44,15 @@ for path in paths:
         doc = yaml.safe_load(fh) or {}
     # YAML 1.1 resolves an unquoted `on:` key to the boolean True.
     triggers = doc.get("on", doc.get(True))
-    reusable = isinstance(triggers, dict) and "workflow_call" in triggers
+    # All three trigger spellings count: the block mapping (`on:\n  workflow_call:`),
+    # the flow sequence (`on: [workflow_call]`) and the bare scalar
+    # (`on: workflow_call`). Accepting only the mapping would undercount.
+    if isinstance(triggers, dict):
+        reusable = "workflow_call" in triggers
+    elif isinstance(triggers, list):
+        reusable = "workflow_call" in triggers
+    else:
+        reusable = triggers == "workflow_call"
     print(f"{'reusable' if reusable else 'internal'}\t{os.path.basename(path)}")
 PY
 )" || fail "could not parse the workflow files"
@@ -110,9 +118,11 @@ grep -qF "# $TOTAL files: $REUSABLE reusable + $INTERNAL internal" "$AGENTS" ||
 grep -qE "^### Internal Workflows \($INTERNAL\)$" "$AGENTS" ||
   fail "AGENTS.md: heading must read '### Internal Workflows ($INTERNAL)'"
 
+# Stop at the next heading of any level, not just `### ` — the Composite
+# Actions section that follows starts with `## ` and carries its own table.
 SECTION="$(
   awk '/^### Internal Workflows \(/ { inside = 1; next }
-       inside && /^### / { exit }
+       inside && /^#{1,6} / { exit }
        inside && /^\| / { print }' "$AGENTS"
 )"
 [ -n "$SECTION" ] || fail "AGENTS.md: Internal Workflows section has no table rows"

--- a/scripts/tests/test-workflow-counts.sh
+++ b/scripts/tests/test-workflow-counts.sh
@@ -8,8 +8,8 @@
 # there seeds wrong assumptions about the repo for a whole session.
 #
 # Counts are derived, never hardcoded here: total is the file count, reusable is
-# the number carrying a `workflow_call` trigger, internal is the remainder. The
-# docs are then grepped for those derived values.
+# the number declaring a `workflow_call` trigger, internal is the remainder. The
+# docs are then checked against those derived values.
 #
 # Run: scripts/tests/test-workflow-counts.sh
 set -euo pipefail
@@ -23,65 +23,107 @@ fail() {
   exit 1
 }
 
-shopt -s nullglob
-FILES=("$WORKFLOWS"/*.yml)
-shopt -u nullglob
+command -v python3 >/dev/null 2>&1 || fail "python3 required to parse the workflow YAML"
 
-TOTAL=${#FILES[@]}
-[ "$TOTAL" -gt 0 ] || fail "no workflow files found in $WORKFLOWS"
+# Classification is done on the parsed `on:` mapping, not by grepping for the
+# bare token: `workflow_call` also appears in prose comments (e.g.
+# ai-claude-review.yml, ops-drift-issue.yml), which would misclassify an
+# internal workflow as reusable. Both .yml and .yaml are collected — GitHub
+# loads either, and a workflow added with the other extension would otherwise
+# be invisible to every count while the check still passed.
+CLASSIFIED="$(
+  python3 - "$WORKFLOWS" <<'PY'
+import os, sys, glob, yaml
 
-REUSABLE=0
+workflows = sys.argv[1]
+paths = sorted(glob.glob(os.path.join(workflows, "*.yml")) +
+               glob.glob(os.path.join(workflows, "*.yaml")))
+
+for path in paths:
+    with open(path) as fh:
+        doc = yaml.safe_load(fh) or {}
+    # YAML 1.1 resolves an unquoted `on:` key to the boolean True.
+    triggers = doc.get("on", doc.get(True))
+    reusable = isinstance(triggers, dict) and "workflow_call" in triggers
+    print(f"{'reusable' if reusable else 'internal'}\t{os.path.basename(path)}")
+PY
+)" || fail "could not parse the workflow files"
+
+[ -n "$CLASSIFIED" ] || fail "no workflow files found in $WORKFLOWS"
+
+TOTAL="$(wc -l <<<"$CLASSIFIED" | tr -d ' ')"
+REUSABLE="$(grep -c '^reusable' <<<"$CLASSIFIED" || true)"
+INTERNAL="$(grep -c '^internal' <<<"$CLASSIFIED" || true)"
+# Plain read loop rather than `mapfile`: that is a bash 4 builtin and this repo
+# still targets the bash 3.2 that macOS ships.
 INTERNAL_FILES=()
-for f in "${FILES[@]}"; do
-  # `workflow_call:` under `on:` is what makes a workflow consumable by another
-  # repo. Matching the bare token is enough — no other construct uses it.
-  if grep -q 'workflow_call' "$f"; then
-    REUSABLE=$((REUSABLE + 1))
-  else
-    INTERNAL_FILES+=("$(basename "$f")")
-  fi
-done
-INTERNAL=$((TOTAL - REUSABLE))
+while IFS= read -r name; do
+  [ -n "$name" ] && INTERNAL_FILES+=("$name")
+done < <(awk -F'\t' '$1 == "internal" { print $2 }' <<<"$CLASSIFIED")
 
 AGENTS="$REPO/AGENTS.md"
 README="$REPO/README.md"
 
+# Counts are matched with a leading boundary so a longer number cannot satisfy a
+# shorter assertion (`24 internal` must not pass for INTERNAL=4, `128 files` must
+# not pass for TOTAL=28).
+has_count() { # has_count <file-or-text> <number> <unit>
+  grep -qE "(^|[^0-9])$2 $3" <<<"$1"
+}
+
 # 1 — AGENTS.md "Current Statistics" states total, reusable and internal.
-STATS_LINE="$(grep -n '\*\*Total Workflows\*\*' "$AGENTS" || true)"
-[ -n "$STATS_LINE" ] || fail "AGENTS.md: '**Total Workflows**' line not found"
+STATS_START="$(awk '/\*\*Total Workflows\*\*/ { print NR; exit }' "$AGENTS")"
+[ -n "$STATS_START" ] || fail "AGENTS.md: '**Total Workflows**' line not found"
 
-# The statement wraps over several lines; read the whole bullet.
-STATS_START="${STATS_LINE%%:*}"
-STATS_BLOCK="$(sed -n "${STATS_START},$((STATS_START + 3))p" "$AGENTS")"
+# The bullet wraps over several lines; take it up to (not including) the next
+# list item, so the window follows the prose instead of a hardcoded length.
+# awk reads the file itself and stops printing at the next list item; piping
+# `tail` into an early-exiting awk would raise SIGPIPE under `pipefail`.
+STATS_BLOCK="$(
+  awk -v start="$STATS_START" '
+    NR < start { next }
+    NR > start && /^- / { done = 1 }
+    !done { print }
+  ' "$AGENTS"
+)"
 
-grep -q "$TOTAL files" <<<"$STATS_BLOCK" ||
+has_count "$STATS_BLOCK" "$TOTAL" "files" ||
   fail "AGENTS.md: statistics must state '$TOTAL files' (found $TOTAL workflow files)"
-grep -q "$REUSABLE reusable" <<<"$STATS_BLOCK" ||
+has_count "$STATS_BLOCK" "$REUSABLE" "reusable" ||
   fail "AGENTS.md: statistics must state '$REUSABLE reusable' (found $REUSABLE with workflow_call)"
-grep -q "$INTERNAL internal" <<<"$STATS_BLOCK" ||
+has_count "$STATS_BLOCK" "$INTERNAL" "internal" ||
   fail "AGENTS.md: statistics must state '$INTERNAL internal' (found $INTERNAL without workflow_call)"
 
 # Every internal workflow is named there — that list is the actually useful bit.
 for name in "${INTERNAL_FILES[@]}"; do
-  grep -q "$name" <<<"$STATS_BLOCK" ||
+  grep -qF "$name" <<<"$STATS_BLOCK" ||
     fail "AGENTS.md: statistics must name the internal workflow '$name'"
 done
 
 # 2 — the repository-structure tree repeats the same numbers.
-grep -q "# $TOTAL files: $REUSABLE reusable + $INTERNAL internal" "$AGENTS" ||
+grep -qF "# $TOTAL files: $REUSABLE reusable + $INTERNAL internal" "$AGENTS" ||
   fail "AGENTS.md: workflows/ tree comment must read '# $TOTAL files: $REUSABLE reusable + $INTERNAL internal'"
 
-# 3 — the "Internal Workflows (N)" section heading and one row per workflow.
-grep -q "^### Internal Workflows ($INTERNAL)$" "$AGENTS" ||
+# 3 — the "Internal Workflows (N)" section heading, plus one table row per
+# internal workflow. Scoped to the section so it cannot be satisfied by the
+# mention in the statistics bullet above.
+grep -qE "^### Internal Workflows \($INTERNAL\)$" "$AGENTS" ||
   fail "AGENTS.md: heading must read '### Internal Workflows ($INTERNAL)'"
 
+SECTION="$(
+  awk '/^### Internal Workflows \(/ { inside = 1; next }
+       inside && /^### / { exit }
+       inside && /^\| / { print }' "$AGENTS"
+)"
+[ -n "$SECTION" ] || fail "AGENTS.md: Internal Workflows section has no table rows"
+
 for name in "${INTERNAL_FILES[@]}"; do
-  grep -q "\`$name\`" "$AGENTS" ||
+  grep -qF "\`$name\`" <<<"$SECTION" ||
     fail "AGENTS.md: Internal Workflows table must have a row for '$name'"
 done
 
 # 4 — README states the reusable count and the internal count.
-grep -q "\*\*Reusable workflows:\*\* $REUSABLE (plus $INTERNAL internal to this repo)" "$README" ||
+grep -qF "**Reusable workflows:** $REUSABLE (plus $INTERNAL internal to this repo)" "$README" ||
   fail "README.md: must state '**Reusable workflows:** $REUSABLE (plus $INTERNAL internal to this repo)'"
 
 echo "PASS: workflow counts ($TOTAL files = $REUSABLE reusable + $INTERNAL internal) match AGENTS.md and README.md"

--- a/scripts/tests/test-workflow-counts.sh
+++ b/scripts/tests/test-workflow-counts.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Drift check: the workflow counts stated in AGENTS.md and README.md must match
+# what is actually in .github/workflows/.
+#
+# Three places used to carry a count and no two agreed (24 / "24 + 1 self-test"
+# / 27 in the repo description) — a hand-maintained number drifts on every
+# workflow added. AGENTS.md is the first file an agent reads, so a wrong count
+# there seeds wrong assumptions about the repo for a whole session.
+#
+# Counts are derived, never hardcoded here: total is the file count, reusable is
+# the number carrying a `workflow_call` trigger, internal is the remainder. The
+# docs are then grepped for those derived values.
+#
+# Run: scripts/tests/test-workflow-counts.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+WORKFLOWS="$REPO/.github/workflows"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+shopt -s nullglob
+FILES=("$WORKFLOWS"/*.yml)
+shopt -u nullglob
+
+TOTAL=${#FILES[@]}
+[ "$TOTAL" -gt 0 ] || fail "no workflow files found in $WORKFLOWS"
+
+REUSABLE=0
+INTERNAL_FILES=()
+for f in "${FILES[@]}"; do
+  # `workflow_call:` under `on:` is what makes a workflow consumable by another
+  # repo. Matching the bare token is enough — no other construct uses it.
+  if grep -q 'workflow_call' "$f"; then
+    REUSABLE=$((REUSABLE + 1))
+  else
+    INTERNAL_FILES+=("$(basename "$f")")
+  fi
+done
+INTERNAL=$((TOTAL - REUSABLE))
+
+AGENTS="$REPO/AGENTS.md"
+README="$REPO/README.md"
+
+# 1 — AGENTS.md "Current Statistics" states total, reusable and internal.
+STATS_LINE="$(grep -n '\*\*Total Workflows\*\*' "$AGENTS" || true)"
+[ -n "$STATS_LINE" ] || fail "AGENTS.md: '**Total Workflows**' line not found"
+
+# The statement wraps over several lines; read the whole bullet.
+STATS_START="${STATS_LINE%%:*}"
+STATS_BLOCK="$(sed -n "${STATS_START},$((STATS_START + 3))p" "$AGENTS")"
+
+grep -q "$TOTAL files" <<<"$STATS_BLOCK" ||
+  fail "AGENTS.md: statistics must state '$TOTAL files' (found $TOTAL workflow files)"
+grep -q "$REUSABLE reusable" <<<"$STATS_BLOCK" ||
+  fail "AGENTS.md: statistics must state '$REUSABLE reusable' (found $REUSABLE with workflow_call)"
+grep -q "$INTERNAL internal" <<<"$STATS_BLOCK" ||
+  fail "AGENTS.md: statistics must state '$INTERNAL internal' (found $INTERNAL without workflow_call)"
+
+# Every internal workflow is named there — that list is the actually useful bit.
+for name in "${INTERNAL_FILES[@]}"; do
+  grep -q "$name" <<<"$STATS_BLOCK" ||
+    fail "AGENTS.md: statistics must name the internal workflow '$name'"
+done
+
+# 2 — the repository-structure tree repeats the same numbers.
+grep -q "# $TOTAL files: $REUSABLE reusable + $INTERNAL internal" "$AGENTS" ||
+  fail "AGENTS.md: workflows/ tree comment must read '# $TOTAL files: $REUSABLE reusable + $INTERNAL internal'"
+
+# 3 — the "Internal Workflows (N)" section heading and one row per workflow.
+grep -q "^### Internal Workflows ($INTERNAL)$" "$AGENTS" ||
+  fail "AGENTS.md: heading must read '### Internal Workflows ($INTERNAL)'"
+
+for name in "${INTERNAL_FILES[@]}"; do
+  grep -q "\`$name\`" "$AGENTS" ||
+    fail "AGENTS.md: Internal Workflows table must have a row for '$name'"
+done
+
+# 4 — README states the reusable count and the internal count.
+grep -q "\*\*Reusable workflows:\*\* $REUSABLE (plus $INTERNAL internal to this repo)" "$README" ||
+  fail "README.md: must state '**Reusable workflows:** $REUSABLE (plus $INTERNAL internal to this repo)'"
+
+echo "PASS: workflow counts ($TOTAL files = $REUSABLE reusable + $INTERNAL internal) match AGENTS.md and README.md"

--- a/scripts/tests/test-workflow-counts.sh
+++ b/scripts/tests/test-workflow-counts.sh
@@ -47,9 +47,7 @@ for path in paths:
     # All three trigger spellings count: the block mapping (`on:\n  workflow_call:`),
     # the flow sequence (`on: [workflow_call]`) and the bare scalar
     # (`on: workflow_call`). Accepting only the mapping would undercount.
-    if isinstance(triggers, dict):
-        reusable = "workflow_call" in triggers
-    elif isinstance(triggers, list):
+    if isinstance(triggers, (dict, list)):
         reusable = "workflow_call" in triggers
     else:
         reusable = triggers == "workflow_call"
@@ -120,9 +118,12 @@ grep -qE "^### Internal Workflows \($INTERNAL\)$" "$AGENTS" ||
 
 # Stop at the next heading of any level, not just `### ` — the Composite
 # Actions section that follows starts with `## ` and carries its own table.
+# `#+` rather than an ERE interval: interval support in awk is not universal
+# (the BWK awk on older macOS reads the braces literally and would never match,
+# silently widening the slice again).
 SECTION="$(
   awk '/^### Internal Workflows \(/ { inside = 1; next }
-       inside && /^#{1,6} / { exit }
+       inside && /^#+ / { exit }
        inside && /^\| / { print }' "$AGENTS"
 )"
 [ -n "$SECTION" ] || fail "AGENTS.md: Internal Workflows section has no table rows"


### PR DESCRIPTION
## Summary

- `AGENTS.md` stated three mutually inconsistent workflow counts ("24 reusable workflows", "24 reusable + 1 internal self-test", and the repo description's "27 production-ready"). Actual state: 28 files, 24 with a `workflow_call` trigger, 4 internal.
- Counts are now expressed as a file/reusable/internal split, and the four internal workflows (`merge.yml`, `pull-request.yml`, `test-actions-dde.yml`, `weekly-security.yml`) are named — the "Internal Self-Tests (1)" section became "Internal Workflows (4)", since it previously implied the dde self-test was the only non-reusable.
- `scripts/tests/test-workflow-counts.sh` derives all three numbers from `.github/workflows/` and fails if the docs disagree, wired into `just test` (already run by `pull-request.yml`).

## Test plan

- [x] `just test` — all four scripts pass, including the new count check
- [x] New check verified to fail on each drift class: stale total, stale tree comment, stale README line, and a newly added workflow file
- [x] `just lint` (yamllint, jq, actionlint) clean; `shellcheck` clean on the new script
- [ ] CI green

Note: the GitHub repo description still says "27 production-ready workflows" — that is set outside the repo and needs a manual update to match.