### PR TITLE
refactor(ci-go)!: merge test-and-lint-postgres into test-and-lint

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -100,7 +100,7 @@ on:
     outputs:
       coverage:
         description: 'Test coverage percentage'
-        value: ${{ jobs.test-and-lint.outputs.coverage || jobs.test-and-lint-postgres.outputs.coverage }}
+        value: ${{ jobs.test-and-lint.outputs.coverage }}
       version:
         description: 'Version extracted from git ref or sha'
         value: ${{ jobs.setup.outputs.version }}
@@ -161,145 +161,27 @@ jobs:
     name: Test & Lint
     runs-on: ubuntu-latest
     needs: setup
-    if: needs.setup.outputs.should-run-tests == 'true' && !inputs.enable-postgres
+    if: needs.setup.outputs.should-run-tests == 'true'
     outputs:
       coverage: ${{ steps.coverage.outputs.coverage }}
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: ${{ inputs.go-version }}
-          check-latest: true
-          cache: true
-          cache-dependency-path: go.sum
-
-      - name: Run pre-build commands
-        if: inputs.pre-build-commands != ''
-        run: ${{ inputs.pre-build-commands }}
-
-      - name: Download and verify dependencies
-        run: |
-          go mod download
-          go mod verify
-
-      - name: Run go vet
-        run: go vet ./...
-
-      - name: Check formatting
-        run: |
-          if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then
-            echo "::error::The following files are not formatted:"
-            gofmt -s -l .
-            exit 1
-          fi
-
-      - name: Run staticcheck
-        uses: dominikh/staticcheck-action@9716614d4101e79b4340dd97b10e54d68234e431 # v1.4.1
-        with:
-          # renovate: datasource=github-releases depName=dominikh/go-tools
-          version: '2025.1.1'
-          install-go: false
-
-      - name: Set test environment variables
-        if: inputs.test-env-vars != ''
-        env:
-          TEST_ENV_VARS: ${{ inputs.test-env-vars }}
-        run: |
-          set -euo pipefail
-          # $GITHUB_ENV is line-based: a newline inside a key or value would inject
-          # additional environment entries for every following step.
-          if ! printf '%s' "$TEST_ENV_VARS" \
-            | jq -e 'to_entries | any(.[]; ((.key, (.value | tostring)) | contains("\n"))) | not' >/dev/null; then
-            echo "Error: multi-line test-env-vars keys or values are not supported" >&2
-            exit 1
-          fi
-          printf '%s' "$TEST_ENV_VARS" \
-            | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> "$GITHUB_ENV"
-
-      - name: Run tests with coverage
-        env:
-          GO_ENV: test
-        run: |
-          go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
-
-      - name: Run integration tests
-        if: inputs.enable-integration-tests && hashFiles('tests/integration/**') != ''
-        run: |
-          go test -v -tags=integration -timeout=10m ./tests/integration/...
-
-      - name: Generate coverage report
-        id: coverage
-        run: |
-          go tool cover -html=coverage.out -o coverage.html
-          COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}')
-          echo "coverage=$COVERAGE" >> "$GITHUB_OUTPUT"
-          echo "Test coverage: $COVERAGE"
-
-      - name: Upload coverage to Codecov
-        if: inputs.enable-codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with:
-          files: ./coverage.out
-          flags: unittests
-          token: ${{ secrets.CODECOV_TOKEN }}
-        continue-on-error: true
-
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ inputs.artifact-name-prefix }}coverage-report
-          path: coverage.html
-          retention-days: 30
-
-      - name: Build and test binary
-        if: inputs.binary-path != ''
-        env:
-          BINARY_PATH: ${{ inputs.binary-path }}
-          VERSION: ${{ needs.setup.outputs.version }}
-        run: |
-          mkdir -p bin
-          BINARY_NAME=$(basename "$BINARY_PATH")
-          go build -ldflags="-s -w -X main.version=$VERSION" -o "bin/${BINARY_NAME}" "$BINARY_PATH"
-
-          if [ ! -f "bin/${BINARY_NAME}" ]; then
-            echo "::error::Binary was not created"
-            exit 1
-          fi
-
-          if [ ! -x "bin/${BINARY_NAME}" ]; then
-            echo "::error::Binary is not executable"
-            exit 1
-          fi
-
-          echo "Testing --version flag..."
-          if ! "./bin/${BINARY_NAME}" --version; then
-            echo "::warning::Binary --version command failed (not critical)"
-          fi
-
-          echo "Testing --help flag..."
-          if ! "./bin/${BINARY_NAME}" --help; then
-            echo "::warning::Binary --help command failed (not critical)"
-          fi
-
-          echo "Binary tests passed successfully"
-
-  test-and-lint-postgres:
-    name: Test & Lint (PostgreSQL)
-    runs-on: ubuntu-latest
-    needs: setup
-    if: needs.setup.outputs.should-run-tests == 'true' && inputs.enable-postgres
-    outputs:
-      coverage: ${{ steps.coverage.outputs.coverage }}
-
+    # `services:` takes no `if:`, so the service is gated on its image: an
+    # empty `image:` makes the runner skip the container, which is the
+    # documented way to declare a conditional service. Gating `ports:` instead
+    # does not work — an empty entry becomes a bare `-p` on the `docker create`
+    # line and fails the job — and leaving the mapping unconditional while the
+    # container runs would expose a Postgres seeded from the `postgres-*`
+    # defaults on localhost:5432 for every Go CI run in the org, including
+    # callers that never asked for one.
+    #
+    # Renovate's built-in github-actions manager does read service images, but
+    # skips any value containing `$` ("contains-variable"), so the marker below
+    # hands this one to the custom manager in the root `renovate.json`, which
+    # captures tag and digest and keeps the pin updated.
     services:
       postgres:
-        image: postgres:18-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
+        # renovate-expression: datasource=docker depName=postgres versioning=docker
+        image: ${{ inputs.enable-postgres && 'postgres:18-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15' || '' }}
         env:
           POSTGRES_DB: ${{ inputs.postgres-db }}
           POSTGRES_USER: ${{ inputs.postgres-user }}
@@ -351,14 +233,17 @@ jobs:
 
       - name: Set test environment variables
         env:
+          ENABLE_POSTGRES: ${{ inputs.enable-postgres }}
           POSTGRES_USER: ${{ inputs.postgres-user }}
           POSTGRES_PASSWORD: ${{ inputs.postgres-password }}
           POSTGRES_DB: ${{ inputs.postgres-db }}
           TEST_ENV_VARS: ${{ inputs.test-env-vars }}
         run: |
           set -euo pipefail
-          printf 'DATABASE_URL=postgres://%s:%s@localhost:5432/%s?sslmode=disable\n' \
-            "$POSTGRES_USER" "$POSTGRES_PASSWORD" "$POSTGRES_DB" >> "$GITHUB_ENV"
+          if [ "$ENABLE_POSTGRES" = "true" ]; then
+            printf 'DATABASE_URL=postgres://%s:%s@localhost:5432/%s?sslmode=disable\n' \
+              "$POSTGRES_USER" "$POSTGRES_PASSWORD" "$POSTGRES_DB" >> "$GITHUB_ENV"
+          fi
 
           if [ -n "${TEST_ENV_VARS:-}" ]; then
             # $GITHUB_ENV is line-based: a newline inside a key or value would inject
@@ -448,7 +333,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    needs: [setup, test-and-lint, test-and-lint-postgres]
+    needs: [setup, test-and-lint]
     if: >-
       always() &&
       inputs.enable-security-scans &&
@@ -548,7 +433,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    needs: [setup, test-and-lint, test-and-lint-postgres]
+    needs: [setup, test-and-lint]
     if: >-
       always() &&
       inputs.enable-codeql &&

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,33 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   deliberate. Scan behaviour is unchanged by this removal.
   **Migration:** remove the `file-patterns:` line from your call.
 
+- **`ci-go.yml` no longer has a `test-and-lint-postgres` job.** `test-and-lint`
+  and `test-and-lint-postgres` were byte-identical over their whole step
+  sequence except for the Postgres service container and the `DATABASE_URL`
+  line in `Set test environment variables`; every other change had to be made
+  twice, which is why earlier fixes repeatedly cited only one of the two
+  copies. The two were already mutually exclusive — each carried an `if:` on
+  `inputs.enable-postgres`, so exactly one ever ran per call — and they are now
+  a single `test-and-lint` job. Actions has no `if:` for `services:`, so the
+  container is gated on its image: an empty `image:` makes the runner skip the
+  service, which is the documented way to declare a conditional service. An
+  `enable-postgres: false` caller therefore gets no container, no listener on
+  `localhost:5432`, and no `DATABASE_URL` — the same as before the merge.
+  Gating the port mapping instead is not possible: an empty entry becomes a
+  bare `-p` on the `docker create` line and fails the job. Test behaviour is
+  unchanged for both values, and the `coverage` output keeps its value without
+  needing the `a || b` fallback.
+  Because Renovate's built-in github-actions manager skips any image value
+  containing `$`, the reference is picked up by a new custom manager in the
+  root `renovate.json` that captures tag and digest, so the SHA pin is still
+  updated automatically. (It goes in the root file, not `.github/renovate.json`
+  — Renovate uses the first config it finds and `renovate.json` comes first, so
+  a manager placed in the latter would never run.)
+  **Migration:** if you list `test-and-lint-postgres` as a required status
+  check, or reference it in a `needs:`/branch-protection ruleset, replace it
+  with `test-and-lint` — that context now covers both modes. Callers that only
+  pass `enable-postgres:` need no change.
+
 - **`ai-claude-review.yml` now fails the job when no review was posted.** The
   `anthropics/claude-code-action` workflow validation refuses to review a PR
   that changes a workflow file, but exits 0 — the `claude-review` check went
@@ -55,9 +82,11 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   escape: interpolation happens before the shell sees the line, so a value
   containing an apostrophe closed the string early and the remainder was parsed
   as shell code — writing to `$GITHUB_ENV`, and thus affecting every later step
-  of the job. The step exists in both `test-and-lint` and
-  `test-and-lint-postgres` and both are fixed; the postgres copy's
-  `DATABASE_URL` line, in the same block, moved to `env:` with it. The blocks
+  of the job. The step existed in both `test-and-lint` and
+  `test-and-lint-postgres` at the time and both were fixed; the postgres copy's
+  `DATABASE_URL` line, in the same block, moved to `env:` with it. (The two
+  jobs have since been merged — see the `⚠ BREAKING` entry above — so there is
+  now one copy of the step.) The blocks
   also gained `set -euo pipefail`, pipe `test-env-vars` through `printf '%s'`
   instead of `echo` (which mangles values with a leading `-` or backslashes),
   and quote `$GITHUB_ENV`. Same pattern as the `ci-ansible.yml` entry below.
@@ -131,9 +160,10 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   the job, `PATH`, `GOFLAGS` or `LD_PRELOAD` included, which also apply to
   `go test`. A guard now fails the step with
   `Error: multi-line test-env-vars keys or values are not supported` before
-  anything is written. Both jobs (`test-and-lint`, `test-and-lint-postgres`) carry the
-  guard, and `scripts/tests/test-ci-go-test-env-guard.sh` reads the expression
-  out of the workflow so the check cannot drift from it. Distinct from the
+  anything is written. Both jobs (`test-and-lint`, `test-and-lint-postgres`)
+  carried the guard when it landed; the two have since been merged, so it now
+  exists once. `scripts/tests/test-ci-go-test-env-guard.sh` reads the
+  expression out of the workflow so the check cannot drift from it. Distinct from the
   quoting fix above: that one closed the shell path, this one the file-format
   path, and the defect predates it. Not breaking for known consumers — they
   pass single-line entries, which are unaffected; only a multi-line one, which

--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,27 @@
       "/(^|/)workflows/[^/]+\\.ya?ml$/",
       "/(^|/)actions/[^/]+/action\\.ya?ml$/"
     ]
-  }
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track Docker images nested in a workflow ${{ }} expression. The built-in github-actions manager does extract service images, but getDep skips any value containing '$' with skipReason 'contains-variable', so a conditional service image needs this manager to stay updated.",
+      "managerFilePatterns": ["/^\\.github/workflows/[^/]+\\.ya?ml$/"],
+      "matchStringsStrategy": "recursive",
+      "matchStrings": [
+        "# renovate-expression:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?\\s*\\n[^\\n]*'[^:'\\n]+:[^'@\\n]+(?:@sha256:[a-f0-9]{64})?'",
+        "'[^:'\\n]+:(?<currentValue>[^'@\\n]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?'"
+      ],
+      "autoReplaceStringTemplate": "'{{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}'"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "The shared preset turns off digest pinning for custom.regex docker deps, since those managers usually capture a version only. The manager above captures currentDigest too, so pinning is re-enabled for it. Repo-level rules are merged after preset ones, so this wins.",
+      "matchManagers": ["custom.regex"],
+      "matchDatasources": ["docker"],
+      "matchFileNames": [".github/workflows/**"],
+      "pinDigests": true
+    }
+  ]
 }

--- a/scripts/tests/test-ci-go-test-env-guard.sh
+++ b/scripts/tests/test-ci-go-test-env-guard.sh
@@ -6,8 +6,10 @@
 # expression actually does that.
 #
 # The expression is read out of ci-go.yml rather than repeated here, so the two
-# cannot drift: a guard edited in the workflow is the guard under test. Both
-# jobs (test-and-lint, test-and-lint-postgres) carry it and both are checked.
+# cannot drift: a guard edited in the workflow is the guard under test. The
+# workflow has a single `test-and-lint` job, so the guard must appear exactly
+# once — a second copy means the job was split again and the two can drift, the
+# failure mode this repo already had.
 #
 # Run: scripts/tests/test-ci-go-test-env-guard.sh
 set -euo pipefail
@@ -28,13 +30,8 @@ GUARDS="$(sed -n "s/.*| jq -e '\(.*\)' >\/dev\/null.*/\1/p" "$WORKFLOW")"
 [ -n "$GUARDS" ] || fail "no 'jq -e' guard found in ci-go.yml"
 
 COUNT="$(grep -c . <<<"$GUARDS")"
-[ "$COUNT" -eq 2 ] ||
-  fail "expected the guard in both jobs, found $COUNT occurrence(s) in ci-go.yml"
-
-# Both occurrences must be the same expression — one job hardened and the other
-# left behind is the failure mode this repo already had.
-[ "$(sort -u <<<"$GUARDS" | grep -c .)" -eq 1 ] ||
-  fail "the two guards in ci-go.yml differ; they must be identical"
+[ "$COUNT" -eq 1 ] ||
+  fail "expected exactly one guard in ci-go.yml, found $COUNT occurrence(s)"
 
 GUARD="$(head -n 1 <<<"$GUARDS")"
 


### PR DESCRIPTION
## Summary

- `ci-go.yml` defined `test-and-lint` and `test-and-lint-postgres` as byte-identical jobs apart from the Postgres service container and one line in `Set test environment variables`. Every change had to be made twice and repeatedly landed in only one copy — most recently the newline guard in #288, which had to be inserted twice.
- The two were already mutually exclusive via `if:` on `enable-postgres`, so exactly one ever ran per call. They are merged into a single `test-and-lint`.
- The Postgres service stays conditional: `services:` takes no `if:`, so it is gated on its image — an empty `image:` makes the runner skip the container ([workflow-syntax reference](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idservicesservice_idimage): "you can use this to set up conditional services"). An `enable-postgres: false` caller gets no container, nothing listening on `localhost:5432`, and no `DATABASE_URL` — exactly as before the merge.
- `security-scan` / `codeql-analysis` `needs:` and the `coverage` output are rewired to the single job; the output no longer needs its `a || b` fallback.
- The newline guard from #288 now exists once; its test asserts a single occurrence, so a re-split would fail it.

Breaking: the `test-and-lint-postgres` job name is gone — see the `⚠ BREAKING` entry in `CHANGELOG.md`.

### Why `ports:` is not the gate

Gating the port mapping instead of the image does not work: an empty entry becomes a bare `-p` on the `docker create` line (`DockerCommandManager.cs` builds `-p {port.Value}` per `UserPortMappings` entry, unfiltered) and fails the job. Leaving the mapping unconditional while the container runs is the variant an earlier revision of this PR had, and it is what the review correctly flagged — it would have exposed a Postgres seeded from the `postgres-*` defaults on `localhost:5432` for every Go CI run in the org.

### Renovate

Renovate's built-in `github-actions` manager does read service images, but `getDep` skips any value containing `$` with `skipReason: 'contains-variable'`, so the conditional image would silently stop being updated. `.github/renovate.json` gains a custom manager that captures tag **and** digest (`currentDigest` is a supported capture group) plus a `packageRules` entry re-enabling `pinDigests` for it, since the shared preset turns that off for `custom.regex` docker deps. The marker is `# renovate-expression:` rather than `# renovate:` so the preset's generic manager does not also match the line and capture `${{` as the version — I verified both regexes against the file.

## Test plan

- [x] `just lint` green (yamllint, actionlint incl. shellcheck, prettier)
- [x] `just test` green, including `test-ci-go-test-env-guard.sh`
- [x] `renovate-config-validator .github/renovate.json` passes
- [x] Both Renovate regexes tested against the workflow: the new manager captures `depName=postgres`, `currentValue=18-alpine`, `currentDigest=sha256:…`; the preset's generic manager no longer matches the line
- [x] No remaining `test-and-lint-postgres` references outside `CHANGELOG.md` history and one dated design spec
- [ ] CI green on this PR
- [ ] Verify in a consumer repo before the next date tag is cut: one caller with `enable-postgres: true` (e.g. `savvy`) and one with `false`
- [ ] Confirm the first Renovate run picks up the postgres image (the custom manager is only exercised once Renovate runs against `main`)