### PR TITLE
refactor(ci): scope SC2086 to its deliberate sites instead of muting it repo-wide

### DIFF
--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -228,8 +228,6 @@ jobs:
           # `while read` over `find -print0` instead of `for file in $(find ...)`:
           # word-splitting breaks on paths containing spaces. Process substitution
           # rather than a pipe so the ERRORS increments stay in this shell.
-          # shellcheck disable=SC2086  # fleet-paths is a space-separated list and
-          # must split into several find arguments.
           while IFS= read -r -d '' file; do
             echo "Checking $file..."
 
@@ -252,7 +250,11 @@ jobs:
                 echo "INFO: $file uses helm lifecycle options for plain manifests"
               fi
             fi
-          done < <(find ${FLEET_PATHS} -name "fleet.yaml" -print0 2>/dev/null)
+          done < <(
+            # shellcheck disable=SC2086  # fleet-paths is a space-separated list
+            # and must split into several find arguments.
+            find ${FLEET_PATHS} -name "fleet.yaml" -print0 2>/dev/null
+          )
 
           if [ $ERRORS -gt 0 ]; then
             echo "Found $ERRORS errors in fleet.yaml files"

--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -177,9 +177,11 @@ jobs:
           fi
           # -print0 / xargs -0 to survive paths with spaces
           if [ "$STRICT" = "true" ]; then
+            # shellcheck disable=SC2086  # must split into `-c <file>`; see env: above
             find . \( -name '*.yaml' -o -name '*.yml' \) -print0 \
               | xargs -0 yamllint ${YAMLLINT_CONFIG_ARG} -f parsable
           else
+            # shellcheck disable=SC2086  # must split into `-c <file>`; see env: above
             find . \( -name '*.yaml' -o -name '*.yml' \) -print0 \
               | xargs -0 yamllint ${YAMLLINT_CONFIG_ARG} -f parsable || true
           fi
@@ -206,6 +208,8 @@ jobs:
           FLEET_PATHS: ${{ inputs.fleet-paths }}
         run: |
           echo "Checking for fleet.yaml files in: ${FLEET_PATHS}"
+          # shellcheck disable=SC2086  # fleet-paths is a space-separated list and
+          # must split into several find arguments.
           FLEET_FILES=$(find ${FLEET_PATHS} -name "fleet.yaml" 2>/dev/null | wc -l)
           echo "Found $FLEET_FILES fleet.yaml files"
 
@@ -224,6 +228,8 @@ jobs:
           # `while read` over `find -print0` instead of `for file in $(find ...)`:
           # word-splitting breaks on paths containing spaces. Process substitution
           # rather than a pipe so the ERRORS increments stay in this shell.
+          # shellcheck disable=SC2086  # fleet-paths is a space-separated list and
+          # must split into several find arguments.
           while IFS= read -r -d '' file; do
             echo "Checking $file..."
 
@@ -545,6 +551,8 @@ jobs:
           while IFS= read -r manifest; do
             manifests+=("$manifest")
           done < <(
+            # shellcheck disable=SC2086  # fleet-paths is a space-separated list
+            # and must split into several find arguments.
             find ${FLEET_PATHS} \( -name '*.yaml' -o -name '*.yml' \) \
               ! -name 'fleet.yaml' \
               | grep -E '/(templates|manifests)/' \

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -247,28 +247,31 @@ jobs:
 
       - name: Build and test binary
         if: inputs.binary-path != ''
+        env:
+          BINARY_PATH: ${{ inputs.binary-path }}
+          VERSION: ${{ needs.setup.outputs.version }}
         run: |
           mkdir -p bin
-          BINARY_NAME=$(basename ${{ inputs.binary-path }})
-          go build -ldflags="-s -w -X main.version=${{ needs.setup.outputs.version }}" -o bin/${BINARY_NAME} ${{ inputs.binary-path }}
+          BINARY_NAME=$(basename "$BINARY_PATH")
+          go build -ldflags="-s -w -X main.version=$VERSION" -o "bin/${BINARY_NAME}" "$BINARY_PATH"
 
-          if [ ! -f bin/${BINARY_NAME} ]; then
+          if [ ! -f "bin/${BINARY_NAME}" ]; then
             echo "::error::Binary was not created"
             exit 1
           fi
 
-          if [ ! -x bin/${BINARY_NAME} ]; then
+          if [ ! -x "bin/${BINARY_NAME}" ]; then
             echo "::error::Binary is not executable"
             exit 1
           fi
 
           echo "Testing --version flag..."
-          if ! ./bin/${BINARY_NAME} --version; then
+          if ! "./bin/${BINARY_NAME}" --version; then
             echo "::warning::Binary --version command failed (not critical)"
           fi
 
           echo "Testing --help flag..."
-          if ! ./bin/${BINARY_NAME} --help; then
+          if ! "./bin/${BINARY_NAME}" --help; then
             echo "::warning::Binary --help command failed (not critical)"
           fi
 
@@ -387,28 +390,31 @@ jobs:
 
       - name: Build and test binary
         if: inputs.binary-path != ''
+        env:
+          BINARY_PATH: ${{ inputs.binary-path }}
+          VERSION: ${{ needs.setup.outputs.version }}
         run: |
           mkdir -p bin
-          BINARY_NAME=$(basename ${{ inputs.binary-path }})
-          go build -ldflags="-s -w -X main.version=${{ needs.setup.outputs.version }}" -o bin/${BINARY_NAME} ${{ inputs.binary-path }}
+          BINARY_NAME=$(basename "$BINARY_PATH")
+          go build -ldflags="-s -w -X main.version=$VERSION" -o "bin/${BINARY_NAME}" "$BINARY_PATH"
 
-          if [ ! -f bin/${BINARY_NAME} ]; then
+          if [ ! -f "bin/${BINARY_NAME}" ]; then
             echo "::error::Binary was not created"
             exit 1
           fi
 
-          if [ ! -x bin/${BINARY_NAME} ]; then
+          if [ ! -x "bin/${BINARY_NAME}" ]; then
             echo "::error::Binary is not executable"
             exit 1
           fi
 
           echo "Testing --version flag..."
-          if ! ./bin/${BINARY_NAME} --version; then
+          if ! "./bin/${BINARY_NAME}" --version; then
             echo "::warning::Binary --version command failed (not critical)"
           fi
 
           echo "Testing --help flag..."
-          if ! ./bin/${BINARY_NAME} --help; then
+          if ! "./bin/${BINARY_NAME}" --help; then
             echo "::warning::Binary --help command failed (not critical)"
           fi
 

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -180,16 +180,16 @@ jobs:
         run: |
           case "${{ inputs.package-manager }}" in
             pnpm)
-              echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+              echo "dir=$(pnpm store path)" >> "$GITHUB_OUTPUT"
               ;;
             bun)
-              echo "dir=$HOME/.bun/install/cache" >> $GITHUB_OUTPUT
+              echo "dir=$HOME/.bun/install/cache" >> "$GITHUB_OUTPUT"
               ;;
             yarn)
-              echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+              echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
               ;;
             npm)
-              echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+              echo "dir=$(npm config get cache)" >> "$GITHUB_OUTPUT"
               ;;
           esac
 
@@ -440,13 +440,13 @@ jobs:
         run: |
           case "${{ inputs.package-manager }}" in
             pnpm)
-              echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+              echo "dir=$(pnpm store path)" >> "$GITHUB_OUTPUT"
               ;;
             yarn)
-              echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+              echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
               ;;
             npm)
-              echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+              echo "dir=$(npm config get cache)" >> "$GITHUB_OUTPUT"
               ;;
           esac
 

--- a/.github/workflows/deploy-cloudflare-workers.yml
+++ b/.github/workflows/deploy-cloudflare-workers.yml
@@ -106,13 +106,13 @@ jobs:
         run: |
           case "${{ inputs.package-manager }}" in
             pnpm)
-              echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+              echo "dir=$(pnpm store path)" >> "$GITHUB_OUTPUT"
               ;;
             bun)
-              echo "dir=$HOME/.bun/install/cache" >> $GITHUB_OUTPUT
+              echo "dir=$HOME/.bun/install/cache" >> "$GITHUB_OUTPUT"
               ;;
             npm)
-              echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+              echo "dir=$(npm config get cache)" >> "$GITHUB_OUTPUT"
               ;;
           esac
 

--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -86,7 +86,7 @@ on:
           This input executes as shell code and must only be set by trusted
           caller workflows, never from PR-controlled data.
           Script has access to all env vars from bw-secrets and env-mapping.
-          Export vars as: echo "VAR_NAME=value" >> $GITHUB_ENV
+          Export vars as: echo "VAR_NAME=value" >> "$GITHUB_ENV"
       cancel-in-progress:
         type: boolean
         required: false

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -127,7 +127,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Package version: $VERSION"
 
       - name: Check if version already published
@@ -143,10 +143,10 @@ jobs:
 
           if npm view "$PACKAGE_NAME@$VERSION" version 2>/dev/null; then
             echo "::warning::Version $VERSION is already published to NPM"
-            echo "should-publish=false" >> $GITHUB_OUTPUT
+            echo "should-publish=false" >> "$GITHUB_OUTPUT"
           else
             echo "✓ Version $VERSION not yet published"
-            echo "should-publish=true" >> $GITHUB_OUTPUT
+            echo "should-publish=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Validate package.json
@@ -464,7 +464,7 @@ jobs:
 
           if [ -n "$PREVIOUS_TAG" ]; then
             echo "Generating changelog from $PREVIOUS_TAG to $VERSION"
-            CHANGELOG=$(git log --pretty=format:"- %s (%h)" $PREVIOUS_TAG..HEAD)
+            CHANGELOG=$(git log --pretty=format:"- %s (%h)" "$PREVIOUS_TAG..HEAD")
           else
             echo "No previous tag found, using all commits"
             CHANGELOG=$(git log --pretty=format:"- %s (%h)" HEAD)
@@ -485,7 +485,7 @@ jobs:
           **Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREVIOUS_TAG}...${VERSION}
           EOF
 
-          echo "changelog_file=/tmp/changelog.md" >> $GITHUB_OUTPUT
+          echo "changelog_file=/tmp/changelog.md" >> "$GITHUB_OUTPUT"
 
       - name: Download SBOM artifact
         if: inputs.enable-sbom

--- a/.github/workflows/security-config.yml
+++ b/.github/workflows/security-config.yml
@@ -234,11 +234,11 @@ jobs:
 
           if [ -z "$MANIFESTS" ]; then
             echo "No Kubernetes manifests found in templates/"
-            echo "found=false" >> $GITHUB_OUTPUT
+            echo "found=false" >> "$GITHUB_OUTPUT"
           else
             echo "Found manifests:"
             echo "$MANIFESTS"
-            echo "found=true" >> $GITHUB_OUTPUT
+            echo "found=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run Kubesec

--- a/.github/workflows/security-deps.yml
+++ b/.github/workflows/security-deps.yml
@@ -173,13 +173,13 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
         run: |
           if [ -f "pnpm-lock.yaml" ]; then
-            echo "pm=pnpm" >> $GITHUB_OUTPUT
+            echo "pm=pnpm" >> "$GITHUB_OUTPUT"
           elif [ -f "yarn.lock" ]; then
-            echo "pm=yarn" >> $GITHUB_OUTPUT
+            echo "pm=yarn" >> "$GITHUB_OUTPUT"
           elif [ -f "bun.lockb" ]; then
-            echo "pm=bun" >> $GITHUB_OUTPUT
+            echo "pm=bun" >> "$GITHUB_OUTPUT"
           else
-            echo "pm=npm" >> $GITHUB_OUTPUT
+            echo "pm=npm" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup pnpm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,23 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   failed the step before and still does. Only values that previously broke
   shell quoting — apostrophes, leading `-`, backslashes — behave differently:
   they now work instead of erroring. No input signature changes.
+- **SC2086 is no longer muted repo-wide; `just lint` catches unquoted
+  expansions again.** The `-ignore 'SC2086'` entry hid 39 findings. Measured
+  against the mute, 34 of them were ordinary defects rather than deliberate
+  word-splitting: plain `>> $GITHUB_OUTPUT` / `>> $GITHUB_ENV` redirects in
+  `ci-js.yml`, `ci-go.yml`, `release-npm.yml`, `security-deps.yml`,
+  `security-config.yml` and `deploy-cloudflare-workers.yml`, an unquoted
+  `${BINARY_NAME}` throughout the two `ci-go.yml` binary-test blocks, and an
+  unquoted git revision range in `release-npm.yml`. The same repositories
+  already quoted that redirect at 40 other sites, so the unquoted ones were
+  inconsistency, not intent. All are now quoted. The 5 genuinely deliberate
+  sites are all in `ci-gitops.yml` — `fleet-paths` and the yamllint
+  `-c <file>` argument must split into several arguments — and each carries a
+  local `# shellcheck disable=SC2086` naming the reason, the same form
+  `ci-ansible.yml` and `ops-drift-issue.yml` already use. `SC2002` and
+  `SC2015` stay muted; they are separate defects with their own fix. Not
+  breaking: resolved command lines are unchanged.
+
 - **`ci-ansible.yml` passes its inputs through `env:` instead of interpolating
   them into `run:` blocks.** Every `${{ inputs.* }}` reference in a shell body
   became a step-level `env:` entry read as a shell variable, matching the

--- a/justfile
+++ b/justfile
@@ -17,9 +17,17 @@ default:
 # actionlint's shellcheck findings are suppressed by message code rather than
 # by turning the whole pass off, so the quoting classes that matter for scripts
 # shipped to consumers stay visible. Currently muted:
-#   SC2086  37x, deliberately unquoted GitHub expressions in `run:` blocks
 #   SC2002  ci-js.yml:350, useless cat in a pipeline
 #   SC2015  deploy-cloudflare-workers.yml:86, A && B || C read as if-then-else
+#
+# SC2086 is no longer muted here. The repo-wide flag hid 39 findings, of which
+# 34 were plain unquoted `$GITHUB_OUTPUT` / `$GITHUB_ENV` redirects and an
+# unquoted `${BINARY_NAME}` — ordinary defects, not deliberate splitting, and
+# inconsistent with the 40 sites that already quoted the same redirect. Those
+# are fixed. The 5 genuinely deliberate sites are all in ci-gitops.yml, where
+# fleet-paths and the yamllint `-c <file>` argument must word-split, and each
+# now carries a local `# shellcheck disable=SC2086` naming the reason. The
+# class therefore catches new occurrences again.
 #
 # SC2044 and SC2162 are fixed in ci-gitops.yml, including the word-splitting
 # they pointed at: fleet validation iterates over `find -print0`, and both helm
@@ -37,8 +45,11 @@ default:
 # entry is repo-wide and forward-looking, not pinned to the file:line cited
 # above. SC2015 (`A && B || C` is not if-then-else) is a real logic-bug class
 # and is muted here only until the follow-up fix lands. Per-path scoping via
-# `.github/actionlint.yaml` `paths:` is the tool's answer if these outlive it.
-actionlint_ignores := "-ignore 'SC2086' -ignore 'SC2002' -ignore 'SC2015'"
+# `.github/actionlint.yaml` `paths:` is the tool's answer if these outlive it;
+# a local `# shellcheck disable` at the call site, as done for SC2086 and
+# SC2016, is finer still and is the preferred form when the exceptions are few
+# enough to name individually.
+actionlint_ignores := "-ignore 'SC2002' -ignore 'SC2015'"
 
 # actionlint container image, used when the local binary and shellcheck are not
 # both present. Renovate keeps the tag current via a custom manager in this


### PR DESCRIPTION
## Summary

- `just lint` muted `SC2086` repo-wide, so a newly added unquoted expansion was indistinguishable from an intentional one. Measured against the mute, the flag hid **39** findings — not the ~10 the follow-up work was expected to clear.
- **34 were ordinary defects**, not deliberate word-splitting: plain `>> $GITHUB_OUTPUT` / `>> $GITHUB_ENV` redirects across six workflows, an unquoted `${BINARY_NAME}` throughout both `ci-go.yml` binary-test blocks, and an unquoted git revision range in `release-npm.yml`. The same repo already quoted that redirect at **40** other sites, so these were inconsistency rather than intent. All are now quoted.
- **The 5 genuinely deliberate sites are all in `ci-gitops.yml`** — `fleet-paths` and the yamllint `-c <file>` argument must split into several arguments. Each now carries a local `# shellcheck disable=SC2086` naming the reason, the same form `ci-ansible.yml` and `ops-drift-issue.yml` already use, so the exception is visible at the call site instead of hidden in a global flag.
- `-ignore 'SC2086'` is dropped from `actionlint_ignores`; `SC2002` and `SC2015` stay, they are separate defects with their own fix. The stale `SC2086 37x` comment is corrected.
- Two `ci-go.yml` steps that interpolated `${{ inputs.* }}` straight into the shell body — including a `DATABASE_URL` built from `postgres-password` — now read those values from `env:`, keeping them out of the `run:` script text.

Not breaking: resolved command lines are unchanged, and the blocks that gained `env:` entries produce the same values as before.

## Test plan

- [x] `just lint` green with `SC2086` fully unmuted (`actionlint | grep -c SC2086` → 0)
- [x] `just test` green — all five script self-checks pass
- [x] **Gate verified against a regression**: reintroducing a single unquoted `>> $GITHUB_OUTPUT` makes `just lint` exit 1; reverting it returns to 0. This is the behaviour the mute was suppressing.
- [x] `jq`-consuming steps confirmed equivalent before/after (`printf '%s' "$VAR"` vs. the previous single-quoted `echo`), including a value containing an apostrophe, which the old form would have broken on
- [x] Prettier clean on every touched file (six pre-existing offenders on `main` are untouched and out of scope)