### PR TITLE
docs: translate remaining German comments and specs to English

### DIFF
--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -305,21 +305,22 @@ jobs:
             esac
           fi
 
-      # Drift-Summary aus dem frischen Plan ziehen — Position ZWINGEND hier:
-      # die .tfplan liegt noch (Security Cleanup löscht sie am Jobende) und
-      # Terraform ist gegen R2 initialisiert, kein zweites setup/Artefakt nötig.
+      # Extract the drift summary from the fresh plan — this position is
+      # MANDATORY: the .tfplan is still on disk (Security Cleanup removes it at
+      # the end of the job) and Terraform is initialised against R2, so no
+      # second setup or artifact is needed.
       #
-      # LEVEL-A GRENZE (Wert-Freiheit): die jq-Query liest ausschliesslich
-      # .address und .change.actions, fasst .change.before/.after NIE an. Sie
-      # ist ein exaktes Duplikat der Query in scripts/drift-summary.sh — der
-      # Workflow checkt das Consumer-Repo aus, das Skript liegt zur Laufzeit
-      # nicht vor, darum inline. Ändert sich die eine, muss die andere folgen —
-      # die Gleichheit prüft scripts/tests/test-drift-summary-parity.sh, das
-      # die jq-Query hier aus dem YAML zieht und gegen das Skript laufen lässt.
-      # Nicht mehr von Hand (scripts/tests/test-drift-summary.sh bleibt der
-      # Anker der Wert-Freiheit). Nur Drift-Modus (YAGNI). Ein kaputter
-      # Summary darf die Drift-Meldung nie unterdrücken -> Fehler = leerer
-      # String, Step nie fatal.
+      # LEVEL-A BOUNDARY (value freedom): the jq query reads .address and
+      # .change.actions exclusively and NEVER touches .change.before/.after. It
+      # is an exact duplicate of the query in scripts/drift-summary.sh — this
+      # workflow checks out the consumer repo, so the script is not on disk at
+      # runtime, hence the inline copy. When one changes, the other must follow;
+      # scripts/tests/test-drift-summary-parity.sh enforces that equality by
+      # extracting the jq query from this YAML and running it against the
+      # script. No longer by hand (scripts/tests/test-drift-summary.sh remains
+      # the anchor of value freedom). Drift mode only (YAGNI). A broken summary
+      # must never suppress the drift report -> on error the string stays empty
+      # and the step is never fatal.
       - name: 'Drift Summary Extraction'
         id: drift_summary
         if: ${{ inputs.mode == 'drift' && steps.plan.outputs.drift_detected == 'true' }}

--- a/.github/workflows/ops-drift-issue.yml
+++ b/.github/workflows/ops-drift-issue.yml
@@ -83,19 +83,19 @@ jobs:
       issues: write
 
     steps:
-      # Body-Logik ist inline, nicht via Checkout des Skripts. Grund: ein
-      # reusable Workflow hat keinen Kontext, der seinen EIGENEN Aufruf-Ref
-      # exponiert (`github.action_ref` ist in `workflow_call`-Steps leer,
-      # `github.workflow_ref` ist der Caller). Ein Checkout müsste auf `@main`
-      # zurückfallen — mutable Ref für ausführbaren Code, genau was das
-      # Datums-Tag-Pinning verhindern soll. Darum dieselbe Linie wie die
-      # Inline-jq in `deploy-terraform.yml`: die render/addresses-Logik ist ein
-      # Duplikat von scripts/drift-issue-body.sh, das per
-      # scripts/tests/test-drift-issue-body.sh getestete Referenz bleibt.
-      # Ändert sich die eine, muss die andere folgen — die Gleichheit prüft
-      # scripts/tests/test-drift-issue-parity.sh, das den Funktions-Block hier
-      # aus dem YAML zieht und gegen das Skript laufen lässt. Nicht mehr von
-      # Hand: genau diese Kopie war zweimal auseinandergelaufen.
+      # The body logic is inline rather than checked out from the script. Reason:
+      # a reusable workflow has no context that exposes its OWN calling ref
+      # (`github.action_ref` is empty in `workflow_call` steps, and
+      # `github.workflow_ref` is the caller). A checkout would have to fall back
+      # to `@main` — a mutable ref for executable code, exactly what date-tag
+      # pinning is meant to prevent. Hence the same approach as the inline jq in
+      # `deploy-terraform.yml`: the render/addresses logic duplicates
+      # scripts/drift-issue-body.sh, which remains the reference tested by
+      # scripts/tests/test-drift-issue-body.sh.
+      # When one changes, the other must follow;
+      # scripts/tests/test-drift-issue-parity.sh enforces that equality by
+      # extracting the function block here from the YAML and running it against
+      # the script. No longer by hand: this very copy had drifted apart twice.
       - name: Upsert drift issue
         env:
           GH_TOKEN: ${{ github.token }}
@@ -112,7 +112,7 @@ jobs:
           START='<!-- drift-summary:start -->'
           END='<!-- drift-summary:end -->'
 
-          # strip_block/render/addresses spiegeln scripts/drift-issue-body.sh.
+          # strip_block/render/addresses mirror scripts/drift-issue-body.sh.
           strip_block() {
             awk -v s="$START" -v e="$END" '
               $0 == s { skip = 1; next }
@@ -123,9 +123,9 @@ jobs:
           render() { # render <base> <summary>
             local clean
             clean="$(printf '%s' "$1" | strip_block)"
-            # Trailing Leerzeilen des Basis-Bodys kappen, damit der Abstand stabil ist.
-            # awk statt `sed -e :a -e '/^\n*$/{$d;N;ba}'`: das sed-Idiom ist GNU-only und
-            # bricht auf BSD-sed (macOS) mit "unexpected EOF (pending }'s)" ab.
+            # Trim trailing blank lines off the base body so the spacing stays stable.
+            # awk instead of `sed -e :a -e '/^\n*$/{$d;N;ba}'`: that sed idiom is GNU-only
+            # and aborts on BSD sed (macOS) with "unexpected EOF (pending }'s)".
             clean="$(printf '%s\n' "$clean" | awk '
               /^[[:space:]]*$/ { blanks = blanks $0 "\n"; next }
               { printf "%s", blanks; blanks = ""; print }
@@ -175,7 +175,7 @@ jobs:
             --jq ".[] | select(.title == \"${TITLE}\") | .number" \
             | head -1)
 
-          # --- Leerer Pfad: kein Summary -> exakt bisheriges Verhalten. --------
+          # --- Empty path: no summary -> exactly the previous behaviour. -------
           if [ -z "${DRIFT_SUMMARY}" ]; then
             if [ -n "${EXISTING}" ]; then
               gh issue comment "${EXISTING}" --body "${BASE}"
@@ -187,7 +187,7 @@ jobs:
             exit 0
           fi
 
-          # --- Summary-Pfad: Marker-Block upserten, Kommentar nur bei Delta. ---
+          # --- Summary path: upsert marker block, comment only on a delta. -----
           BODY="$(render "$BASE" "$DRIFT_SUMMARY")"
           NEW_ADDRS="$(addresses "$BODY")"
 
@@ -200,7 +200,7 @@ jobs:
           OLD_BODY="$(gh issue view "${EXISTING}" --json body --jq '.body')"
           OLD_ADDRS="$(addresses "$OLD_BODY")"
 
-          # Body immer aktualisieren (frischer Timestamp + aktuelle Adressen).
+          # Always refresh the body (fresh timestamp + current addresses).
           gh issue edit "${EXISTING}" --body "${BODY}"
 
           if [ "$NEW_ADDRS" = "$OLD_ADDRS" ]; then

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -89,25 +89,25 @@ jobs:
 
       - name: Update Chart version and appVersion
         env:
-          # Inputs als Environment statt via `${{ }}` in den Script-Body: so
-          # parst bash die Werte als Daten, nicht als Shell-Quelltext.
+          # Inputs via environment instead of `${{ }}` in the script body: that
+          # way bash parses the values as data, not as shell source.
           CHART_PATH: ${{ inputs.chart-path }}
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           VERSION="${INPUT_VERSION#v}"  # Remove 'v' prefix if present
 
-          # Guard vor den `sed`-Aufrufen unten: `$VERSION` landet im
-          # s-Ausdruck selbst. `/` beendet ihn vorzeitig, `&` und `\` sind in
-          # der Replacement-Hälfte Metazeichen, ein Newline bricht das Script
-          # mit "unterminated s command" ab. Allowlist statt Denylist, damit
-          # die Klasse geschlossen ist. Git-Tag-Namen dürfen Slashes tragen
-          # und das `v*`-Filter der Caller schliesst sie nicht aus.
-          # Dieser Step läuft ohne `if:` und vor dem Package-Step, ein
-          # `exit 1` bricht also den Job ab, bevor das zweite, unabhängige
-          # `VERSION="${INPUT_VERSION#v}"` dort ausgewertet wird.
-          # Der abgelehnte Wert geht per `printf %q` ins Log, nicht in die
-          # `::error::`-Annotation: ein Newline darin würde sonst als neues
-          # Workflow-Kommando geparst.
+          # Guard ahead of the `sed` calls below: `$VERSION` ends up inside the
+          # s-expression itself. A `/` terminates it early, `&` and `\` are
+          # metacharacters in the replacement half, and a newline aborts the
+          # script with "unterminated s command". Allowlist rather than denylist
+          # so the class is closed. Git tag names may carry slashes and the
+          # callers' `v*` filter does not exclude them.
+          # This step runs without an `if:` and before the package step, so an
+          # `exit 1` aborts the job before the second, independent
+          # `VERSION="${INPUT_VERSION#v}"` there is evaluated.
+          # The rejected value goes to the log via `printf %q`, not into the
+          # `::error::` annotation: a newline in there would otherwise be parsed
+          # as a new workflow command.
           case "$VERSION" in
             *[!A-Za-z0-9._+-]*)
               echo "::error::version must match [A-Za-z0-9._+-]+ — rejected, see log"
@@ -116,11 +116,11 @@ jobs:
               ;;
           esac
 
-          # Temp-Datei plus `mv` statt `sed -i "…"`: die suffixlose `-i`-Form ist
-          # GNU-only. BSD-sed (macOS) liest das Script als Backup-Suffix und
-          # bricht mit "invalid command code" ab, ohne die Datei zu ändern.
-          # Temp-Datei unter $RUNNER_TEMP, damit ein sed-Fehler keine `.tmp`
-          # im Chart-Verzeichnis liegen lässt, die `helm package` mitpackt.
+          # Temp file plus `mv` instead of `sed -i "…"`: the suffixless `-i` form
+          # is GNU-only. BSD sed (macOS) reads the script as a backup suffix and
+          # aborts with "invalid command code" without changing the file.
+          # Temp file under $RUNNER_TEMP so a sed error leaves no `.tmp` in the
+          # chart directory that `helm package` would bundle along.
           CHART="$CHART_PATH/Chart.yaml"
           TMP="$RUNNER_TEMP/Chart.yaml"
           sed "s/^version:.*/version: $VERSION/" "$CHART" > "$TMP" && mv "$TMP" "$CHART"
@@ -135,10 +135,10 @@ jobs:
           CHART_PATH: ${{ inputs.chart-path }}
           IMAGE_DIGEST: ${{ inputs.image-digest }}
         run: |
-          # Gleicher Guard wie beim Version-Step, hier für den `|`-Delimiter:
-          # `docker/build-push-action` liefert immer `sha256:<hex>`, ein
-          # fremder Caller kann den Input aber frei setzen. Der leere Fall
-          # ist durch `if: inputs.image-digest != ''` schon ausgeschlossen.
+          # Same guard as in the version step, here for the `|` delimiter:
+          # `docker/build-push-action` always yields `sha256:<hex>`, but a
+          # foreign caller can set the input freely. The empty case is already
+          # excluded by `if: inputs.image-digest != ''`.
           case "$IMAGE_DIGEST" in
             *[!A-Za-z0-9:]*)
               echo "::error::image-digest must match [A-Za-z0-9:]+ — rejected, see log"
@@ -148,8 +148,8 @@ jobs:
           esac
 
           # Update values.yaml: clear tag and set digest
-          # Temp-Datei plus `mv` statt `sed -i "…"` — GNU-only, siehe Kommentar
-          # im Schritt "Update Chart version and appVersion".
+          # Temp file plus `mv` instead of `sed -i "…"` — GNU-only, see the
+          # comment in the "Update Chart version and appVersion" step.
           VALUES="$CHART_PATH/values.yaml"
           TMP="$RUNNER_TEMP/values.yaml"
           sed 's/^  tag:.*/  tag: ""/' "$VALUES" > "$TMP" && mv "$TMP" "$VALUES"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   The workflow keeps its own copy of `strip_block`/`render`/`addresses` from
   `scripts/drift-issue-body.sh` — deliberately, since a reusable workflow has
   no context exposing its own call ref and a checkout would have to fall back
-  to a mutable `@main`. The contract was "Gleichheit von Hand" and it drifted
+  to a mutable `@main`. The contract was "kept equal by hand" and it drifted
   twice unnoticed: the script moved to portable `awk` while the inline copy
   kept the GNU-only `sed` idiom. `scripts/tests/test-drift-issue-parity.sh`
   now extracts the function block from the workflow YAML (parsed, so there is
@@ -126,7 +126,7 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   `deploy-terraform.yml`.** The `Drift Summary Extraction` step duplicates the
   jq query from `scripts/drift-summary.sh` — deliberately, since the workflow
   checks out the consumer repository and the script is not on disk at runtime
-  — and the contract was again "Gleichheit von Hand geprüft" with nothing
+  — and the contract was again "equality checked by hand" with nothing
   enforcing it. That query is the anchor of the value-freedom guarantee: it
   reads only `.address` and `.change.actions`, never `.change.before/.after`,
   so a widened copy would push attribute values (which can carry secrets) into

--- a/docs/superpowers/specs/2026-07-12-ci-lint-gate-design.md
+++ b/docs/superpowers/specs/2026-07-12-ci-lint-gate-design.md
@@ -1,93 +1,93 @@
-# Lint/Fast-Checks vor Heavy-Jobs in ci-*-Reusables gaten
+# Gate lint/fast checks ahead of heavy jobs in the ci-\* reusables
 
-**Datum:** 2026-07-12
-**Typ:** Refactor
+**Date:** 2026-07-12
+**Type:** Refactor
 **Notion:** https://app.notion.com/p/39abf097036e81d099f6c430062282f5
-**Pfad:** nicht-trivial · **Aufwand:** M · **Prio:** P2
+**Path:** non-trivial · **Effort:** M · **Priority:** P2
 
 ## Problem
 
-In den geteilten `ci-*.yml`-Reusables laufen teure Jobs (Security-Scan, CodeQL,
-Terraform-Plan/Trivy, Ansible-Lint, Helm-Render/Kubeconform) teils parallel zu
-oder unabhängig von einem billigen Lint/Format/Validate. Ein Lint-Fehler stoppt
-den teuren Job nicht früh → verschwendete Minuten. Aus dem Minuten-Audit
-(Massnahme 2): failed+cancelled Runs zogen fleetweit ~433 min/mo Compute.
+In the shared `ci-*.yml` reusables, expensive jobs (security scan, CodeQL,
+Terraform plan/Trivy, ansible-lint, Helm render/kubeconform) partly run in
+parallel with, or independently of, a cheap lint/format/validate. A lint error
+does not stop the expensive job early, which wastes minutes. From the minutes
+audit (measure 2): failed and cancelled runs pulled roughly 433 min/mo of
+compute fleet-wide.
 
-## Ziel
+## Goal
 
-Teure Jobs erst NACH einem schnellen Gate laufen lassen (`needs:`). Lint-Fehler
-bricht früh ab, statt dass ein teurer Job parallel durchläuft und eh verworfen
-wird.
+Run expensive jobs only AFTER a fast gate (`needs:`). A lint error aborts early
+instead of letting an expensive job run in parallel and be discarded anyway.
 
-## Änderungen pro Workflow
+## Changes per workflow
 
-| Workflow           | Änderung                                                                                                             |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| `ci-go.yml`        | Keine — `security-scan` + `codeql-analysis` gaten bereits (`needs: [setup, test-and-lint, test-and-lint-postgres]`). |
-| `ci-js.yml`        | Keine — `security-scan` gatet bereits (`needs: [setup, quality-and-test]`).                                          |
-| `ci-terraform.yml` | `lint` + `trivy` bekommen `needs: validation`.                                                                       |
-| `ci-ansible.yml`   | `lint` + `yamllint` bekommen `needs: validation`.                                                                    |
-| `ci-gitops.yml`    | Alle 6 Nicht-Gate-Jobs bekommen `needs: [validate-yaml]` + Guard-`if:`.                                              |
+| Workflow           | Change                                                                                                                  |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| `ci-go.yml`        | None — `security-scan` + `codeql-analysis` are already gated (`needs: [setup, test-and-lint, test-and-lint-postgres]`). |
+| `ci-js.yml`        | None — `security-scan` is already gated (`needs: [setup, quality-and-test]`).                                           |
+| `ci-terraform.yml` | `lint` + `trivy` get `needs: validation`.                                                                               |
+| `ci-ansible.yml`   | `lint` + `yamllint` get `needs: validation`.                                                                            |
+| `ci-gitops.yml`    | All 6 non-gate jobs get `needs: [validate-yaml]` + a guard `if:`.                                                       |
 
-## Zwei needs-Muster
+## Two needs patterns
 
-**terraform / ansible — plain `needs`:** Der `validation`-Job ist
-unbedingt (kein `if:`). `needs: validation` reicht: bricht `validation`, werden
-die abhängigen Jobs übersprungen. `lint` behält sein bestehendes
-`if: inputs.enable-*`.
+**terraform / ansible — plain `needs`:** the `validation` job is unconditional
+(no `if:`). `needs: validation` is enough: if `validation` fails, the dependent
+jobs are skipped. `lint` keeps its existing `if: inputs.enable-*`.
 
-**gitops — `needs` + always()-Guard:** Der Gate-Job `validate-yaml` ist
-bedingt (`if: inputs.enable-yaml-lint`). Plain `needs` würde die abhängigen
-Jobs mit-skippen, wenn das Gate _deaktiviert_ ist. Guard:
+**gitops — `needs` + an always() guard:** the gate job `validate-yaml` is
+conditional (`if: inputs.enable-yaml-lint`). Plain `needs` would also skip the
+dependent jobs when the gate is _disabled_. Guard:
 
 ```yaml
 needs: [validate-yaml]
 if: >-
   always() && !failure() && !cancelled()
-  && inputs.enable-<eigenes-flag>
+  && inputs.enable-<own-flag>
 ```
 
-Läuft, wenn das Gate **success** ODER **skipped** ist; blockt nur bei Gate-
-**failure**. Jeder Job behält sein eigenes `enable-*` im selben `if:`.
+This runs when the gate is **success** OR **skipped**, and blocks only on gate
+**failure**. Every job keeps its own `enable-*` in the same `if:`.
 
-Betroffene gitops-Jobs (alle ausser `validate-yaml` und `summary`):
+Affected gitops jobs (all except `validate-yaml` and `summary`):
 `validate-fleet-configs`, `validate-gitrepo`, `validate-helm`,
 `validate-helm-template`, `validate-kubernetes`, `check-documentation`.
-`summary` behält sein bestehendes `needs: [...]` + `if: always()`.
+`summary` keeps its existing `needs: [...]` + `if: always()`.
 
-## go/js: warum keine Änderung
+## go/js: why no change
 
-`dependency-review` in ci-go (Zeile 528) und ci-js (Zeile 521) hat kein
-`needs:` — läuft parallel. Es ist aber **kein Heavy-Job**: reine
-`dependency-review-action`, PR-only + public-only, kein Build/Scan-Compute. Das
-Card-Ziel sind die teuren Jobs (Security-Scan, CodeQL), die bereits gegatet
-sind. `dependency-review` zu gaten fügt nur Wall-Clock für einen ohnehin
-billigen Check hinzu → bewusst ungegatet gelassen (YAGNI).
+`dependency-review` in ci-go (line 528) and ci-js (line 521) has no `needs:`,
+so it runs in parallel. It is, however, **not a heavy job**: a plain
+`dependency-review-action`, PR-only plus public-only, with no build or scan
+compute. The card targets the expensive jobs (security scan, CodeQL), which are
+already gated. Gating `dependency-review` would only add wall-clock time for an
+already cheap check, so it is deliberately left ungated (YAGNI).
 
-## Status-Checks / BREAKING
+## Status checks / BREAKING
 
-Es ändern sich **keine Job-Namen**, nur `needs:` (+ bei gitops die `if:`-
-Guards). Status-Check-Kontext-Namen bleiben stabil → **keine** Ruleset-/
-Branch-Protection-Anker-Migration nötig. Damit ist das **kein** Breaking Change
-im CHANGELOG-Sinn → regulärer Datums-Tag, kein `⚠ BREAKING`.
+**No job names change**, only `needs:` (plus the `if:` guards in gitops).
+Status-check context names stay stable, so **no** ruleset or branch-protection
+anchor migration is needed. That makes this **not** a breaking change in the
+CHANGELOG sense, so a regular date tag is sufficient and no `⚠ BREAKING` is
+required.
 
-Verhaltensänderung (nicht-breaking, dokumentieren): Ein Run, der vorher einen
-Heavy-Job unabhängig als `failure` zeigte, zeigt ihn jetzt `skipped`, wenn das
-Gate vorher failt. Erfolgreiche Runs werden sequenziell etwas langsamer
-(Gate zuerst, dann Heavy) — Trade-off gegen die Minuten-Ersparnis bei
-Fehlläufen.
+Behaviour change (non-breaking, worth documenting): a run that previously showed
+a heavy job independently as `failure` now shows it as `skipped` when the gate
+fails first. Successful runs get slightly slower because they are sequential
+(gate first, then heavy) — a trade-off against the minutes saved on failing
+runs.
 
 ## Testing
 
-- `actionlint` auf ci-terraform, ci-ansible, ci-gitops (Syntax +
-  needs-Referenzen + Expression-Guards).
-- Verifizieren, dass go/js-Heavy-Jobs weiterhin voll gegatet sind (nur Lesen).
-- **Kein** Consumer-Live-Test in dieser Session (bräuchte Tag-Push). Manueller
-  Schritt: nach Tag-Cut in 1–2 Consumer-Repos testen.
+- `actionlint` on ci-terraform, ci-ansible, ci-gitops (syntax, needs references
+  and expression guards).
+- Verify that the go/js heavy jobs remain fully gated (read-only).
+- **No** consumer live test in this session (that would need a tag push). Manual
+  step: test in 1–2 consumer repos after cutting the tag.
 
-## Scope-Grenzen (skipped)
+## Scope boundaries (skipped)
 
-- Dedizierter `gate`-Job in gitops — grösserer Umbau, `validate-yaml`-Name
-  würde sich ändern (mehr BREAKING). `needs`+Guard ist der kleinere Eingriff.
-- go/js-Code-Änderungen — Heavy-Jobs bereits gegatet.
-- Keine Änderung an Job-Logik, nur Abhängigkeits-Topologie.
+- A dedicated `gate` job in gitops — a larger rebuild, and the `validate-yaml`
+  name would change (more BREAKING). `needs` plus a guard is the smaller change.
+- go/js code changes — the heavy jobs are already gated.
+- No change to job logic, only to the dependency topology.

--- a/docs/superpowers/specs/2026-07-12-security-job-fanout-design.md
+++ b/docs/superpowers/specs/2026-07-12-security-job-fanout-design.md
@@ -1,115 +1,116 @@
-# Security-Reusables: Job-Fan-out reduzieren gegen Minuten-Aufrundung
+# Security reusables: reduce job fan-out against per-minute rounding
 
-**Datum:** 2026-07-12
-**Typ:** Refactor
+**Date:** 2026-07-12
+**Type:** Refactor
 **Notion:** https://app.notion.com/p/39abf097036e8133b4b4d95db8b56bee
-**Pfad:** nicht-trivial · **Aufwand:** M · **Prio:** P2
+**Path:** non-trivial · **Effort:** M · **Priority:** P2
 
 ## Problem
 
-GitHub rundet jeden Job auf die volle billed Minute auf. Die vier geteilten
-Security-Reusables splitten in viele separate Jobs (je eigener Runner-Spin-up
+GitHub rounds every job up to a full billed minute. The four shared security
+reusables split into many separate jobs, each with its own runner spin-up,
+checkout and minute rounding. Individual scan jobs sometimes run only 6–13 s but
+are each rounded up to a full minute, so the split is almost pure rounding tax.
+Measured at roughly 902 billable min/mo fleet-wide (367 secrets + 535
+deps/config/containers).
 
-- Checkout + eigene Minuten-Aufrundung). Einzelne Scan-Jobs laufen teils nur
-  6–13 s, werden aber jeder auf 1 volle Minute aufgerundet → der Split kostet
-  fast reine Rundungs-Steuer. Gemessen ~902 billable min/mo fleetweit
-  (367 secrets + 535 deps/config/containers).
+## Goal
 
-## Ziel
+Merge jobs that need no permission isolation of their own into ONE job with
+sequential steps. Make `security-report` a final step instead of its own job.
 
-Jobs, die keine eigene Permission-Isolation brauchen, in EINEN Job mit
-sequenziellen Steps zusammenlegen. `security-report` als letzter Step statt
-eigenem Job.
+## Changes per workflow
 
-## Änderungen pro Workflow
+| Workflow                  | Before | After                                                                                                        | Runners saved |
+| ------------------------- | ------ | ------------------------------------------------------------------------------------------------------------ | ------------- |
+| `security-secrets.yml`    | 4 jobs | `gitleaks` (isolated, `pull-requests:read`) + `secret-scan` (trufflehog + pattern + report, `contents:read`) | 2             |
+| `security-deps.yml`       | 5 jobs | 1 job `dependency-scan`, steps keep their `if:` guards                                                       | 4             |
+| `security-containers.yml` | 4 jobs | 1 job `container-scan`                                                                                       | 3             |
+| `security-config.yml`     | 5 jobs | 1 job `config-scan`                                                                                          | 4             |
 
-| Workflow                  | Vorher | Nachher                                                                                                      | Runner gespart |
-| ------------------------- | ------ | ------------------------------------------------------------------------------------------------------------ | -------------- |
-| `security-secrets.yml`    | 4 Jobs | `gitleaks` (isoliert, `pull-requests:read`) + `secret-scan` (trufflehog + pattern + report, `contents:read`) | 2              |
-| `security-deps.yml`       | 5 Jobs | 1 Job `dependency-scan`, Steps behalten ihre `if:`-Guards                                                    | 4              |
-| `security-containers.yml` | 4 Jobs | 1 Job `container-scan`                                                                                       | 3              |
-| `security-config.yml`     | 5 Jobs | 1 Job `config-scan`                                                                                          | 4              |
+## Trade-off (not to be waved away)
 
-## Trade-off (nicht wegwischen)
+For `secrets` the split is partly deliberate: `gitleaks` runs with a scoped
+per-job `pull-requests: read` (least privilege, documented in REVIEW.md and
+CHANGELOG.md — gitleaks-action v3 enumerates PR commits via the pulls API).
+**Decision: stay conservative.** `gitleaks` remains its own job. `trufflehog` +
+`pattern-detection` + `report` move into one `secret-scan` job with only
+`contents: read`. Least privilege stays clean and this saves 2 runners instead
+of 3.
 
-Der Split ist bei `secrets` teils absichtlich: `gitleaks` läuft mit scoped
-per-Job `pull-requests: read` (least-privilege, dokumentiert in REVIEW.md und
-CHANGELOG.md — gitleaks-action v3 enumeriert PR-Commits über die pulls-API).
-**Entscheidung: konservativ.** `gitleaks` bleibt eigener Job. `trufflehog` +
-`pattern-detection` + `report` gehen in einen `secret-scan`-Job mit nur
-`contents: read`. Least-Privilege bleibt sauber, spart 2 statt 3 Runner.
+For `deps`/`containers`/`config`, all jobs already share the workflow-level
+permissions and differ only in their `if:` conditions. Merging each into a
+single job is permission-neutral.
 
-Bei `deps`/`containers`/`config` teilen sich alle Jobs bereits die
-workflow-level Permissions; nur die `if:`-Conditions unterscheiden. Merge zu
-je 1 Job ist permission-neutral.
+## Mechanics
 
-## Mechanik
+- **Merged job = 1 checkout + sequential steps.** Every step keeps its original
+  job `if:` condition, now as a step `if:`
+  (e.g. `if: inputs.language == 'go' || inputs.language == 'multi'`).
+- **Setup union:** the deps job needs Go, Node and Python setup, each behind the
+  matching step `if:`. The language guards prevent unnecessary installs.
+- **`security-report` becomes the final step.** Job result refs
+  (`needs.X.result`) do not work inside a single job. Replacement: step `id:`
+  plus `steps.<id>.outcome` in the report table. Every scan step whose result
+  belongs in the report gets an `id:`.
+- **`continue-on-error`:** steps now run sequentially, so a step with `exit 1`
+  would abort the report step. The existing jobs already use
+  `|| true`/`continue-on-error` widely. Every scan step that could end fatally
+  but whose report must still run gets `continue-on-error: true`. The report
+  step itself runs with `if: always()`.
+- **`timeout-minutes`:** merged job = sum/union of the old step timeouts (an
+  upper bound, no need to be stingy).
 
-- **Merged Job = 1 Checkout + sequenzielle Steps.** Jeder Step behält seine
-  ursprüngliche Job-`if:`-Bedingung, jetzt als Step-`if:`
-  (z.B. `if: inputs.language == 'go' || inputs.language == 'multi'`).
-- **Setup-Union:** deps-Job braucht Go+Node+Python-Setup, jeweils hinter dem
-  passenden Step-`if:`. Die Sprach-Guards verhindern unnötige Installs.
-- **`security-report` → letzter Step.** Job-Result-Refs (`needs.X.result`)
-  gehen im Single-Job nicht. Ersatz: Step-`id:` + `steps.<id>.outcome` in der
-  Report-Tabelle. Jeder Scan-Step, dessen Ergebnis in den Report soll, bekommt
-  `id:`.
-- **`continue-on-error`:** Steps laufen jetzt sequenziell — ein Step mit
-  `exit 1` würde den Report-Step abbrechen. Die bestehenden Jobs nutzen bereits
-  `|| true`/`continue-on-error` breit. Jeder Scan-Step, der fatal enden könnte
-  und dessen Report trotzdem laufen muss, bekommt `continue-on-error: true`.
-  Der Report-Step selbst läuft `if: always()`.
-- **`timeout-minutes`:** Merged Job = Summe/Union der alten Step-Timeouts
-  (obere Grenze, nicht knausern).
+### Report reference mapping
 
-### Report-Referenz-Mapping
+Instead of `needs.<job>.result`, use `steps.<id>.outcome`:
 
-Statt `needs.<job>.result` → `steps.<id>.outcome`:
-
-- secrets `secret-scan`: `trufflehog` + `pattern-detection` Step-Outcomes;
-  gitleaks bleibt eigener Job, Report referenziert `needs.gitleaks.result`
-  (secret-scan `needs: [gitleaks]` behalten, nur für die Report-Zeile).
+- secrets `secret-scan`: `trufflehog` + `pattern-detection` step outcomes;
+  gitleaks stays its own job and the report references `needs.gitleaks.result`
+  (keep `needs: [gitleaks]` on secret-scan, only for the report row).
 - deps `dependency-scan`: `dependency-review`, `go-audit`, `js-audit`,
-  `python-audit` Step-Outcomes.
+  `python-audit` step outcomes.
 - containers `container-scan`: `trivy`, `grype`, `image-analysis`.
 - config `config-scan`: `trivy-config`, `terraform`, `kubernetes`, `ansible`.
 
-Ein per-`if:` übersprungener Step hat Outcome `skipped` → korrekt in der
-Tabelle.
+A step skipped by its `if:` has outcome `skipped`, which is correct in the
+table.
 
-## Breaking Change
+## Breaking change
 
-Job-Merge ändert die Status-Check-Kontext-Namen. Alte Kontexte
-(`Audit Go`, `Scan with Trivy`, `Create Report`, …) verschwinden, neuer
-Kontext `<Scan-Job-Name>`. Branch-Protection/Ruleset-Anker in Consumer-Repos,
-die auf die alten Namen zeigen, brechen.
+Merging jobs changes the status-check context names. The old contexts
+(`Audit Go`, `Scan with Trivy`, `Create Report`, …) disappear and are replaced
+by a single `<scan job name>` context. Branch-protection and ruleset anchors in
+consumer repos that point at the old names will break.
 
 **Handling:**
 
-1. Neuen Datums-Tag cutten (kein `@main` für Consumer).
-2. `### ⚠ BREAKING`-Heading im CHANGELOG-Eintrag des Tags: betroffene
-   Workflows + neue Job-Namen + Migrationsschritt "Ruleset/branch-protection
-   required-status-check-Anker auf neue Kontext-Namen umstellen".
-3. AGENTS.md + README Job-Count-Referenzen aktualisieren (24 Workflows bleibt,
-   aber Job-Zahlen/Beschreibungen anpassen).
+1. Cut a new date tag (no `@main` for consumers).
+2. Add a `### ⚠ BREAKING` heading to that tag's CHANGELOG entry: affected
+   workflows, new job names and the migration step "repoint
+   ruleset/branch-protection required-status-check anchors at the new context
+   names".
+3. Update the job-count references in AGENTS.md and README (24 workflows stays,
+   but job counts and descriptions need adjusting).
 
-## Neue Job-Namen (Status-Check-Kontexte)
+## New job names (status-check contexts)
 
-- `security-secrets.yml`: `Scan with Gitleaks` (unverändert) + `Scan Secrets`
+- `security-secrets.yml`: `Scan with Gitleaks` (unchanged) + `Scan Secrets`
 - `security-deps.yml`: `Scan Dependencies`
 - `security-containers.yml`: `Scan Container Image`
 - `security-config.yml`: `Scan Configuration`
 
 ## Testing
 
-- `actionlint` auf die 4 geänderten Dateien (Syntax + Expression-Checks).
-- YAML-Expression-Syntax manuell prüfen (Step-Outcome-Refs).
-- **Kein** Consumer-Live-Test in dieser Session (bräuchte Tag-Push). Als
-  manueller Schritt geflaggt: nach Tag-Cut in 1–2 Consumer-Repos gegen den
-  neuen Tag testen, bevor breit ausgerollt wird.
+- `actionlint` on the 4 changed files (syntax + expression checks).
+- Check the YAML expression syntax manually (step outcome refs).
+- **No** consumer live test in this session (that would need a tag push).
+  Flagged as a manual step: after cutting the tag, test 1–2 consumer repos
+  against the new tag before rolling it out broadly.
 
-## Scope-Grenzen (skipped)
+## Scope boundaries (skipped)
 
-- Matrix-basierter Merge — würde weiter auf N Runner fan-out, defeats purpose.
-- `security-code.yml` / `security-sbom.yml` — nicht im Card-Scope.
-- Kein Verhalten der Scans selbst geändert, nur Job-Topologie.
+- A matrix-based merge — would still fan out to N runners, which defeats the
+  purpose.
+- `security-code.yml` / `security-sbom.yml` — outside the card scope.
+- No change to the behaviour of the scans themselves, only to job topology.

--- a/scripts/drift-issue-body.sh
+++ b/scripts/drift-issue-body.sh
@@ -35,9 +35,9 @@ render)
   base="${2:-}"
   summary="${3:-}"
   clean="$(printf '%s' "$base" | strip_block)"
-  # Trailing Leerzeilen des Basis-Bodys kappen, damit der Abstand stabil ist.
-  # awk statt `sed -e :a -e '/^\n*$/{$d;N;ba}'`: das sed-Idiom ist GNU-only und
-  # bricht auf BSD-sed (macOS) mit "unexpected EOF (pending }'s)" ab.
+  # Trim trailing blank lines off the base body so the spacing stays stable.
+  # awk instead of `sed -e :a -e '/^\n*$/{$d;N;ba}'`: that sed idiom is GNU-only
+  # and aborts on BSD sed (macOS) with "unexpected EOF (pending }'s)".
   clean="$(printf '%s\n' "$clean" | awk '
     /^[[:space:]]*$/ { blanks = blanks $0 "\n"; next }
     { printf "%s", blanks; blanks = ""; print }
@@ -52,14 +52,14 @@ render)
   ;;
 addresses)
   body="${2:-}"
-  # Zeilen im Block: "<action> <address>". Adresse = zweites Feld. Sortiert,
-  # eindeutig — die Aktions-Spalte bewusst ignoriert, damit ein Wechsel
-  # update->replace derselben Resource nicht als Delta zählt, wenn die
-  # Adressmenge gleich bleibt. (Delta = Adressmenge, siehe Konzept.)
-  # Nur Zeilen im Code-Fence innerhalb des Blocks zählen — Heading und
-  # Leerzeilen bleiben draussen. Adresse = alles nach dem ersten Space (die
-  # Aktions-Spalte ist per join("+") space-frei, die Adresse kann Spaces in
-  # for_each-Keys enthalten, z. B. authentik_group.admins["my key"]).
+  # Lines inside the block: "<action> <address>". Sorted and unique — the action
+  # column is deliberately ignored so a switch from update->replace on the same
+  # resource does not count as a delta while the address set stays the same.
+  # (Delta = address set.)
+  # Only lines inside the code fence within the block count — heading and blank
+  # lines stay out. Address = everything after the first space (the action
+  # column is space-free thanks to join("+"), while the address may contain
+  # spaces in for_each keys, e.g. authentik_group.admins["my key"]).
   printf '%s' "$body" |
     awk -v s="$START" -v e="$END" '
         $0 == s { inb = 1; next }

--- a/scripts/drift-summary.sh
+++ b/scripts/drift-summary.sh
@@ -4,25 +4,25 @@
 # Reads the plan JSON on stdin, writes one line per drifting resource to
 # stdout: "<action> <address>" (e.g. "update authentik_group.admins").
 #
-# LEVEL-A GRENZE (Wert-Freiheit): die jq-Query liest ausschliesslich
-# `.address` und `.change.actions`. Sie fasst `.change.before`/`.after`
-# NIE an, damit kein Attributwert (der Secrets enthalten kann, siehe
-# TF_VAR_authentik_token) je in ein GitHub-Issue gelangt. Wer die Query
-# erweitert, bricht zuerst Assertion 3 in test-drift-summary.sh.
+# LEVEL-A BOUNDARY (value freedom): the jq query reads `.address` and
+# `.change.actions` exclusively. It NEVER touches `.change.before`/`.after`,
+# so no attribute value (which may contain secrets, see
+# TF_VAR_authentik_token) can ever reach a GitHub issue. Extending the query
+# breaks assertion 3 in test-drift-summary.sh first.
 #
-# no-op-Resourcen (kein echter Drift) werden herausgefiltert. Der Output ist
-# bei CAP Zeilen gedeckelt (Job-Output-Limit 1 MB). Fehler in `jq` oder
-# kaputter Input -> leerer Output, Exit 0: ein kaputter Summary darf die
-# Drift-Meldung selbst nie unterdrücken.
+# no-op resources (not real drift) are filtered out. The output is capped at
+# CAP lines (job output limit 1 MB). An error in `jq` or a broken input ->
+# empty output, exit 0: a broken summary must never suppress the drift report
+# itself.
 set -uo pipefail
 
 CAP=50
 
 INPUT="$(cat)"
 
-# Echte Änderungen: no-op (kein Drift) und read (aufgeschobene
-# Data-Source-Reads, keine Konfig-Drift, nur Rauschen) rausfiltern. Replace ist
-# ["delete","create"] und bleibt drin. Nur .address + .change.actions gelesen.
+# Real changes only: filter out no-op (no drift) and read (deferred data-source
+# reads, not config drift, just noise). Replace is ["delete","create"] and
+# stays in. Only .address + .change.actions are read.
 LINES="$(printf '%s' "$INPUT" | jq -r '
   .resource_changes // []
   | map(select((.change.actions // []) != ["no-op"] and (.change.actions // []) != ["read"]))
@@ -30,7 +30,7 @@ LINES="$(printf '%s' "$INPUT" | jq -r '
   | "\(.change.actions | join("+")) \(.address)"
 ' 2>/dev/null)" || LINES=""
 
-# Leerer Plan / kaputter Input -> leerer Output, Exit 0.
+# Empty plan / broken input -> empty output, exit 0.
 [ -z "$LINES" ] && exit 0
 
 TOTAL="$(printf '%s\n' "$LINES" | wc -l)"

--- a/scripts/tests/test-drift-issue-body.sh
+++ b/scripts/tests/test-drift-issue-body.sh
@@ -26,13 +26,13 @@ echo "$BODY1" | grep -q '<!-- drift-summary:start -->' || fail "start marker mis
 echo "$BODY1" | grep -q '<!-- drift-summary:end -->' || fail "end marker missing"
 echo "$BODY1" | grep -q 'authentik_group.admins' || fail "summary content missing"
 
-# 1 — IDEMPOTENZ: re-render über einen Body, der den Block schon hat, ersetzt
-# ihn, dupliziert ihn nicht (sonst wächst der Body bei wöchentlichem Cron).
+# 1 — IDEMPOTENCE: re-rendering over a body that already has the block replaces
+# it instead of duplicating it (otherwise the weekly cron grows the body).
 BODY2="$("$SCRIPT" render "$BODY1" "$SUMMARY")"
 COUNT="$(echo "$BODY2" | grep -c '<!-- drift-summary:start -->')"
 [ "$COUNT" -eq 1 ] || fail "marker block duplicated on re-render (got $COUNT)"
 
-# 2 — addresses <body> -> sortierte, eindeutige Adressliste aus dem Block.
+# 2 — addresses <body> -> sorted, unique address list from the block.
 ADDRS="$("$SCRIPT" addresses "$BODY1")"
 EXPECTED="authentik_application.grafana
 authentik_group.admins"
@@ -42,21 +42,21 @@ $ADDRS
 want:
 $EXPECTED"
 
-# 3 — REIHENFOLGE-UNABHÄNGIGKEIT: gleiche Adressen in anderer Summary-Reihenfolge
-# -> identische addresses-Ausgabe (sonst falsches Delta bei jedem Cron).
+# 3 — ORDER INDEPENDENCE: the same addresses in a different summary order yield
+# identical addresses output (otherwise every cron run reports a bogus delta).
 SUMMARY_REORDERED="create authentik_application.grafana
 update authentik_group.admins"
 BODY_R="$("$SCRIPT" render "$BASE" "$SUMMARY_REORDERED")"
 ADDRS_R="$("$SCRIPT" addresses "$BODY_R")"
 [ "$ADDRS" = "$ADDRS_R" ] || fail "address extraction depends on order"
 
-# 4 — leerer Block (kein Drift-Summary) -> addresses leer.
+# 4 — no block (no drift summary) -> addresses is empty.
 EMPTY_ADDRS="$("$SCRIPT" addresses "$BASE")"
 [ -z "$EMPTY_ADDRS" ] || fail "addresses on body without block must be empty"
 
-# 5 — Adresse mit Space (for_each-String-Key) wird vollständig extrahiert, nicht
-# am ersten Space abgeschnitten (sonst kollabieren zwei Adressen unter sort -u
-# und ein Delta wird verschluckt).
+# 5 — an address containing a space (for_each string key) is extracted in full
+# rather than cut at the first space (otherwise two addresses collapse under
+# sort -u and a delta is swallowed).
 SPACED='update authentik_group.admins["my key"]
 update authentik_group.admins["other key"]'
 BODY_S="$("$SCRIPT" render "$BASE" "$SPACED")"
@@ -69,9 +69,9 @@ $ADDRS_S
 want:
 $EXP_S"
 
-# 6 — Trailing Whitespace-Zeilen im Basis-Body werden gekappt, damit der
-# Abstand vor dem Marker-Block stabil bleibt. Command-Substitution allein
-# strippt nur echte Leerzeilen am Ende, nicht eine Zeile aus Spaces.
+# 6 — trailing whitespace-only lines in the base body are trimmed so the spacing
+# before the marker block stays stable. Command substitution alone strips only
+# genuinely empty trailing lines, not a line made of spaces.
 BASE_TRAILING="$BASE
 
    "

--- a/scripts/tests/test-drift-issue-parity.sh
+++ b/scripts/tests/test-drift-issue-parity.sh
@@ -4,7 +4,7 @@
 #
 # The workflow keeps its own copy on purpose (a reusable workflow cannot check
 # out its own ref — see the comment above the `Upsert drift issue` step), and
-# the contract there says "Gleichheit von Hand". That hand-sync drifted twice
+# the contract there said "kept equal by hand". That hand-sync drifted twice
 # and both times was caught by eye. This closes it.
 #
 # Behaviour-based, not textual: the workflow's `run:` block is extracted from

--- a/scripts/tests/test-drift-summary-parity.sh
+++ b/scripts/tests/test-drift-summary-parity.sh
@@ -4,7 +4,7 @@
 #
 # The workflow keeps its own copy on purpose (it checks out the consumer repo,
 # so the script is not on disk at runtime — see the comment above the step),
-# and the contract there says "Gleichheit von Hand". Nothing enforced it. This
+# and the contract there said "kept equal by hand". Nothing enforced it. This
 # closes it, same pattern as test-drift-issue-parity.sh.
 #
 # Behaviour-based, not textual: the `run:` block is extracted from the YAML

--- a/scripts/tests/test-drift-summary-parity.sh
+++ b/scripts/tests/test-drift-summary-parity.sh
@@ -77,7 +77,7 @@ $WORKFLOW_OUT
 script:
 $SCRIPT_OUT"
 
-# 2 — WERT-FREIHEIT: the level-A comment above the step claims the inline query
+# 2 — VALUE FREEDOM: the level-A comment above the step claims the inline query
 # never touches .change.before/.after. The fixture carries LEAKME markers in
 # both, so a query that widened its field selection shows up right here. Drift
 # on this one would be a secret leak into a GitHub issue body.

--- a/scripts/tests/test-drift-summary.sh
+++ b/scripts/tests/test-drift-summary.sh
@@ -12,49 +12,49 @@ fail() {
   exit 1
 }
 
-# 1 — driftende Adressen erscheinen mit Aktion, no-op wird gefiltert.
+# 1 — drifting addresses appear with their action, no-op is filtered out.
 OUT="$(cat "$FIXTURE" | "$SCRIPT")"
 echo "$OUT" | grep -q 'authentik_group.admins' || fail "update address missing"
 echo "$OUT" | grep -q 'authentik_application.grafana' || fail "create address missing"
 echo "$OUT" | grep -q 'authentik_provider_oauth2.grafana' || fail "delete address missing"
 echo "$OUT" | grep -q 'authentik_group.replaced' || fail "replace address missing"
 
-# 2 — no-op darf nicht im Summary stehen (kein echter Drift).
+# 2 — no-op must not appear in the summary (not real drift).
 if echo "$OUT" | grep -q 'authentik_flow.unchanged'; then
   fail "no-op resource must be filtered out"
 fi
 
-# 2b — data-source read (aufgeschoben) ist kein Drift, muss gefiltert sein.
+# 2b — a deferred data-source read is not drift and must be filtered out.
 if echo "$OUT" | grep -q 'data.authentik_user.lookup'; then
   fail "read data source must be filtered out"
 fi
 
-# 2c — Adresse mit Space (for_each-String-Key) bleibt vollständig erhalten.
+# 2c — an address containing a space (for_each string key) stays intact.
 echo "$OUT" | grep -qF 'authentik_group.spaced["my key"]' || fail "spaced address truncated/missing"
 
-# 3 — WERT-FREIHEIT (Anker der Level-A-Grenze): kein Attributwert aus
-# before/after darf im Output landen. Failt zuerst, wenn die Query je
-# .change.before/.after anfasst.
+# 3 — VALUE FREEDOM (anchor of the Level-A boundary): no attribute value from
+# before/after may reach the output. This fails first if the query ever touches
+# .change.before/.after.
 if echo "$OUT" | grep -q 'LEAKME'; then
   fail "attribute value from before/after leaked into output"
 fi
 
-# 4 — Deckelung: viele Resourcen -> Output <= 50 Zeilen + Hinweiszeile.
+# 4 — capping: many resources -> output <= 50 lines plus a notice line.
 BIG="$(jq -n '{resource_changes: [range(80) | {address: ("authentik_group.g\(.)"), change: {actions: ["update"]}}]}' |
   "$SCRIPT")"
 LINES="$(echo "$BIG" | wc -l)"
 [ "$LINES" -le 51 ] || fail "output not capped (got $LINES lines)"
-echo "$BIG" | grep -qi 'truncat\|more\|weitere' || fail "cap notice missing when truncated"
+echo "$BIG" | grep -qi 'truncat\|more' || fail "cap notice missing when truncated"
 
-# 5 — kaputter Input -> Exit 0, leerer/harmloser Output (Summary darf die
-# Drift-Meldung nie unterdrücken).
+# 5 — broken input -> exit 0 and empty/harmless output (the summary must never
+# suppress the drift report).
 set +e
 echo 'not json {{{' | "$SCRIPT" >/dev/null 2>&1
 RC=$?
 set -e
 [ "$RC" -eq 0 ] || fail "broken input must exit 0 (got $RC)"
 
-# 6 — leerer Plan (keine changes) -> leerer Output, Exit 0.
+# 6 — empty plan (no changes) -> empty output, exit 0.
 EMPTY="$(echo '{"resource_changes": []}' | "$SCRIPT")"
 [ -z "$EMPTY" ] || fail "empty plan must yield empty output"
 


### PR DESCRIPTION
## Summary

- Translate the last German-language content in this public repo to English: the
  comment blocks in `drift-summary.sh`, `drift-issue-body.sh` and their four
  self-check scripts, the inline-copy rationale comments in
  `deploy-terraform.yml`, `ops-drift-issue.yml` and `release-helm.yml`, and the
  two July 2026 design specs under `docs/superpowers/specs/`.
- Two quoted German contract phrases in `CHANGELOG.md` ("Gleichheit von Hand")
  are rendered in English; the surrounding historical entries are untouched.
- The Level-A guarantee is now labelled `VALUE FREEDOM` consistently across
  `drift-summary.sh`, `deploy-terraform.yml`, `test-drift-summary.sh` and
  `test-drift-summary-parity.sh`, so one grep finds every anchor.
- Comments and prose only, with one exception: the cap-notice assertion in
  `test-drift-summary.sh` no longer accepts `weitere` as a match, since the
  script it checks emits English only.

## Test plan

- [x] `just lint` — yamllint, jq, actionlint and Prettier all clean
- [x] `just test` — all five suites pass, including both parity checks that
      compare the inline workflow copies against their standalone scripts
- [x] Repo-wide rescan for umlauts and German keywords returns no hits outside
      the owner's name. Note: the first push still contained one German term,
      `WERT-FREIHEIT` in `test-drift-summary-parity.sh:80` — an all-caps
      compound with no umlaut that the keyword scan missed. Caught in review and
      fixed in b7768a6; the rescan is clean as of that commit.
