### PR TITLE
fix(ci-go): reject test-env-vars entries containing a newline

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -212,6 +212,13 @@ jobs:
           TEST_ENV_VARS: ${{ inputs.test-env-vars }}
         run: |
           set -euo pipefail
+          # $GITHUB_ENV is line-based: a newline inside a key or value would inject
+          # additional environment entries for every following step.
+          if ! printf '%s' "$TEST_ENV_VARS" \
+            | jq -e 'to_entries | any(.[]; ((.key, (.value | tostring)) | contains("\n"))) | not' >/dev/null; then
+            echo "Error: multi-line test-env-vars keys or values are not supported" >&2
+            exit 1
+          fi
           printf '%s' "$TEST_ENV_VARS" \
             | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
 
@@ -354,6 +361,13 @@ jobs:
             "$POSTGRES_USER" "$POSTGRES_PASSWORD" "$POSTGRES_DB" >> "$GITHUB_ENV"
 
           if [ -n "${TEST_ENV_VARS:-}" ]; then
+            # $GITHUB_ENV is line-based: a newline inside a key or value would inject
+            # additional environment entries for every following step.
+            if ! printf '%s' "$TEST_ENV_VARS" \
+              | jq -e 'to_entries | any(.[]; ((.key, (.value | tostring)) | contains("\n"))) | not' >/dev/null; then
+              echo "Error: multi-line test-env-vars keys or values are not supported" >&2
+              exit 1
+            fi
             printf '%s' "$TEST_ENV_VARS" \
               | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,23 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ### Fixed
 
+- **`ci-go.yml` rejects `test-env-vars` entries containing a newline instead of
+  writing them to `$GITHUB_ENV`.** The step renders each entry as
+  `jq -r 'to_entries[] | "\(.key)=\(.value)"'`, and `jq -r` prints a JSON `\n`
+  as a real line break — `$GITHUB_ENV` is line-based, so one entry with a
+  newline in its key or value became several. Whoever controls `test-env-vars`
+  could thereby set arbitrary environment variables for every following step of
+  the job, `PATH`, `GOFLAGS` or `LD_PRELOAD` included, which also apply to
+  `go test`. A guard now fails the step with
+  `Error: multi-line test-env-vars keys or values are not supported` before
+  anything is written. Both jobs (`test-and-lint`, `test-and-lint-postgres`) carry the
+  guard, and `scripts/tests/test-ci-go-test-env-guard.sh` reads the expression
+  out of the workflow so the check cannot drift from it. Distinct from the
+  quoting fix above: that one closed the shell path, this one the file-format
+  path, and the defect predates it. Not breaking for known consumers — they
+  pass single-line entries, which are unaffected; only a multi-line one, which
+  never reached the environment intact anyway, now fails loudly instead of
+  silently injecting.
 - **`ci-gitops.yml` no longer fails when `gitrepos/production.yaml` is
   absent.** The GitRepo existence step exited 1 on a missing file, and
   `enable-gitrepo-validation` defaults to `true` — so every GitOps consumer

--- a/justfile
+++ b/justfile
@@ -105,6 +105,7 @@ test:
     scripts/tests/test-drift-issue-body.sh
     scripts/tests/test-drift-issue-parity.sh
     scripts/tests/test-workflow-counts.sh
+    scripts/tests/test-ci-go-test-env-guard.sh
 
 # fmt → format Markdown and JSON in place
 fmt:

--- a/scripts/tests/test-ci-go-test-env-guard.sh
+++ b/scripts/tests/test-ci-go-test-env-guard.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# $GITHUB_ENV is line-based, so a newline inside a `test-env-vars` value turns
+# one entry into several — whoever controls that input can set PATH, GOFLAGS or
+# LD_PRELOAD for every following step of the job, `go test` included. ci-go.yml
+# rejects such values before writing the file; this checks the rejecting jq
+# expression actually does that.
+#
+# The expression is read out of ci-go.yml rather than repeated here, so the two
+# cannot drift: a guard edited in the workflow is the guard under test. Both
+# jobs (test-and-lint, test-and-lint-postgres) carry it and both are checked.
+#
+# Run: scripts/tests/test-ci-go-test-env-guard.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+WORKFLOW="$REPO/.github/workflows/ci-go.yml"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+command -v jq >/dev/null 2>&1 || fail "jq required"
+
+# One line per occurrence, leading whitespace and the trailing redirect stripped.
+GUARDS="$(sed -n "s/.*| jq -e '\(.*\)' >\/dev\/null.*/\1/p" "$WORKFLOW")"
+[ -n "$GUARDS" ] || fail "no 'jq -e' guard found in ci-go.yml"
+
+COUNT="$(grep -c . <<<"$GUARDS")"
+[ "$COUNT" -eq 2 ] ||
+  fail "expected the guard in both jobs, found $COUNT occurrence(s) in ci-go.yml"
+
+# Both occurrences must be the same expression — one job hardened and the other
+# left behind is the failure mode this repo already had.
+[ "$(sort -u <<<"$GUARDS" | grep -c .)" -eq 1 ] ||
+  fail "the two guards in ci-go.yml differ; they must be identical"
+
+GUARD="$(head -n 1 <<<"$GUARDS")"
+
+# accept <label> <json> — value has no newline, the step must proceed.
+accept() {
+  printf '%s' "$2" | jq -e "$GUARD" >/dev/null ||
+    fail "guard rejects a legitimate input: $1"
+}
+
+# reject <label> <json> — value carries a newline, the step must stop.
+reject() {
+  if printf '%s' "$2" | jq -e "$GUARD" >/dev/null 2>&1; then
+    fail "guard accepts an injecting input: $1"
+  fi
+}
+
+accept "single-line entries" '{"API_URL":"http://localhost","MSG":"a b"}'
+accept "empty object" '{}'
+accept "non-string values" '{"PORT":5432,"DEBUG":true}'
+accept "value containing a literal backslash-n" '{"MSG":"a\\nb"}'
+reject "newline in a value" '{"MSG":"harmless\nPATH=/tmp/evil"}'
+reject "newline in the second of two values" '{"API":"a b","MSG":"x\nGOFLAGS=-tags=evil"}'
+reject "trailing newline in a value" '{"MSG":"value\n"}'
+
+# A key carries the same injection: `{"A\nPATH=/tmp/evil":"x"}` renders as two
+# lines, the second of which is a complete assignment.
+reject "newline in a key" '{"MSG\nPATH=/tmp/evil":"x"}'
+reject "newline in the second of two keys" '{"API":"a b","MSG\nLD_PRELOAD=/tmp/evil.so":"x"}'
+
+# Invalid JSON already failed the step before the guard existed (`set -euo
+# pipefail` plus a non-zero jq); it must keep failing rather than fall through.
+reject "invalid JSON" 'not-json'
+
+echo "PASS: ci-go.yml test-env-vars newline guard"


### PR DESCRIPTION
## Summary

- `ci-go.yml` wrote `test-env-vars` entries to `$GITHUB_ENV` via `jq -r 'to_entries[] | "\(.key)=\(.value)"'`. `jq -r` prints a JSON `\n` as a real line break and `$GITHUB_ENV` is line-based, so an entry with a newline in its key or value became several — whoever controls the input could set `PATH`, `GOFLAGS` or `LD_PRELOAD` for every following step of the job, `go test` included.
- Both jobs (`test-and-lint`, `test-and-lint-postgres`) now reject such entries before writing anything. Distinct from the earlier quoting fix: that closed the shell path, this one the file-format path.
- Not breaking for known consumers — they pass single-line entries, which are unaffected; a multi-line one never reached the environment intact anyway and now fails loudly.

## Test plan

- [ ] `scripts/tests/test-ci-go-test-env-guard.sh` — reads the guard out of `ci-go.yml` (no duplicated logic), asserts both jobs carry the same expression, and covers single-line, empty, non-string, literal-backslash-n, newline-in-value, newline-in-key, trailing-newline and invalid-JSON inputs
- [ ] `just lint` green (yamllint, actionlint + shellcheck, prettier)
- [ ] `just test` green
