### PR TITLE
fix(ci-gitops): fail GitRepo path validation when nothing parses

### DIFF
--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -295,6 +295,7 @@ jobs:
         env:
           GITREPO_FILE: ${{ inputs.gitrepo-file }}
         run: |
+          set -euo pipefail
           echo "Validating GitRepo paths..."
           ERRORS=0
 
@@ -307,9 +308,36 @@ jobs:
             exit 1
           fi
 
-          PATHS=$(grep -A 100 "paths:" "${GITREPO_FILE}" | grep "^    - " | sed 's/^    - //')
+          # Line heuristic, not a YAML parser: it reads at most 100 lines after
+          # the first `paths:` and only accepts entries indented with exactly
+          # four spaces. A list further down the manifest, or indented
+          # differently, is invisible to it. `|| true` keeps the non-match from
+          # tripping `pipefail`, so the empty result is judged below instead of
+          # aborting the step without a message.
+          PATHS=$(grep -A 100 "paths:" "${GITREPO_FILE}" | grep "^    - " | sed 's/^    - //' || true)
 
-          for path in $PATHS; do
+          # An empty result is an error, not a pass. Reporting success here
+          # would make an unparsable manifest indistinguishable from a valid
+          # one, which is the failure this guard exists for.
+          if [ -z "${PATHS}" ]; then
+            echo "ERROR: no paths parsed from ${GITREPO_FILE%%$'\n'*}"
+            echo "Either the manifest declares no 'paths:', or its entries sit"
+            echo "beyond the 100-line window or are not indented with exactly"
+            echo "four spaces."
+            exit 1
+          fi
+
+          # Read loop instead of `mapfile -t`: mapfile is a bash-4 builtin and
+          # macOS still ships bash 3.2 as /bin/bash, so the block would break
+          # the moment it runs outside ubuntu-latest. Quoting the expansion
+          # keeps a path containing spaces one entry instead of splitting it
+          # into phantom ones.
+          paths=()
+          while IFS= read -r path; do
+            paths+=("$path")
+          done <<< "${PATHS}"
+
+          for path in "${paths[@]}"; do
             if [ ! -d "$path" ]; then
               echo "WARNING: Path $path in GitRepo does not exist"
             elif [ ! -f "$path/fleet.yaml" ]; then

--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -309,35 +309,38 @@ jobs:
           fi
 
           # Line heuristic, not a YAML parser: it reads at most 100 lines after
-          # the first `paths:` and only accepts entries indented with exactly
-          # four spaces. A list further down the manifest, or indented
-          # differently, is invisible to it. `|| true` keeps the non-match from
-          # tripping `pipefail`, so the empty result is judged below instead of
-          # aborting the step without a message.
-          PATHS=$(grep -A 100 "paths:" "${GITREPO_FILE}" | grep "^    - " | sed 's/^    - //' || true)
+          # the first `paths:`. Any indentation is accepted, because a YAML
+          # sequence may sit at its parent's level — `paths:` followed by
+          # `  - platform` is what Rancher's own GitRepo examples use, and
+          # anchoring on four spaces would silently skip it. `|| true` keeps a
+          # non-match from tripping `pipefail`, so an empty result is judged
+          # below instead of aborting the step without a message.
+          PATHS=$(grep -A 100 "paths:" "${GITREPO_FILE}" | grep -E "^ +- " | sed -E 's/^ +- //' || true)
 
-          # An empty result is an error, not a pass. Reporting success here
-          # would make an unparsable manifest indistinguishable from a valid
-          # one, which is the failure this guard exists for.
+          # No paths is not an error: `spec.paths` is optional in Fleet, and
+          # omitting it means "scan the repository root". Warn instead, so the
+          # case stays visible without failing manifests that rely on it.
           if [ -z "${PATHS}" ]; then
-            echo "ERROR: no paths parsed from ${GITREPO_FILE%%$'\n'*}"
-            echo "Either the manifest declares no 'paths:', or its entries sit"
-            echo "beyond the 100-line window or are not indented with exactly"
-            echo "four spaces."
-            exit 1
+            echo "::warning::No paths parsed from ${GITREPO_FILE%%$'\n'*}"
+            echo "Either the manifest declares no 'paths:' (Fleet then scans the"
+            echo "repository root), or its entries sit beyond the 100-line window."
           fi
 
-          # Read loop instead of `mapfile -t`: mapfile is a bash-4 builtin and
-          # macOS still ships bash 3.2 as /bin/bash, so the block would break
-          # the moment it runs outside ubuntu-latest. Quoting the expansion
-          # keeps a path containing spaces one entry instead of splitting it
-          # into phantom ones.
+          # Read loop instead of `mapfile -t`, which is a bash-4 builtin: the
+          # runner is bash 5, but the neighbouring loops in this file avoid it
+          # for portability and this one stays consistent with them. Quoting
+          # the expansion is the load-bearing part — it keeps a path containing
+          # spaces one entry instead of splitting it into phantom ones.
+          # `${paths[@]+…}` guards the empty-array case, which `set -u` rejects
+          # on bash < 4.4.
           paths=()
-          while IFS= read -r path; do
-            paths+=("$path")
-          done <<< "${PATHS}"
+          if [ -n "${PATHS}" ]; then
+            while IFS= read -r path; do
+              paths+=("$path")
+            done <<< "${PATHS}"
+          fi
 
-          for path in "${paths[@]}"; do
+          for path in ${paths[@]+"${paths[@]}"}; do
             if [ ! -d "$path" ]; then
               echo "WARNING: Path $path in GitRepo does not exist"
             elif [ ! -f "$path/fleet.yaml" ]; then


### PR DESCRIPTION
## Summary

- `for path in $PATHS` was unquoted, so a path containing spaces split into phantom entries. Converted to the read-loop idiom the neighbouring loops in this file already use, with quoting as the load-bearing part.
- The `paths:` parser anchored on exactly four spaces, which silently skipped sequences written at the parent's indent level (`paths:` followed by `  - platform`) — the shape Rancher's own GitRepo examples use. Widened to `grep -E "^ +- "`, so a valid manifest is no longer read as empty.
- An empty parse result now emits a `::warning::` rather than passing silently. It is deliberately not a hard failure: `spec.paths` is optional in Fleet and its absence means "scan the repository root", so failing would flip valid consumers red.
- Added `set -euo pipefail`, coupled to `|| true` on the assignment — on its own it would have turned the silent pass into a silent failure, since `grep` exits 1 when the manifest has no `paths:`.

## Test plan

- [x] Four-space entries: both paths validated, exit 0
- [x] Two-space entries (Rancher style): both paths validated, exit 0 — previously parsed as empty
- [x] Manifest without `paths:`: warning emitted, exit 0
- [x] Path containing a space (`my dir`): one entry, not two
- [x] Path missing `fleet.yaml`: still counted as an error, exit 1
- [x] All cases re-run under bash 3.2 and 5.3 — identical results, empty array safe under `set -u`
- [x] `just lint` (yamllint, jq, actionlint+shellcheck) and `just test` green
