### PR TITLE
fix(security-secrets)!: remove the unused file-patterns input

### DIFF
--- a/.github/workflows/security-secrets.yml
+++ b/.github/workflows/security-secrets.yml
@@ -24,10 +24,6 @@ on:
           `*.tf`/`*.yml`/`*.yaml`/`*.json` and private-key content in
           `*.pem`/`*.key`. Both fail the job on a hit. This is not a
           general-purpose secret scanner — gitleaks and TruffleHog cover that.
-      file-patterns:
-        type: string
-        default: '*.tf,*.yml,*.yaml,*.json,*.env.example'
-        description: 'File patterns to scan (comma-separated)'
       cancel-in-progress:
         type: boolean
         required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ## 2026-08-02
 
+### ⚠ BREAKING
+
+- **`security-secrets.yml` no longer takes `file-patterns`.** The input was
+  declared with a default of `'*.tf,*.yml,*.yaml,*.json,*.env.example'` but no
+  step ever read it — the scan scope lives in two hard-wired `--include=` lists,
+  one for AWS keys (`*.tf`/`*.yml`/`*.yaml`/`*.json`) and one for private-key
+  content (`*.pem`/`*.key`). A caller setting it got no change in behaviour and
+  no warning. It is removed rather than wired up: the job checks two fixed key
+  formats, not a configurable file tree, and one shared pattern list does not
+  fit two steps with different semantics — the `*.env.example` portion of the
+  default is meaningless for the private-key step, whose narrow includes are
+  deliberate. Scan behaviour is unchanged by this removal.
+  **Migration:** remove the `file-patterns:` line from your call.
+
 ### Changed
 
 - **`ci-ansible.yml` passes its inputs through `env:` instead of interpolating


### PR DESCRIPTION
## Summary

- `security-secrets.yml` declared a `file-patterns` input that no step ever read — the scan scope lives in two hard-wired `--include=` lists (AWS keys in `*.tf`/`*.yml`/`*.yaml`/`*.json`, private-key content in `*.pem`/`*.key`). A caller setting it got no behaviour change and no warning.
- Removed rather than wired up: the job checks two fixed key formats, not a configurable file tree, and one shared pattern list does not fit two steps with different semantics — the `*.env.example` part of the old default is meaningless for the private-key step.
- Breaking per repo convention (removing an input), so the CHANGELOG gains a `### ⚠ BREAKING` entry with the migration step. Scan behaviour is unchanged.

## Test plan

- [x] `just lint` — exit 0
- [x] `just test` — exit 0, including `test-workflow-counts.sh` (an input removal does not shift the file/reusable counts)
- [x] `grep -rn "file-patterns" .github/` → no hits
- [x] Diff is 4 deletions / 0 insertions in the workflow; the two `--include=` lines are byte-identical to their pre-change baseline
- [x] YAML parse check: `file-patterns` gone from the inputs map, `cancel-in-progress` intact with all four of its own fields (guards against deleting one line off and silently renaming an input)