### PR TITLE
ci(justfile): gate Markdown and JSON formatting in lint

### DIFF
--- a/.github/actions/project/README.md
+++ b/.github/actions/project/README.md
@@ -68,7 +68,7 @@ matrix re-uses the same `with:` block.
 ## Inputs
 
 | Input               | Default        | Description                                                              |
-|---------------------|----------------|--------------------------------------------------------------------------|
+| ------------------- | -------------- | ------------------------------------------------------------------------ |
 | `command`           | `up`           | dde project subcommand (`up`, `down`, `restart`, `update`, ...).         |
 | `version`           | `latest`       | dde version (`v2.0.0-alpha.5`, `2.0.0-alpha.5`, or `latest`).            |
 | `working-directory` | `.`            | Directory with `.dde/config.yml`. Fails fast if missing.                 |
@@ -82,7 +82,7 @@ matrix re-uses the same `with:` block.
 ## Outputs
 
 | Output        | Description                                              |
-|---------------|----------------------------------------------------------|
+| ------------- | -------------------------------------------------------- |
 | `version`     | Resolved tag that was installed (e.g. `v2.0.0-alpha.5`). |
 | `binary-path` | Absolute path to the installed `dde` binary.             |
 
@@ -97,7 +97,7 @@ the simplest pattern:
   uses: sbaerlocher/.github/.github/actions/project@2026-04-30
   with:
     command: down
-    working-directory: ./apps/web   # match the up working-directory
+    working-directory: ./apps/web # match the up working-directory
 ```
 
 For longer-lived runners (self-hosted) you may also want

--- a/.github/actions/setup-dde/README.md
+++ b/.github/actions/setup-dde/README.md
@@ -45,13 +45,13 @@ other `dde project:<command>`), use the sibling
 
 ## Inputs
 
-| Input            | Default        | Description                                                              |
-|------------------|----------------|--------------------------------------------------------------------------|
-| `version`        | `latest`       | Tag to install (`v2.0.0-alpha.5`, `2.0.0-alpha.5`, or `latest`).         |
-| `install-mkcert` | `true`         | Install `mkcert` (and `libnss3-tools` on Linux) for local TLS certs.     |
-| `system-install` | `false`        | Run `dde system:install` (required for `dde project:up`).                |
-| `github-token`   | `github.token` | Token for the GitHub API call that resolves `latest`.                    |
-| `repository`     | `whatwedo/dde` | Source repository. Override for forks or staging mirrors.                |
+| Input            | Default        | Description                                                          |
+| ---------------- | -------------- | -------------------------------------------------------------------- |
+| `version`        | `latest`       | Tag to install (`v2.0.0-alpha.5`, `2.0.0-alpha.5`, or `latest`).     |
+| `install-mkcert` | `true`         | Install `mkcert` (and `libnss3-tools` on Linux) for local TLS certs. |
+| `system-install` | `false`        | Run `dde system:install` (required for `dde project:up`).            |
+| `github-token`   | `github.token` | Token for the GitHub API call that resolves `latest`.                |
+| `repository`     | `whatwedo/dde` | Source repository. Override for forks or staging mirrors.            |
 
 `latest` resolves the most recent published release, including
 pre-releases. The default `github-token` works for public repos and avoids
@@ -60,14 +60,14 @@ unauthenticated rate limits.
 ## Outputs
 
 | Output        | Description                                              |
-|---------------|----------------------------------------------------------|
+| ------------- | -------------------------------------------------------- |
 | `version`     | Resolved tag that was installed (e.g. `v2.0.0-alpha.5`). |
 | `binary-path` | Absolute path to the installed `dde` binary.             |
 
 ## Supported runners
 
 | Runner             | Status                                                       |
-|--------------------|--------------------------------------------------------------|
+| ------------------ | ------------------------------------------------------------ |
 | `ubuntu-latest`    | Supported (`linux-amd64`).                                   |
 | `ubuntu-24.04-arm` | Supported (`linux-arm64`).                                   |
 | `macos-latest`     | Supported (`darwin-arm64`). `mkcert` installed via Homebrew. |
@@ -106,7 +106,7 @@ can isolate dde state into a temp directory:
     system-install: 'true'
   env:
     DDE_CONFIG_DIR: ${{ runner.temp }}/dde-config
-    DDE_DATA_DIR:   ${{ runner.temp }}/dde-data
+    DDE_DATA_DIR: ${{ runner.temp }}/dde-data
 ```
 
 ## Security

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,14 @@
         "actionlint_image\\s*:=\\s*\"(?<depName>[^:\"]+):(?<currentValue>[^\"@]+)\""
       ],
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Track the prettier version used by the justfile fmt and fmt-check recipes",
+      "managerFilePatterns": ["/(^|/)justfile$/"],
+      "matchStrings": ["prettier_version\\s*:=\\s*\"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "prettier",
+      "datasourceTemplate": "npm"
     }
   ]
 }

--- a/.github/templates/vitest-cloudflare-workers/README.md
+++ b/.github/templates/vitest-cloudflare-workers/README.md
@@ -3,10 +3,10 @@
 Org template for testing a Cloudflare Worker (typically an Astro SSR app) with
 two Vitest **projects** in one config:
 
-| Project       | Runs                                   | Speed | What it catches                          |
-| ------------- | -------------------------------------- | ----- | ---------------------------------------- |
-| `unit`        | plain logic in a DOM-ish env, no Worker | fast  | pure functions, components, lib code     |
-| `integration` | the **built** worker inside Miniflare  | slow  | routing, rendering, service bindings     |
+| Project       | Runs                                    | Speed | What it catches                      |
+| ------------- | --------------------------------------- | ----- | ------------------------------------ |
+| `unit`        | plain logic in a DOM-ish env, no Worker | fast  | pure functions, components, lib code |
+| `integration` | the **built** worker inside Miniflare   | slow  | routing, rendering, service bindings |
 
 The integration project loads the real build output and serves any outbound
 service binding from a **mock upstream worker**, so the worker is exercised
@@ -51,8 +51,8 @@ Unit tests stay co-located with source (`src/**/*.test.ts`).
        "test:unit": "vitest run --project unit",
        "test:integration": "vitest run --project integration",
        "test:watch": "vitest --project unit",
-       "test:coverage": "vitest run --coverage"
-     }
+       "test:coverage": "vitest run --coverage",
+     },
    }
    ```
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,6 +22,10 @@ jobs:
   # its local-binary path only when actionlint is too; it is not, so the recipe
   # falls through to the rhysd/actionlint container, which bundles both. Either
   # way the embedded shell checks run rather than being silently skipped.
+  #
+  # Node is pinned rather than taken from the image default because `just lint`
+  # now runs `fmt-check`, which fetches prettier via `npx`. The image's Node
+  # major changes without notice; the formatting gate should not.
   local-checks:
     name: Local Checks
     runs-on: ubuntu-latest
@@ -37,6 +41,11 @@ jobs:
 
       - name: Install yamllint
         run: pip install yamllint
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
 
       - name: Run lint
         run: just lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ inputs:
   cancel-in-progress:
     type: boolean
     required: false
-    default: <per-workflow-default>  # CI/security/e2e: true; deploy/release/ops: false
+    default: <per-workflow-default> # CI/security/e2e: true; deploy/release/ops: false
     description: Cancel in-progress runs in the same group.
   concurrency-suffix:
     type: string
@@ -174,13 +174,13 @@ concurrency:
 
 - **Caller-isolated** — `${{ github.workflow }}-${{ github.ref }}`. Used by
   CI, Security, Release, E2E, and most Ops/Deploy workflows. `github.workflow`
-  resolves to the *caller's* workflow name when invoked via `workflow_call`,
+  resolves to the _caller's_ workflow name when invoked via `workflow_call`,
   so different callers automatically get different groups.
 - **Resource-locked** — built from inputs (e.g.
   `${{ inputs.project-name }}-terraform-${{ inputs.environment }}` in
   `deploy-terraform.yml`, or `${{ inputs.project-name }}-${{ inputs.environment }}`
   in `ops-drift-issue.yml`). Used when the workflow guards a shared resource
-  (Terraform state, GitHub-issue list) that must serialise across *all*
+  (Terraform state, GitHub-issue list) that must serialise across _all_
   callers, not just the same caller.
 
 When adding a new reusable workflow, pick the base-group pattern based on
@@ -288,10 +288,10 @@ runs cannot race on `gh issue list`.
 
 **Purpose**: End-to-end testing with Docker Compose or whatwedo dde
 
-| Workflow   | File             | Description                                                     |
-| ---------- | ---------------- | --------------------------------------------------------------- |
-| E2E Docker | `e2e-docker.yml` | E2E tests via Docker Compose + Playwright                       |
-| E2E dde    | `e2e-dde.yml`    | E2E tests via whatwedo `dde project:up` + Playwright (Linux)    |
+| Workflow   | File             | Description                                                  |
+| ---------- | ---------------- | ------------------------------------------------------------ |
+| E2E Docker | `e2e-docker.yml` | E2E tests via Docker Compose + Playwright                    |
+| E2E dde    | `e2e-dde.yml`    | E2E tests via whatwedo `dde project:up` + Playwright (Linux) |
 
 `e2e-dde.yml` is the dde-native counterpart to `e2e-docker.yml`. Inputs
 overlap (Playwright/Node setup is identical); the stack-management surface
@@ -304,12 +304,12 @@ macOS runners don't ship).
 **Purpose**: This repository's own CI and release plumbing. None of these
 carry a `workflow_call` trigger — they are not reusable from consumer repos.
 
-| Workflow         | File                     | Description                                  |
-| ---------------- | ------------------------ | -------------------------------------------- |
-| Test dde actions | `test-actions-dde.yml`   | Smoke-test `setup-dde` on Linux/macOS        |
-| Pull Request     | `pull-request.yml`       | `just lint` + `just test` on PRs to `main`   |
-| Merge to Main    | `merge.yml`              | Cuts the `YYYY-MM-DD` date tag on push       |
-| Weekly Security  | `weekly-security.yml`    | Scheduled config + secret self-scan (Mon)    |
+| Workflow         | File                   | Description                                |
+| ---------------- | ---------------------- | ------------------------------------------ |
+| Test dde actions | `test-actions-dde.yml` | Smoke-test `setup-dde` on Linux/macOS      |
+| Pull Request     | `pull-request.yml`     | `just lint` + `just test` on PRs to `main` |
+| Merge to Main    | `merge.yml`            | Cuts the `YYYY-MM-DD` date tag on push     |
+| Weekly Security  | `weekly-security.yml`  | Scheduled config + secret self-scan (Mon)  |
 
 ---
 
@@ -318,12 +318,12 @@ carry a `workflow_call` trigger — they are not reusable from consumer repos.
 Located under [`.github/actions/`](./.github/actions/). Consume from any
 workflow via `sbaerlocher/.github/.github/actions/<name>@<DATE-TAG>`.
 
-| Action                           | File                                                | Purpose                                                       |
-| -------------------------------- | --------------------------------------------------- | ------------------------------------------------------------- |
-| `setup-dde`                      | `.github/actions/setup-dde/`                        | Install whatwedo dde CLI; optional mkcert + `system:install`  |
-| `project`                        | `.github/actions/project/`                          | Install dde + run any `dde project:<command>` (default `up`)  |
-| `sbom-npm`                       | `.github/actions/sbom-npm/`                         | CycloneDX SBOM for npm/pnpm/yarn/bun (internal helper)        |
-| `validate-observability-configs` | `.github/actions/validate-observability-configs/`   | Validate Grafana Alloy and JSON observability configs         |
+| Action                           | File                                              | Purpose                                                      |
+| -------------------------------- | ------------------------------------------------- | ------------------------------------------------------------ |
+| `setup-dde`                      | `.github/actions/setup-dde/`                      | Install whatwedo dde CLI; optional mkcert + `system:install` |
+| `project`                        | `.github/actions/project/`                        | Install dde + run any `dde project:<command>` (default `up`) |
+| `sbom-npm`                       | `.github/actions/sbom-npm/`                       | CycloneDX SBOM for npm/pnpm/yarn/bun (internal helper)       |
+| `validate-observability-configs` | `.github/actions/validate-observability-configs/` | Validate Grafana Alloy and JSON observability configs        |
 
 ### dde actions (`setup-dde`, `project`)
 
@@ -353,7 +353,7 @@ date tags via the standard github-actions manager.
 The self-test workflow (`test-actions-dde.yml`) is the one place `./...`
 is safe — it's a normal workflow that runs `actions/checkout` first, so
 the workspace coincidentally matches the action's repo. Side-effect of
-the full-path pin: the `smoke-project-*` jobs exercise the *tagged*
+the full-path pin: the `smoke-project-*` jobs exercise the _tagged_
 `setup-dde`, not the in-PR copy, so changes to `setup-dde/action.yml`
 are only validated end-to-end through `project` once a new date tag
 has been cut. Direct changes to `setup-dde` are still covered by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,19 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   one argument per playbook, and the resolved command lines are otherwise
   unchanged. Four sibling workflows carry the same pattern and follow
   separately.
+- **`just lint` now checks Markdown and JSON formatting.** A new `fmt-check`
+  recipe runs `prettier --check` over the same globs `fmt` writes, and `lint`
+  calls it as a fourth step — so formatting drift fails the `Lint and Test` job
+  instead of accumulating silently. The seven files that had drifted are
+  reformatted in the same change, which is why this touches `AGENTS.md`,
+  `CHANGELOG.md`, four `README.md` files and two design specs beyond the recipe
+  itself. Two supporting changes: `prettier` is pinned to a `prettier_version`
+  variable and fetched via `npx` by both recipes, so `fmt` and the gate can
+  never disagree about what correct formatting is, and Renovate tracks that pin
+  through a new custom manager; and `pull-request.yml` gained a SHA-pinned
+  `actions/setup-node` step, without which `just lint` has no Node in the
+  runner. Consumers are unaffected — this is local tooling and this repo's own
+  CI, no reusable workflow changes behaviour.
 
 ### Fixed
 
@@ -117,7 +130,7 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 ### Changed
 
 - **`ci-gitops.yml` — `yaml-lint-strict` and the yamllint config argument now
-  reach the shell via `env:`.** The *Validate YAML files* step interpolated
+  reach the shell via `env:`.** The _Validate YAML files_ step interpolated
   `${{ inputs.yaml-lint-strict }}` and the `hashFiles('.yamllint.yml')`
   expression directly into its `run:` block, which produces recurring CodeQL
   "potential code injection" findings and diverged from the `env:` pattern the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,10 +45,11 @@ entrypoint is [`just`](https://just.systems), the org-wide command runner —
 run it without arguments to list the recipes:
 
 ```bash
-just lint         # yamllint, Renovate JSON validity, actionlint
+just lint         # yamllint, Renovate JSON validity, actionlint, fmt-check
 just actionlint   # actionlint alone (local binary or container)
 just test         # script self-checks under scripts/tests/
 just fmt          # prettier over Markdown and JSON
+just fmt-check    # prettier --check, no writes — the formatting gate in `lint`
 ```
 
 Run `just lint` and `just test` before opening a PR — the `Lint and Test` job
@@ -56,8 +57,9 @@ in `pull-request.yml` runs both again, so a local failure is a CI failure.
 `fmt` reflows Markdown tables repo-wide, so keep its output out of otherwise
 unrelated changes.
 
-Recipes call `yamllint`, `jq`, and `prettier` directly — install those
-separately, `just` does not vendor them.
+Recipes call `yamllint` and `jq` directly — install those separately, `just`
+does not vendor them. `prettier` is the exception: `fmt` and `fmt-check` fetch
+a pinned version through `npx`, so only Node has to be present.
 
 `actionlint` is the exception — it needs no manual install. `just actionlint`
 picks a path by coverage rather than by preference:

--- a/README.md
+++ b/README.md
@@ -273,10 +273,11 @@ runner. Run it without arguments to list the recipes:
 | Recipe            | What it does                                              |
 | ----------------- | --------------------------------------------------------- |
 | `just`            | List all recipes                                          |
-| `just lint`       | yamllint, Renovate JSON validity, actionlint              |
+| `just lint`       | yamllint, Renovate JSON validity, actionlint, `fmt-check` |
 | `just actionlint` | actionlint alone — local binary or container, by coverage |
 | `just test`       | Script self-checks under `scripts/tests/`                 |
 | `just fmt`        | prettier over Markdown and JSON                           |
+| `just fmt-check`  | prettier `--check` — the formatting gate inside `lint`    |
 
 There is no `build` or `dev` recipe — this repository ships no build artifact
 and has no dev loop. `templates/justfile` is the reference template consumer

--- a/docs/superpowers/specs/2026-07-12-ci-lint-gate-design.md
+++ b/docs/superpowers/specs/2026-07-12-ci-lint-gate-design.md
@@ -21,13 +21,13 @@ wird.
 
 ## Änderungen pro Workflow
 
-| Workflow           | Änderung                                                                 |
-| ------------------ | ----------------------------------------------------------------------- |
+| Workflow           | Änderung                                                                                                             |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------- |
 | `ci-go.yml`        | Keine — `security-scan` + `codeql-analysis` gaten bereits (`needs: [setup, test-and-lint, test-and-lint-postgres]`). |
-| `ci-js.yml`        | Keine — `security-scan` gatet bereits (`needs: [setup, quality-and-test]`). |
-| `ci-terraform.yml` | `lint` + `trivy` bekommen `needs: validation`.                          |
-| `ci-ansible.yml`   | `lint` + `yamllint` bekommen `needs: validation`.                        |
-| `ci-gitops.yml`    | Alle 6 Nicht-Gate-Jobs bekommen `needs: [validate-yaml]` + Guard-`if:`.  |
+| `ci-js.yml`        | Keine — `security-scan` gatet bereits (`needs: [setup, quality-and-test]`).                                          |
+| `ci-terraform.yml` | `lint` + `trivy` bekommen `needs: validation`.                                                                       |
+| `ci-ansible.yml`   | `lint` + `yamllint` bekommen `needs: validation`.                                                                    |
+| `ci-gitops.yml`    | Alle 6 Nicht-Gate-Jobs bekommen `needs: [validate-yaml]` + Guard-`if:`.                                              |
 
 ## Zwei needs-Muster
 
@@ -38,7 +38,7 @@ die abhängigen Jobs übersprungen. `lint` behält sein bestehendes
 
 **gitops — `needs` + always()-Guard:** Der Gate-Job `validate-yaml` ist
 bedingt (`if: inputs.enable-yaml-lint`). Plain `needs` würde die abhängigen
-Jobs mit-skippen, wenn das Gate *deaktiviert* ist. Guard:
+Jobs mit-skippen, wenn das Gate _deaktiviert_ ist. Guard:
 
 ```yaml
 needs: [validate-yaml]

--- a/docs/superpowers/specs/2026-07-12-security-job-fanout-design.md
+++ b/docs/superpowers/specs/2026-07-12-security-job-fanout-design.md
@@ -9,10 +9,11 @@
 
 GitHub rundet jeden Job auf die volle billed Minute auf. Die vier geteilten
 Security-Reusables splitten in viele separate Jobs (je eigener Runner-Spin-up
-+ Checkout + eigene Minuten-Aufrundung). Einzelne Scan-Jobs laufen teils nur
-6–13 s, werden aber jeder auf 1 volle Minute aufgerundet → der Split kostet
-fast reine Rundungs-Steuer. Gemessen ~902 billable min/mo fleetweit
-(367 secrets + 535 deps/config/containers).
+
+- Checkout + eigene Minuten-Aufrundung). Einzelne Scan-Jobs laufen teils nur
+  6–13 s, werden aber jeder auf 1 volle Minute aufgerundet → der Split kostet
+  fast reine Rundungs-Steuer. Gemessen ~902 billable min/mo fleetweit
+  (367 secrets + 535 deps/config/containers).
 
 ## Ziel
 
@@ -22,12 +23,12 @@ eigenem Job.
 
 ## Änderungen pro Workflow
 
-| Workflow                 | Vorher  | Nachher                                                                      | Runner gespart |
-| ------------------------ | ------- | --------------------------------------------------------------------------- | -------------- |
-| `security-secrets.yml`   | 4 Jobs  | `gitleaks` (isoliert, `pull-requests:read`) + `secret-scan` (trufflehog + pattern + report, `contents:read`) | 2 |
-| `security-deps.yml`      | 5 Jobs  | 1 Job `dependency-scan`, Steps behalten ihre `if:`-Guards                    | 4              |
-| `security-containers.yml`| 4 Jobs  | 1 Job `container-scan`                                                       | 3              |
-| `security-config.yml`    | 5 Jobs  | 1 Job `config-scan`                                                          | 4              |
+| Workflow                  | Vorher | Nachher                                                                                                      | Runner gespart |
+| ------------------------- | ------ | ------------------------------------------------------------------------------------------------------------ | -------------- |
+| `security-secrets.yml`    | 4 Jobs | `gitleaks` (isoliert, `pull-requests:read`) + `secret-scan` (trufflehog + pattern + report, `contents:read`) | 2              |
+| `security-deps.yml`       | 5 Jobs | 1 Job `dependency-scan`, Steps behalten ihre `if:`-Guards                                                    | 4              |
+| `security-containers.yml` | 4 Jobs | 1 Job `container-scan`                                                                                       | 3              |
+| `security-config.yml`     | 5 Jobs | 1 Job `config-scan`                                                                                          | 4              |
 
 ## Trade-off (nicht wegwischen)
 

--- a/justfile
+++ b/justfile
@@ -47,11 +47,20 @@ actionlint_ignores := "-ignore 'SC2086' -ignore 'SC2002' -ignore 'SC2015'"
 # anywhere else. Keep the assignment on one line; the manager regex expects it.
 actionlint_image := "rhysd/actionlint:1.7.7"
 
+# prettier version used by both `fmt` and `fmt-check`. Pinned because the two
+# recipes have to agree: an unpinned `npx prettier` resolves to whatever is
+# current, so a formatting change in a new release would turn `lint` red on a
+# commit that nobody touched. There is no package.json here to pin it instead.
+# Renovate keeps this current via the custom manager in .github/renovate.json.
+# Keep the assignment on one line; the manager regex expects it.
+prettier_version := "3.9.6"
+
 # lint → static checks over YAML, Renovate presets and workflow definitions
 lint:
     yamllint .
     jq empty renovate.json .github/renovate.json renovate-*.json
     just actionlint
+    just fmt-check
 
 # Coverage decides the order, not locality: actionlint needs shellcheck for its
 # embedded shell checks and skips them *silently* without it, so a local binary
@@ -88,4 +97,12 @@ test:
 
 # fmt → format Markdown and JSON in place
 fmt:
-    prettier --write '**/*.md' '**/*.json'
+    npx -y prettier@{{ prettier_version }} --write '**/*.md' '**/*.json'
+
+# fmt-check → verify Markdown and JSON formatting without writing
+#
+# Wired into `lint` so formatting drift fails the same gate as YAML and workflow
+# problems. Without it the repo drifted back to seven unclean files after the
+# last cleanup: `fmt` alone only helps whoever remembers to run it.
+fmt-check:
+    npx -y prettier@{{ prettier_version }} --check '**/*.md' '**/*.json'


### PR DESCRIPTION
## Summary

- `just lint` now runs a new `fmt-check` recipe (`prettier --check` over the
  globs `fmt` writes), so formatting drift fails the `Lint and Test` job instead
  of accumulating silently — it had grown back to seven unclean files since the
  last cleanup.
- Those seven files are reformatted in the same change, which is why the diff
  reaches `AGENTS.md`, `CHANGELOG.md`, three action/template `README.md` files
  and two design specs beyond the recipe itself. Gate and cleanup ship together
  because a gate-only commit would land `just lint` red with no green path.
- `prettier` is pinned via a `prettier_version` variable that both `fmt` and
  `fmt-check` fetch through `npx`, so the writer and the gate cannot disagree
  about what correct formatting is; Renovate tracks the pin through a new custom
  manager. `pull-request.yml` gains a SHA-pinned `actions/setup-node` step —
  without it `just lint` has no Node in the runner.

No reusable workflow changes behaviour, so consumers are unaffected.

## Test plan

- [x] `just fmt-check` green on the branch; exits 1 on injected drift and 0 once
      reformatted, so the gate demonstrably catches what it is for
- [x] `just lint` green (yamllint, Renovate JSON, actionlint, fmt-check)
- [x] `just test` green — all five script self-checks, workflow counts unchanged
- [x] `git diff origin/main | gitleaks stdin` — no leaks
- [ ] CI `Lint and Test` green, confirming Node is present for `fmt-check`