### PR TITLE
refactor(ci-go): pass Get version context values through env

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -142,11 +142,16 @@ jobs:
 
       - name: Get version
         id: version
+        env:
+          REF: ${{ github.ref }}
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
         run: |
-          if [[ "${{ github.ref }}" =~ ^refs/tags/v.* ]]; then
-            VERSION="${{ github.ref_name }}"
+          set -euo pipefail
+          if [[ "$REF" =~ ^refs/tags/v.* ]]; then
+            VERSION="$REF_NAME"
           else
-            VERSION="${{ github.sha }}"
+            VERSION="$SHA"
             VERSION="${VERSION:0:8}"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,19 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   `actions/setup-node` step, without which `just lint` has no Node in the
   runner. Consumers are unaffected — this is local tooling and this repo's own
   CI, no reusable workflow changes behaviour.
+- **`ci-go.yml` passes the `Get version` step's context values through `env:`
+  instead of interpolating them into the `run:` block.** The step read
+  `${{ github.ref }}`, `${{ github.ref_name }}` and `${{ github.sha }}`
+  directly, and the first of those drives a `[[ =~ ]]` branch — git permits
+  `` ` ``, `$`, `(` and `)` in ref names, so anyone with push access could get
+  a branch or tag name to reach the shell as code rather than as data. The
+  three values become step-level `env:` entries read as quoted shell
+  variables, and the block gains `set -euo pipefail`. Same pattern as the
+  `ci-ansible.yml` entry above. This was the last `${{ }}` interpolation in a
+  `run:` block of this file other than `pre-build-commands` (lines 184 and
+  320), which is caller-supplied shell executed by design and therefore cannot
+  move to `env:`. The resolved version string is unchanged, and no input
+  signature or default changes.
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

- `Get version` moves `github.ref`, `github.ref_name` and `github.sha` into
  `env:` and reads them as quoted shell variables. The first drives a
  `[[ =~ ]]` branch, and git permits `` ` ``, `$`, `(` and `)` in ref names,
  so a branch or tag pushed by anyone with write access reached the shell as
  code rather than as data.
- The block gains `set -euo pipefail`. Same pattern as #279
  (`ci-ansible.yml`).
- Scope shrank after rebasing onto #285, which already fixed the two
  `Build and test binary` blocks and removed the repo-wide SC2086 mute.

`run: ${{ inputs.pre-build-commands }}` (lines 184 and 320) stays as it is —
that input is caller-supplied shell by design and cannot move to `env:`.

## Test plan

- [x] `just lint` passes — and now genuinely covers SC2086, since #285 dropped
      the repo-wide mute
- [x] `just test` passes
- [x] `actionlint` reports 0 SC2086 findings for `ci-go.yml`
- [x] No `${{ }}` interpolation left in a `run:` block of `ci-go.yml` other
      than the two deliberate `pre-build-commands` lines
- [ ] CI green