### PR TITLE
fix(ai-claude-review): fail the check when no review was posted

### DIFF
--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -271,26 +271,50 @@ jobs:
       # clean review in the PR checklist. Assert a review actually landed on the
       # current head SHA (a follow-up run already has older reviews from the same
       # bot, so counting reviews alone would pass vacuously).
+      #
+      # `!cancelled()` rather than `always()`: this workflow cancels in-progress
+      # runs by default, and a superseded run has no review on its head SHA —
+      # `always()` would red the check while the newer run posts a real review.
+      # Failures of the action step itself are still covered.
       - name: Assert a review was posted
-        if: always()
+        if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
-          BOT: ${{ steps.mode.outputs.bot-login }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # Marker keeps the comment idempotent across re-runs and later pushes,
+          # same upsert idea as ops-drift-issue.yml.
+          MARKER: '<!-- claude-review-missing -->'
         run: |
           set -euo pipefail
 
-          COUNT=$(gh api "repos/$REPO/pulls/$PR/reviews" \
-            --jq '[.[] | select(.user.login==env.BOT and .commit_id==env.HEAD_SHA)] | length')
+          # Same bot predicate as the `mode` step above rather than its
+          # `bot-login` output: that output falls back to a hard-coded
+          # `claude[bot]` on a first review, which would make this assertion
+          # fail for any consumer whose app posts under a different login.
+          # `--paginate` because reviews come back oldest-first, 30 per page.
+          COUNT=$(gh api --paginate "repos/$REPO/pulls/$PR/reviews" \
+            | jq -s 'add // [] | [.[]
+                | select(.user.type == "Bot"
+                    and (.user.login | test("claude"; "i"))
+                    and .commit_id == env.HEAD_SHA)] | length')
 
           if [ "$COUNT" -gt 0 ]; then
-            echo "Review by $BOT found on $HEAD_SHA."
+            echo "Review found on $HEAD_SHA."
             exit 0
           fi
 
-          gh pr comment "$PR" --repo "$REPO" --body \
-            "Claude Code Review übersprungen — Workflow-Validierung. Bitte manuell prüfen."
-          echo "::error::No review by $BOT on $HEAD_SHA — the review was skipped."
+          # Neutral wording: this also fires on a genuinely failed action step
+          # (expired token, exhausted --max-turns, job timeout), where naming
+          # the workflow validation would point at the wrong cause.
+          POSTED=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
+            | jq -s --arg m "$MARKER" 'add // [] | [.[] | select(.body | contains($m))] | length')
+
+          if [ "$POSTED" -eq 0 ]; then
+            gh pr comment "$PR" --repo "$REPO" --body "$(printf '%s\n%s' "$MARKER" \
+              'No Claude Code Review was posted for this commit, so this check cannot confirm the diff was reviewed. See the job log for the cause and review manually before merging.')"
+          fi
+
+          echo "::error::No review on $HEAD_SHA — the review did not run."
           exit 1

--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -264,3 +264,33 @@ jobs:
               }
             '
             ```
+
+      # The action's workflow validation refuses to run when the PR changes a
+      # workflow file that differs from the default branch — but it exits 0, so
+      # the check goes green with no review attached. Indistinguishable from a
+      # clean review in the PR checklist. Assert a review actually landed on the
+      # current head SHA (a follow-up run already has older reviews from the same
+      # bot, so counting reviews alone would pass vacuously).
+      - name: Assert a review was posted
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          BOT: ${{ steps.mode.outputs.bot-login }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          COUNT=$(gh api "repos/$REPO/pulls/$PR/reviews" \
+            --jq '[.[] | select(.user.login==env.BOT and .commit_id==env.HEAD_SHA)] | length')
+
+          if [ "$COUNT" -gt 0 ]; then
+            echo "Review by $BOT found on $HEAD_SHA."
+            exit 0
+          fi
+
+          gh pr comment "$PR" --repo "$REPO" --body \
+            "Claude Code Review übersprungen — Workflow-Validierung. Bitte manuell prüfen."
+          echo "::error::No review by $BOT on $HEAD_SHA — the review was skipped."
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,17 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   deliberate. Scan behaviour is unchanged by this removal.
   **Migration:** remove the `file-patterns:` line from your call.
 
+- **`ai-claude-review.yml` now fails the job when no review was posted.** The
+  `anthropics/claude-code-action` workflow validation refuses to review a PR
+  that changes a workflow file, but exits 0 — the `claude-review` check went
+  green with no review attached, indistinguishable from a clean pass. A guard
+  step now asserts a Claude bot review exists on the current head SHA and exits
+  1 otherwise, leaving a single marker comment on the PR. Migration: consumers
+  listing this context in `required_status_checks` will see PRs that touch the
+  review workflow itself blocked until reviewed manually — merge those with an
+  admin bypass, or drop the context from the ruleset if that is not the
+  intended policy.
+
 ### Changed
 
 - **`ci-go.yml` passes the `Set test environment variables` step's inputs


### PR DESCRIPTION
## Summary

- The `anthropics/claude-code-action` workflow validation blocks the review when a PR changes a workflow file, but the step still exits 0 — the `claude-review` check went green with no review attached, indistinguishable from a clean pass (observed on #269, ~1.7s step, zero comments).
- Add a guard step after the action that asserts a review by the bot login exists **on the current head SHA**, comments on the PR and exits 1 otherwise. Matching on the head SHA rather than a bare review count is what makes follow-up runs work — those already carry older reviews from the same bot.
- `if: always()` so the guard also fires when the action step itself fails.

This repo has no `required_status_checks` rule, so a red check does not block here. In the two consumer repos that do require this context, failing is the intended signal: a PR that changes the review workflow gets no review and should not pass unnoticed.

## Test plan

- [ ] `just lint` (yamllint, jq, actionlint incl. shellcheck) green
- [ ] `just test` green
- [ ] jq filter verified against fixtures: review on head SHA → 1, only older-SHA review → 0, empty review list → 0
- [ ] CI green on this PR — note this PR changes the review workflow itself, so it is the live case: the review is expected to be skipped and this guard should now turn the check red instead of green