### PR TITLE
fix(ci-go): pass test env inputs through env instead of interpolating into run

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -203,8 +203,12 @@ jobs:
 
       - name: Set test environment variables
         if: inputs.test-env-vars != ''
+        env:
+          TEST_ENV_VARS: ${{ inputs.test-env-vars }}
         run: |
-          echo '${{ inputs.test-env-vars }}' | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> $GITHUB_ENV
+          set -euo pipefail
+          printf '%s' "$TEST_ENV_VARS" \
+            | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
 
       - name: Run tests with coverage
         env:
@@ -331,11 +335,18 @@ jobs:
           install-go: false
 
       - name: Set test environment variables
+        env:
+          POSTGRES_USER: ${{ inputs.postgres-user }}
+          POSTGRES_PASSWORD: ${{ inputs.postgres-password }}
+          POSTGRES_DB: ${{ inputs.postgres-db }}
+          TEST_ENV_VARS: ${{ inputs.test-env-vars }}
         run: |
-          echo "DATABASE_URL=postgres://${{ inputs.postgres-user }}:${{ inputs.postgres-password }}@localhost:5432/${{ inputs.postgres-db }}?sslmode=disable" >> $GITHUB_ENV
+          set -euo pipefail
+          echo "DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}?sslmode=disable" >> "$GITHUB_ENV"
 
-          if [[ -n "${{ inputs.test-env-vars }}" ]]; then
-            echo '${{ inputs.test-env-vars }}' | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> $GITHUB_ENV
+          if [ -n "${TEST_ENV_VARS:-}" ]; then
+            printf '%s' "$TEST_ENV_VARS" \
+              | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
           fi
 
       - name: Run tests with coverage

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -342,7 +342,8 @@ jobs:
           TEST_ENV_VARS: ${{ inputs.test-env-vars }}
         run: |
           set -euo pipefail
-          echo "DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}?sslmode=disable" >> "$GITHUB_ENV"
+          printf 'DATABASE_URL=postgres://%s:%s@localhost:5432/%s?sslmode=disable\n' \
+            "$POSTGRES_USER" "$POSTGRES_PASSWORD" "$POSTGRES_DB" >> "$GITHUB_ENV"
 
           if [ -n "${TEST_ENV_VARS:-}" ]; then
             printf '%s' "$TEST_ENV_VARS" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,21 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ### Changed
 
+- **`ci-go.yml` passes the `Set test environment variables` step's inputs
+  through `env:` instead of interpolating them into the `run:` block.** The step
+  wrapped `${{ inputs.test-env-vars }}` in single quotes, which is not an
+  escape: interpolation happens before the shell sees the line, so a value
+  containing an apostrophe closed the string early and the remainder was parsed
+  as shell code — writing to `$GITHUB_ENV`, and thus affecting every later step
+  of the job. The step exists in both `test-and-lint` and
+  `test-and-lint-postgres` and both are fixed; the postgres copy's
+  `DATABASE_URL` line, in the same block, moved to `env:` with it. The blocks
+  also gained `set -euo pipefail`, use `printf '%s'` instead of `echo` (which
+  mangles values with a leading `-` or backslashes), and quote `$GITHUB_ENV`.
+  Same pattern as the `ci-ansible.yml` entry below. **One behaviour change, not
+  breaking:** invalid JSON in `test-env-vars` now fails the step instead of
+  passing silently with no variables set. No input signature changes, and valid
+  JSON behaves exactly as before.
 - **`ci-ansible.yml` passes its inputs through `env:` instead of interpolating
   them into `run:` blocks.** Every `${{ inputs.* }}` reference in a shell body
   became a step-level `env:` entry read as a shell variable, matching the
@@ -131,7 +146,7 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 ### Changed
 
 - **`ci-gitops.yml` — `yaml-lint-strict` and the yamllint config argument now
-  reach the shell via `env:`.** The *Validate YAML files* step interpolated
+  reach the shell via `env:`.** The _Validate YAML files_ step interpolated
   `${{ inputs.yaml-lint-strict }}` and the `hashFiles('.yamllint.yml')`
   expression directly into its `run:` block, which produces recurring CodeQL
   "potential code injection" findings and diverged from the `env:` pattern the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,12 +47,13 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   of the job. The step exists in both `test-and-lint` and
   `test-and-lint-postgres` and both are fixed; the postgres copy's
   `DATABASE_URL` line, in the same block, moved to `env:` with it. The blocks
-  also gained `set -euo pipefail`, use `printf '%s'` instead of `echo` (which
-  mangles values with a leading `-` or backslashes), and quote `$GITHUB_ENV`.
-  Same pattern as the `ci-ansible.yml` entry below. **One behaviour change, not
-  breaking:** invalid JSON in `test-env-vars` now fails the step instead of
-  passing silently with no variables set. No input signature changes, and valid
-  JSON behaves exactly as before.
+  also gained `set -euo pipefail`, pipe `test-env-vars` through `printf '%s'`
+  instead of `echo` (which mangles values with a leading `-` or backslashes),
+  and quote `$GITHUB_ENV`. Same pattern as the `ci-ansible.yml` entry below.
+  **No behaviour change for valid or invalid JSON:** invalid `test-env-vars`
+  failed the step before and still does. Only values that previously broke
+  shell quoting — apostrophes, leading `-`, backslashes — behave differently:
+  they now work instead of erroring. No input signature changes.
 - **`ci-ansible.yml` passes its inputs through `env:` instead of interpolating
   them into `run:` blocks.** Every `${{ inputs.* }}` reference in a shell body
   became a step-level `env:` entry read as a shell variable, matching the


### PR DESCRIPTION
## Summary

- The `Set test environment variables` step interpolated `test-env-vars` into a single-quoted `echo` in the `run:` body. Single quotes are not an escape here: GitHub substitutes the value before the shell parses the line, so an apostrophe in the value ends the string and the remainder is executed as shell code — and the output goes to `$GITHUB_ENV`, affecting every later step of the job.
- The step exists in both `test-and-lint` and `test-and-lint-postgres`; both are fixed. The postgres copy's `DATABASE_URL` line sits in the same block and moved to `env:` with it, so the block is touched once.
- Follows the pattern already established in `ci-ansible.yml` (#279): step-level `env:`, `set -euo pipefail`, `printf` instead of `echo` (which mangles leading `-` and backslashes), and quoted `$GITHUB_ENV`.

**No behaviour change for valid or invalid JSON.** Invalid `test-env-vars` failed the step before this PR and still does — `jq` is the last stage of the pipeline, so its non-zero exit was already the pipeline status, and the runner's default `bash -e {0}` already failed the step. Only values that previously broke shell quoting behave differently: they now work instead of erroring. No input signature changes.

## Test plan

- [x] No `${{ ... }}` left in either `run:` body; interpolation only in `env:` blocks
- [x] Valid JSON (current consumer value): two variables written, exit 0 — unchanged
- [x] Apostrophe in value (`{"MSG": "it's here"}`): writes `MSG=it's here`, exit 0 — previously a shell syntax error
- [x] Invalid JSON: `jq` parse error, exit 5 — unchanged from before (verified against the pre-PR code under `bash -e`)
- [x] Empty value: guard skips, exit 0
- [x] `DATABASE_URL` renders byte-identically after the `echo` → `printf` change
- [x] `just lint` and `just test` green locally
- [ ] CI green

### Not in scope

Newline values in `test-env-vars` can still inject extra `$GITHUB_ENV` lines (raised in review). Pre-existing and unchanged by this PR — same before and after — so it is tracked separately rather than widened into this diff.
