### PR TITLE
feat(ci-gitops): add gitrepo-file and require-gitrepo-file inputs

### DIFF
--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -38,6 +38,24 @@ on:
         type: boolean
         required: false
         default: true
+      gitrepo-file:
+        description: |
+          Path to the Fleet GitRepo manifest whose `paths:` are validated.
+          Used in the step conditions and the grep, so the location is stated
+          once instead of being repeated per call site.
+        type: string
+        required: false
+        default: 'gitrepos/production.yaml'
+      require-gitrepo-file:
+        description: |
+          Fail the job when `gitrepo-file` is absent. Default `false` treats a
+          missing manifest as "nothing to validate", which is correct for repos
+          whose GitRepo resources are provisioned elsewhere. Set to `true` in
+          repos whose Fleet deployment hangs off the manifest, so renaming or
+          deleting it turns the job red instead of passing with a notice.
+        type: boolean
+        required: false
+        default: false
       enable-helm-lint:
         description: 'Lint Helm charts'
         type: boolean
@@ -241,18 +259,32 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Report missing GitRepo configuration
-        if: hashFiles('gitrepos/production.yaml') == ''
+      - name: Require GitRepo configuration
+        if: inputs.require-gitrepo-file && hashFiles(inputs.gitrepo-file) == ''
+        env:
+          GITREPO_FILE: ${{ inputs.gitrepo-file }}
         run: |
-          echo "::notice::gitrepos/production.yaml not found - skipping GitRepo validation"
+          echo "ERROR: ${GITREPO_FILE} not found, but require-gitrepo-file is true"
+          exit 1
+
+      - name: Report missing GitRepo configuration
+        if: >-
+          !inputs.require-gitrepo-file
+          && hashFiles(inputs.gitrepo-file) == ''
+        env:
+          GITREPO_FILE: ${{ inputs.gitrepo-file }}
+        run: |
+          echo "::notice::${GITREPO_FILE} not found - skipping GitRepo validation"
 
       - name: Validate GitRepo paths
-        if: hashFiles('gitrepos/production.yaml') != ''
+        if: hashFiles(inputs.gitrepo-file) != ''
+        env:
+          GITREPO_FILE: ${{ inputs.gitrepo-file }}
         run: |
           echo "Validating GitRepo paths..."
           ERRORS=0
 
-          PATHS=$(grep -A 100 "paths:" gitrepos/production.yaml | grep "^    - " | sed 's/^    - //')
+          PATHS=$(grep -A 100 "paths:" "${GITREPO_FILE}" | grep "^    - " | sed 's/^    - //')
 
           for path in $PATHS; do
             if [ ! -d "$path" ]; then

--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -302,7 +302,7 @@ jobs:
           # A glob or an unreadable path would otherwise die mid-pipeline with
           # a bare "No such file or directory".
           if [ ! -f "${GITREPO_FILE}" ]; then
-            echo "ERROR: ${GITREPO_FILE} is not a readable file"
+            echo "ERROR: ${GITREPO_FILE%%$'\n'*} is not a readable file"
             echo "gitrepo-file takes a single literal path, not a glob"
             exit 1
           fi

--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -43,6 +43,12 @@ on:
           Path to the Fleet GitRepo manifest whose `paths:` are validated.
           Used in the step conditions and the grep, so the location is stated
           once instead of being repeated per call site.
+
+          A single literal path — globs are not supported. `hashFiles()` reads
+          the value as a pattern while `grep` reads it as a filename, so a
+          wildcard would pass the existence gate and then fail in the shell.
+          The value is also echoed into a `::notice::`, so pass static caller
+          configuration only, never event-controlled data.
         type: string
         required: false
         default: 'gitrepos/production.yaml'
@@ -53,6 +59,10 @@ on:
           whose GitRepo resources are provisioned elsewhere. Set to `true` in
           repos whose Fleet deployment hangs off the manifest, so renaming or
           deleting it turns the job red instead of passing with a notice.
+
+          Enforced by a step inside `validate-gitrepo`, so it requires
+          `enable-gitrepo-validation: true` — with the job disabled this input
+          is inert and a missing manifest still reports green.
         type: boolean
         required: false
         default: false
@@ -264,7 +274,8 @@ jobs:
         env:
           GITREPO_FILE: ${{ inputs.gitrepo-file }}
         run: |
-          echo "ERROR: ${GITREPO_FILE} not found, but require-gitrepo-file is true"
+          # First line only, same reasoning as the notice step below.
+          echo "ERROR: ${GITREPO_FILE%%$'\n'*} not found, but require-gitrepo-file is true"
           exit 1
 
       - name: Report missing GitRepo configuration
@@ -274,7 +285,10 @@ jobs:
         env:
           GITREPO_FILE: ${{ inputs.gitrepo-file }}
         run: |
-          echo "::notice::${GITREPO_FILE} not found - skipping GitRepo validation"
+          # First line only: the runner parses any stdout line starting with
+          # `::` as a workflow command, so a newline in the value could smuggle
+          # a second one into this notice.
+          echo "::notice::${GITREPO_FILE%%$'\n'*} not found - skipping GitRepo validation"
 
       - name: Validate GitRepo paths
         if: hashFiles(inputs.gitrepo-file) != ''
@@ -283,6 +297,15 @@ jobs:
         run: |
           echo "Validating GitRepo paths..."
           ERRORS=0
+
+          # hashFiles() above matched a pattern; grep below needs a real file.
+          # A glob or an unreadable path would otherwise die mid-pipeline with
+          # a bare "No such file or directory".
+          if [ ! -f "${GITREPO_FILE}" ]; then
+            echo "ERROR: ${GITREPO_FILE} is not a readable file"
+            echo "gitrepo-file takes a single literal path, not a glob"
+            exit 1
+          fi
 
           PATHS=$(grep -A 100 "paths:" "${GITREPO_FILE}" | grep "^    - " | sed 's/^    - //')
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,24 +22,6 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ## 2026-08-02
 
-### Added
-
-- **`ci-gitops.yml` takes `gitrepo-file` and `require-gitrepo-file`.** The
-  GitRepo manifest path was hard-coded at four call sites (both step
-  conditions, the `::notice::` text and the `grep`), so a repo keeping the
-  manifest anywhere but `gitrepos/production.yaml` could not use the job at
-  all. `gitrepo-file` (default `gitrepos/production.yaml`) states the location
-  once. `require-gitrepo-file` (default `false`) restores the ability to make a
-  missing manifest fail: the preceding change turned absence into a
-  `::notice::` for every consumer, which is right for repos whose GitRepo
-  resources live elsewhere but hides an accidental rename or deletion in repos
-  whose Fleet deployment hangs off the file. Those repos set
-  `require-gitrepo-file: true` and get a red job again. The path reaches the
-  `run:` blocks via `env:` rather than direct `${{ }}` interpolation, matching
-  the hardening the yamllint step carries in the same release. Not breaking —
-  both inputs are optional and their defaults reproduce the current behaviour
-  exactly.
-
 ### Fixed
 
 - **`ci-gitops.yml` no longer fails when `gitrepos/production.yaml` is
@@ -58,6 +40,23 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ### Added
 
+- **`ci-gitops.yml` takes `gitrepo-file` and `require-gitrepo-file`.** The
+  GitRepo manifest path was hard-coded at four call sites (both step
+  conditions, the `::notice::` text and the `grep`), so a repo keeping the
+  manifest anywhere but `gitrepos/production.yaml` could not use the job at
+  all. `gitrepo-file` (default `gitrepos/production.yaml`) states the location
+  once; it takes a single literal path, not a glob. `require-gitrepo-file`
+  (default `false`) restores the ability to make a missing manifest fail: the
+  change above turned absence into a `::notice::` for every consumer, which is
+  right for repos whose GitRepo resources live elsewhere but hides an
+  accidental rename or deletion in repos whose Fleet deployment hangs off the
+  file. Those repos set `require-gitrepo-file: true` and get a red job again —
+  it is enforced inside `validate-gitrepo`, so it needs
+  `enable-gitrepo-validation: true` to have any effect. The path reaches the
+  `run:` blocks via `env:` rather than direct `${{ }}` interpolation, matching
+  the hardening the yamllint step carries in the same release. Not breaking —
+  both inputs are optional and their defaults reproduce the current behaviour
+  exactly.
 - **Drift check for the workflow counts stated in the docs.** Three places
   carried a count and no two agreed: `AGENTS.md` said "24 reusable workflows"
   in one section and "24 reusable + 1 internal self-test" in another, while the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,24 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ## 2026-08-02
 
+### Added
+
+- **`ci-gitops.yml` takes `gitrepo-file` and `require-gitrepo-file`.** The
+  GitRepo manifest path was hard-coded at four call sites (both step
+  conditions, the `::notice::` text and the `grep`), so a repo keeping the
+  manifest anywhere but `gitrepos/production.yaml` could not use the job at
+  all. `gitrepo-file` (default `gitrepos/production.yaml`) states the location
+  once. `require-gitrepo-file` (default `false`) restores the ability to make a
+  missing manifest fail: the preceding change turned absence into a
+  `::notice::` for every consumer, which is right for repos whose GitRepo
+  resources live elsewhere but hides an accidental rename or deletion in repos
+  whose Fleet deployment hangs off the file. Those repos set
+  `require-gitrepo-file: true` and get a red job again. The path reaches the
+  `run:` blocks via `env:` rather than direct `${{ }}` interpolation, matching
+  the hardening the yamllint step carries in the same release. Not breaking —
+  both inputs are optional and their defaults reproduce the current behaviour
+  exactly.
+
 ### Fixed
 
 - **`ci-gitops.yml` no longer fails when `gitrepos/production.yaml` is


### PR DESCRIPTION
## Summary

- `ci-gitops.yml` had the GitRepo manifest path hard-coded at four call sites (both step conditions, the `::notice::` text and the `grep`), so the job only worked for repos keeping the manifest at `gitrepos/production.yaml`. The new optional `gitrepo-file` input (same default) states the location once.
- A missing manifest currently always passes with a `::notice::`. That is right for repos whose GitRepo resources are provisioned elsewhere, but it hides an accidental rename or deletion in repos whose Fleet deployment hangs off the file. The new `require-gitrepo-file` input (default `false`) lets those repos turn the job red again.
- The path reaches the `run:` blocks via `env:` rather than direct `${{ }}` interpolation, matching the hardening the yamllint step carries in the same release.
- Non-breaking per `REVIEW.md:43` — both inputs are optional and their defaults reproduce the current behaviour exactly.

## Test plan

- [x] `just lint` clean (yamllint, jq, actionlint via container with shellcheck)
- [x] `actionlint` on `ci-gitops.yml` exits 0
- [x] `just test` passes (4 script self-checks)
- [ ] CI green