### PR TITLE
test(drift-summary): enforce parity between workflow copy and script

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -313,9 +313,11 @@ jobs:
       # .address und .change.actions, fasst .change.before/.after NIE an. Sie
       # ist ein exaktes Duplikat der Query in scripts/drift-summary.sh — der
       # Workflow checkt das Consumer-Repo aus, das Skript liegt zur Laufzeit
-      # nicht vor, darum inline. Ändert sich die eine, muss die andere folgen
-      # (Gleichheit von Hand geprüft; scripts/tests/test-drift-summary.sh ist
-      # der Anker der Wert-Freiheit). Nur Drift-Modus (YAGNI). Ein kaputter
+      # nicht vor, darum inline. Ändert sich die eine, muss die andere folgen —
+      # die Gleichheit prüft scripts/tests/test-drift-summary-parity.sh, das
+      # die jq-Query hier aus dem YAML zieht und gegen das Skript laufen lässt.
+      # Nicht mehr von Hand (scripts/tests/test-drift-summary.sh bleibt der
+      # Anker der Wert-Freiheit). Nur Drift-Modus (YAGNI). Ein kaputter
       # Summary darf die Drift-Meldung nie unterdrücken -> Fehler = leerer
       # String, Step nie fatal.
       - name: 'Drift Summary Extraction'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,24 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   no hardcoded line range to go stale), sources it, and compares its output
   against the script over the same inputs. Behaviour-based rather than
   textual, so indentation and comment churn do not produce false failures.
+- **Parity self-check for the inline drift jq query in
+  `deploy-terraform.yml`.** The `Drift Summary Extraction` step duplicates the
+  jq query from `scripts/drift-summary.sh` — deliberately, since the workflow
+  checks out the consumer repository and the script is not on disk at runtime
+  — and the contract was again "Gleichheit von Hand geprüft" with nothing
+  enforcing it. That query is the anchor of the value-freedom guarantee: it
+  reads only `.address` and `.change.actions`, never `.change.before/.after`,
+  so a widened copy would push attribute values (which can carry secrets) into
+  a GitHub issue body. `scripts/tests/test-drift-summary-parity.sh` now
+  extracts the query from the workflow YAML (parsed, no hardcoded line range),
+  runs it against the existing `plan-drift.json` fixture alongside the script,
+  and compares the output, asserting that no `LEAKME` marker from
+  `before`/`after` reaches it. The step's whole `run:` block then executes
+  against a stubbed `terraform` and a temporary `GITHUB_OUTPUT`, so the
+  duplicated cap — its value, the threshold at exactly `CAP` resources, and the
+  `… N more (truncated)` notice — is exercised rather than re-derived by the
+  test. No consumer impact — the workflow change is a comment, plus a
+  repository-local test.
 
 ### Changed
 

--- a/justfile
+++ b/justfile
@@ -81,6 +81,7 @@ actionlint:
 # test → run the script self-checks
 test:
     scripts/tests/test-drift-summary.sh
+    scripts/tests/test-drift-summary-parity.sh
     scripts/tests/test-drift-issue-body.sh
     scripts/tests/test-drift-issue-parity.sh
     scripts/tests/test-workflow-counts.sh

--- a/scripts/tests/test-drift-summary-parity.sh
+++ b/scripts/tests/test-drift-summary-parity.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Parity check: the inline jq query in the `Drift Summary Extraction` step of
+# deploy-terraform.yml must behave exactly like scripts/drift-summary.sh.
+#
+# The workflow keeps its own copy on purpose (it checks out the consumer repo,
+# so the script is not on disk at runtime — see the comment above the step),
+# and the contract there says "Gleichheit von Hand". Nothing enforced it. This
+# closes it, same pattern as test-drift-issue-parity.sh.
+#
+# Behaviour-based, not textual: the `run:` block is extracted from the YAML
+# (not by a hardcoded line range, which goes stale on the next edit), the jq
+# expression is cut out of it, and the same fixture goes through both copies.
+# Comparing outputs catches semantic drift while ignoring indentation churn.
+#
+# Unlike ops-drift-issue.yml, this step has no shell functions to source. The
+# query is compared on its own first (assertions 1-2, which is where the
+# value-freedom guarantee lives), then the whole step runs against a stubbed
+# `terraform` and a temporary $GITHUB_OUTPUT (assertions 3-5), so the cap
+# threshold and the truncation notice are covered rather than re-derived.
+#
+# Run: scripts/tests/test-drift-summary-parity.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+SCRIPT="$REPO/scripts/drift-summary.sh"
+WORKFLOW="$REPO/.github/workflows/deploy-terraform.yml"
+FIXTURE="$HERE/fixtures/plan-drift.json"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+command -v python3 >/dev/null 2>&1 || fail "python3 required to parse the workflow YAML"
+
+# Pull the `run:` body of the Drift Summary step out of the workflow. PyYAML
+# resolves the block scalar, so the result is already de-indented shell.
+RUN_BLOCK="$(
+  python3 - "$WORKFLOW" <<'PY'
+import sys, yaml
+
+with open(sys.argv[1]) as fh:
+    doc = yaml.safe_load(fh)
+
+for job in doc.get("jobs", {}).values():
+    for step in job.get("steps", []):
+        if step.get("name") == "Drift Summary Extraction":
+            sys.stdout.write(step["run"])
+            sys.exit(0)
+
+sys.exit("step 'Drift Summary Extraction' not found in workflow")
+PY
+)" || fail "could not extract the workflow run block"
+
+# Cut the jq expression out of the block: everything between `jq -r '` and the
+# next line whose first non-blank character is the closing quote.
+QUERY="$(
+  printf '%s\n' "$RUN_BLOCK" | awk "
+    /jq -r '/ { grab = 1; next }
+    grab && /^[[:space:]]*'/ { exit }
+    grab { print }
+  "
+)"
+
+# A silently empty extraction would compare "" against "" further down and pass.
+printf '%s\n' "$QUERY" | grep -q 'resource_changes' || fail "jq query extraction came up empty (workflow step reshaped?)"
+
+# 1 — same fixture through both copies must yield the same lines. The fixture
+# covers update/create/delete/replace plus the filtered no-op and read cases.
+PLAN="$(cat "$FIXTURE")"
+WORKFLOW_OUT="$(printf '%s' "$PLAN" | jq -r "$QUERY")" || fail "workflow query failed on the fixture"
+SCRIPT_OUT="$(printf '%s' "$PLAN" | "$SCRIPT")"
+[ "$WORKFLOW_OUT" = "$SCRIPT_OUT" ] || fail "query drifted on plan-drift.json:
+workflow:
+$WORKFLOW_OUT
+script:
+$SCRIPT_OUT"
+
+# 2 — WERT-FREIHEIT: the level-A comment above the step claims the inline query
+# never touches .change.before/.after. The fixture carries LEAKME markers in
+# both, so a query that widened its field selection shows up right here. Drift
+# on this one would be a secret leak into a GitHub issue body.
+if printf '%s\n' "$WORKFLOW_OUT" | grep -q 'LEAKME'; then
+  fail "attribute value from before/after leaked into the workflow query output"
+fi
+
+# 3 — the cap logic is duplicated too (CAP, the threshold, and the
+# "… N more (truncated)" notice). Extracting only the CAP literal and
+# re-deriving the rest here would compare the script against a copy of itself,
+# so instead run the workflow's own block: substitute the single `${{ }}`
+# expression, stub `terraform show -json` to emit the fixture, and capture what
+# the step writes to $GITHUB_OUTPUT. That makes the whole step the unit under
+# test — threshold and notice wording included.
+run_workflow_step() { # run_workflow_step <plan-json>
+  local plan="$1" dir block
+  dir="$(mktemp -d)"
+  # shellcheck disable=SC2064  # expand dir now, it is local to this function
+  trap "rm -rf '$dir'" RETURN
+
+  printf '%s' "$plan" >"$dir/plan.json"
+
+  # `terraform show -json <file>` is the step's only external dependency; the
+  # stub ignores the arguments and emits the fixture. `environment` is the one
+  # ${{ }} expression in the block.
+  {
+    printf 'terraform() { cat "%s"; }\n' "$dir/plan.json"
+    printf 'GITHUB_OUTPUT="%s/out"\n' "$dir"
+    printf '%s\n' "$RUN_BLOCK" | sed 's/\${{ inputs\.environment }}/test/g'
+  } >"$dir/step.sh"
+
+  # The block ends in `exit 0`, so run it in a subshell rather than sourcing.
+  bash "$dir/step.sh" >/dev/null 2>&1
+
+  [ -f "$dir/out" ] || return 1
+  # Unwrap the `summary<<DELIM ... DELIM` heredoc the step appends.
+  block="$(sed -e '1d' -e '$d' "$dir/out")"
+  printf '%s' "$block"
+}
+
+printf '%s\n' "$RUN_BLOCK" | grep -q 'GITHUB_OUTPUT' || fail "workflow step no longer writes to GITHUB_OUTPUT (test harness stale)"
+
+# Drive more resources than the cap through both copies and compare. The script
+# caps at 50, so 80 crosses the threshold in both. Mirrors assertion 4 in
+# test-drift-summary.sh.
+BIG_PLAN="$(jq -n '{resource_changes: [range(80) | {address: ("authentik_group.g\(.)"), change: {actions: ["update"]}}]}')"
+BIG_SCRIPT="$(printf '%s' "$BIG_PLAN" | "$SCRIPT")"
+BIG_WORKFLOW="$(run_workflow_step "$BIG_PLAN")" || fail "workflow step produced no GITHUB_OUTPUT for the capped case"
+[ "$BIG_WORKFLOW" = "$BIG_SCRIPT" ] || fail "capped output drifted for 80 resources:
+workflow:
+$BIG_WORKFLOW
+script:
+$BIG_SCRIPT"
+
+# 4 — the same block below the cap, so the else-branch is covered too.
+SMALL_WORKFLOW="$(run_workflow_step "$PLAN")" || fail "workflow step produced no GITHUB_OUTPUT for the fixture"
+[ "$SMALL_WORKFLOW" = "$SCRIPT_OUT" ] || fail "uncapped step output drifted:
+workflow:
+$SMALL_WORKFLOW
+script:
+$SCRIPT_OUT"
+
+# 5 — exactly CAP resources. This is the only input size where `-gt` and `-ge`
+# disagree, so without it a flipped threshold passes both cases above: 80 is
+# truncated either way, and the fixture is under the cap either way. At the
+# boundary the correct behaviour is no truncation notice.
+CAP_N="$(printf '%s\n' "$RUN_BLOCK" | sed -n 's/^[[:space:]]*CAP=\([0-9][0-9]*\)[[:space:]]*$/\1/p' | head -n 1)"
+[ -n "$CAP_N" ] || fail "CAP not found in the workflow step"
+EDGE_PLAN="$(jq -n --argjson n "$CAP_N" '{resource_changes: [range($n) | {address: ("authentik_group.g\(.)"), change: {actions: ["update"]}}]}')"
+EDGE_SCRIPT="$(printf '%s' "$EDGE_PLAN" | "$SCRIPT")"
+EDGE_WORKFLOW="$(run_workflow_step "$EDGE_PLAN")" || fail "workflow step produced no GITHUB_OUTPUT at the cap boundary"
+[ "$EDGE_WORKFLOW" = "$EDGE_SCRIPT" ] || fail "output drifted at exactly CAP ($CAP_N) resources:
+workflow:
+$EDGE_WORKFLOW
+script:
+$EDGE_SCRIPT"
+if printf '%s\n' "$EDGE_WORKFLOW" | grep -q 'truncated'; then
+  fail "exactly CAP resources must not be reported as truncated"
+fi
+
+echo "PASS: deploy-terraform.yml <-> drift-summary.sh parity"


### PR DESCRIPTION
## Summary

- The `Drift Summary Extraction` step in `deploy-terraform.yml` keeps its own copy of the jq query from `scripts/drift-summary.sh`. The duplication is deliberate — the workflow checks out the consumer repository, so the script is not on disk at runtime — but the contract was "Gleichheit von Hand geprüft" with nothing enforcing it.
- That query is the anchor of the value-freedom guarantee: it reads only `.address` and `.change.actions`, never `.change.before/.after`. A widened copy would push attribute values, which can carry secrets, into a GitHub issue body.
- `scripts/tests/test-drift-summary-parity.sh` extracts the query from the workflow YAML by parsing it (no hardcoded line range to go stale), runs it against the existing `plan-drift.json` fixture alongside the script, and compares. It also asserts the `LEAKME` markers in `before`/`after` never reach the output, and that the duplicated `CAP` value and its truncation behaviour still match. Same pattern as `test-drift-issue-parity.sh`, minus the sourcing — this step has no shell functions.
- Wired into `just test`, and the level-A comment in the workflow now points at the test instead of claiming a hand check.

## Test plan

- [x] `just test` — all five self-checks pass, including the new one
- [x] `just lint` — yamllint, jq, actionlint clean; `shellcheck` clean on the new script
- [x] Negative check: widening the workflow query to emit `.change.before` fails assertion 1 and surfaces the `LEAKME` values
- [x] Negative check: changing `CAP` in the workflow only fails the cap assertion
- [x] Negative check: renaming the step fails extraction rather than passing vacuously
- [ ] CI green