### PR TITLE
fix(workflows): pass caller inputs through env instead of interpolating

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -317,11 +317,11 @@ jobs:
               ;;
           esac
 
-      # TEST_COMMAND is deliberately unquoted at the call sites below: the input
-      # carries a script name plus optional arguments (e.g. `test -- --shard=1/2`),
-      # so it must word-split. Passing it through `env:` still keeps it out of the
-      # `run:` block at expression-expansion time, which is what closes the
-      # injection: the value reaches the shell as data, not as source text.
+      # TEST_COMMAND is deliberately unquoted below: the input carries a script
+      # name plus optional arguments (e.g. `test -- --shard=1/2`), so it must
+      # word-split. Going through `env:` makes the value data rather than source
+      # text, so it is IFS-split and globbed but never parsed as shell — quotes
+      # and escapes inside it are no longer honoured (see CHANGELOG 2026-08-03).
       - name: Run tests without coverage
         if: inputs.enable-tests && !inputs.enable-coverage
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -177,8 +177,10 @@ jobs:
 
       - name: Get cache directory
         id: cache-dir
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
         run: |
-          case "${{ inputs.package-manager }}" in
+          case "$PACKAGE_MANAGER" in
             pnpm)
               echo "dir=$(pnpm store path)" >> "$GITHUB_OUTPUT"
               ;;
@@ -213,8 +215,10 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ inputs.working-directory }}
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
         run: |
-          case "${{ inputs.package-manager }}" in
+          case "$PACKAGE_MANAGER" in
             pnpm)
               pnpm install --frozen-lockfile
               ;;
@@ -232,8 +236,10 @@ jobs:
       - name: Type check
         if: inputs.enable-typecheck
         working-directory: ${{ inputs.working-directory }}
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
         run: |
-          case "${{ inputs.package-manager }}" in
+          case "$PACKAGE_MANAGER" in
             pnpm)
               pnpm typecheck
               ;;
@@ -251,8 +257,10 @@ jobs:
       - name: Format check
         if: inputs.enable-format-check
         working-directory: ${{ inputs.working-directory }}
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
         run: |
-          case "${{ inputs.package-manager }}" in
+          case "$PACKAGE_MANAGER" in
             pnpm)
               pnpm format:check
               ;;
@@ -270,8 +278,10 @@ jobs:
       - name: Lint
         if: inputs.enable-lint
         working-directory: ${{ inputs.working-directory }}
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
         run: |
-          case "${{ inputs.package-manager }}" in
+          case "$PACKAGE_MANAGER" in
             pnpm)
               pnpm lint
               ;;
@@ -289,8 +299,10 @@ jobs:
       - name: Build
         if: inputs.enable-build
         working-directory: ${{ inputs.working-directory }}
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
         run: |
-          case "${{ inputs.package-manager }}" in
+          case "$PACKAGE_MANAGER" in
             pnpm)
               pnpm build
               ;;
@@ -305,30 +317,41 @@ jobs:
               ;;
           esac
 
+      # TEST_COMMAND is deliberately unquoted at the call sites below: the input
+      # carries a script name plus optional arguments (e.g. `test -- --shard=1/2`),
+      # so it must word-split. Passing it through `env:` still keeps it out of the
+      # `run:` block at expression-expansion time, which is what closes the
+      # injection: the value reaches the shell as data, not as source text.
       - name: Run tests without coverage
         if: inputs.enable-tests && !inputs.enable-coverage
         working-directory: ${{ inputs.working-directory }}
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
+          TEST_COMMAND: ${{ inputs.test-command }}
         run: |
-          case "${{ inputs.package-manager }}" in
+          # shellcheck disable=SC2086 # test-command may carry arguments
+          case "$PACKAGE_MANAGER" in
             pnpm)
-              pnpm ${{ inputs.test-command }}
+              pnpm $TEST_COMMAND
               ;;
             bun)
-              bun run ${{ inputs.test-command }}
+              bun run $TEST_COMMAND
               ;;
             yarn)
-              yarn ${{ inputs.test-command }}
+              yarn $TEST_COMMAND
               ;;
             npm)
-              npm run ${{ inputs.test-command }}
+              npm run $TEST_COMMAND
               ;;
           esac
 
       - name: Run tests with coverage
         if: inputs.enable-tests && inputs.enable-coverage
         working-directory: ${{ inputs.working-directory }}
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
         run: |
-          case "${{ inputs.package-manager }}" in
+          case "$PACKAGE_MANAGER" in
             pnpm)
               pnpm test:coverage
               ;;
@@ -437,8 +460,10 @@ jobs:
       - name: Get cache directory
         if: matrix.scanner == 'dependency-audit'
         id: cache-dir
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
         run: |
-          case "${{ inputs.package-manager }}" in
+          case "$PACKAGE_MANAGER" in
             pnpm)
               echo "dir=$(pnpm store path)" >> "$GITHUB_OUTPUT"
               ;;
@@ -462,8 +487,10 @@ jobs:
       - name: Install dependencies for audit
         if: matrix.scanner == 'dependency-audit'
         working-directory: ${{ inputs.working-directory }}
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
         run: |
-          case "${{ inputs.package-manager }}" in
+          case "$PACKAGE_MANAGER" in
             pnpm)
               pnpm install --frozen-lockfile
               ;;
@@ -478,17 +505,20 @@ jobs:
       - name: Run dependency audit
         if: matrix.scanner == 'dependency-audit'
         working-directory: ${{ inputs.working-directory }}
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
+          AUDIT_LEVEL: ${{ inputs.audit-level }}
         run: |
           echo "Running dependency audit..."
-          case "${{ inputs.package-manager }}" in
+          case "$PACKAGE_MANAGER" in
             pnpm)
-              pnpm audit --audit-level=${{ inputs.audit-level }} || echo "::warning::Vulnerabilities found"
+              pnpm audit --audit-level="$AUDIT_LEVEL" || echo "::warning::Vulnerabilities found"
               ;;
             yarn)
-              yarn audit --level ${{ inputs.audit-level }} || echo "::warning::Vulnerabilities found"
+              yarn audit --level "$AUDIT_LEVEL" || echo "::warning::Vulnerabilities found"
               ;;
             npm)
-              npm audit --audit-level=${{ inputs.audit-level }} || echo "::warning::Vulnerabilities found"
+              npm audit --audit-level="$AUDIT_LEVEL" || echo "::warning::Vulnerabilities found"
               ;;
           esac
 

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -400,8 +400,9 @@ jobs:
       - name: Check bundle sizes
         if: inputs.enable-bundle-size-check
         working-directory: ${{ inputs.working-directory }}
+        env:
+          MAX_SIZE_KB: ${{ inputs.max-bundle-size-kb }}
         run: |
-          MAX_SIZE_KB=${{ inputs.max-bundle-size-kb }}
           FAILED=0
 
           for dir in src/*/; do
@@ -579,21 +580,35 @@ jobs:
     if: always() && !cancelled()
     steps:
       - name: Generate Summary
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+          REPOSITORY: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          QUALITY_RESULT: ${{ needs.quality-and-test.result }}
+          SECURITY_RESULT: ${{ needs.security-scan.result }}
+          DEPENDENCY_RESULT: ${{ needs.dependency-review.result }}
+          COVERAGE: ${{ needs.quality-and-test.outputs.coverage }}
+        # Every value arrives via `env:` and both heredoc delimiters are quoted,
+        # so nothing in the template bodies is expanded by the shell. The
+        # dynamic lines are emitted with `printf` between the heredocs.
         run: |
           TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
-          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+          {
+            cat << 'EOF'
           # CI — JavaScript/TypeScript
 
-          **Timestamp:** $TIMESTAMP
-          **Repository:** ${{ github.repository }} @ ${{ github.ref_name }}
-
+          EOF
+            printf '**Timestamp:** %s\n**Repository:** %s @ %s\n\n' \
+              "$TIMESTAMP" "$REPOSITORY" "$REF_NAME"
+            cat << 'EOF'
           | Job | Status |
           | --- | --- |
-          | Quality & Tests | ${{ needs.quality-and-test.result }} |
-          | Security Scan | ${{ needs.security-scan.result }} |
-          | Dependency Review | ${{ needs.dependency-review.result }} |
-
-          **Coverage:** ${{ needs.quality-and-test.outputs.coverage }}
-          **Package Manager:** ${{ inputs.package-manager }}
-          **Working Directory:** ${{ inputs.working-directory }}
           EOF
+            printf '| Quality & Tests | %s |\n' "$QUALITY_RESULT"
+            printf '| Security Scan | %s |\n' "$SECURITY_RESULT"
+            printf '| Dependency Review | %s |\n\n' "$DEPENDENCY_RESULT"
+            printf '**Coverage:** %s\n' "$COVERAGE"
+            printf '**Package Manager:** %s\n' "$PACKAGE_MANAGER"
+            printf '**Working Directory:** %s\n' "$WORKING_DIRECTORY"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-cloudflare-workers.yml
+++ b/.github/workflows/deploy-cloudflare-workers.yml
@@ -103,8 +103,10 @@ jobs:
 
       - name: Get cache directory
         id: cache-dir
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
         run: |
-          case "${{ inputs.package-manager }}" in
+          case "$PACKAGE_MANAGER" in
             pnpm)
               echo "dir=$(pnpm store path)" >> "$GITHUB_OUTPUT"
               ;;
@@ -126,8 +128,10 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ inputs.working-directory-prefix }}/${{ matrix.worker }}
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
         run: |
-          case "${{ inputs.package-manager }}" in
+          case "$PACKAGE_MANAGER" in
             pnpm)
               pnpm install --frozen-lockfile
               ;;
@@ -142,21 +146,24 @@ jobs:
       - name: Run build scripts
         if: inputs.run-scripts
         working-directory: ${{ inputs.working-directory-prefix }}/${{ matrix.worker }}
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
+          WORKER: ${{ matrix.worker }}
         run: |
-          case "${{ inputs.package-manager }}" in
+          case "$PACKAGE_MANAGER" in
             pnpm)
               if ! pnpm build; then
-                echo "::warning::Build script failed or not found for ${{ matrix.worker }}"
+                echo "::warning::Build script failed or not found for $WORKER"
               fi
               ;;
             bun)
               if ! bun run build; then
-                echo "::warning::Build script failed or not found for ${{ matrix.worker }}"
+                echo "::warning::Build script failed or not found for $WORKER"
               fi
               ;;
             npm)
               if ! npm run build; then
-                echo "::warning::Build script failed or not found for ${{ matrix.worker }}"
+                echo "::warning::Build script failed or not found for $WORKER"
               fi
               ;;
           esac

--- a/.github/workflows/deploy-cloudflare-workers.yml
+++ b/.github/workflows/deploy-cloudflare-workers.yml
@@ -188,11 +188,19 @@ jobs:
 
       - name: Deployment Summary
         if: always()
+        env:
+          WORKER: ${{ matrix.worker }}
+          JOB_STATUS: ${{ job.status }}
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
+          WRANGLER_VERSION: ${{ inputs.wrangler-version }}
+        # Every value arrives via `env:` and is written with `printf`. A quoted
+        # heredoc delimiter alone would not be enough: `${{ }}` is substituted
+        # into the script text before the shell sees it, so a value carrying a
+        # newline followed by the delimiter would end the heredoc early.
         run: |
-          cat >> "$GITHUB_STEP_SUMMARY" << 'EOF'
-          ## Deploy — Cloudflare Worker: ${{ matrix.worker }}
-
-          **Status:** ${{ job.status }}
-          **Package Manager:** ${{ inputs.package-manager }}
-          **Wrangler Version:** ${{ inputs.wrangler-version }}
-          EOF
+          {
+            printf '## Deploy — Cloudflare Worker: %s\n\n' "$WORKER"
+            printf '**Status:** %s\n' "$JOB_STATUS"
+            printf '**Package Manager:** %s\n' "$PACKAGE_MANAGER"
+            printf '**Wrangler Version:** %s\n' "$WRANGLER_VERSION"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -124,31 +124,45 @@ jobs:
       # Install Playwright dependencies
       - name: Install dependencies
         working-directory: ${{ inputs.playwright-directory }}
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
         run: |
-          case "${{ inputs.package-manager }}" in
+          case "$PACKAGE_MANAGER" in
             pnpm) pnpm install --frozen-lockfile ;;
             bun) bun install --frozen-lockfile ;;
             yarn) yarn install --frozen-lockfile ;;
             npm) npm ci ;;
           esac
 
+      # PLAYWRIGHT_BROWSERS stays unquoted in the install call: it is a
+      # space-separated browser list (e.g. `chromium firefox`) and must split
+      # into separate arguments.
       - name: Install Playwright browsers
         working-directory: ${{ inputs.playwright-directory }}
+        env:
+          PLAYWRIGHT_BROWSERS: ${{ inputs.playwright-browsers }}
         run: |
-          case "${{ inputs.playwright-browsers }}" in
+          # shellcheck disable=SC2086 # browser list must word-split
+          case "$PLAYWRIGHT_BROWSERS" in
             all) npx playwright install --with-deps ;;
-            *) npx playwright install --with-deps ${{ inputs.playwright-browsers }} ;;
+            *) npx playwright install --with-deps $PLAYWRIGHT_BROWSERS ;;
           esac
 
+      # TEST_COMMAND stays unquoted: it may carry arguments after the script
+      # name and must word-split. See the same note in ci-js.yml.
       # Run E2E Tests
       - name: Run Playwright tests
         working-directory: ${{ inputs.playwright-directory }}
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
+          TEST_COMMAND: ${{ inputs.test-command }}
         run: |
-          case "${{ inputs.package-manager }}" in
-            pnpm) pnpm ${{ inputs.test-command }} ;;
-            bun) bun run ${{ inputs.test-command }} ;;
-            yarn) yarn ${{ inputs.test-command }} ;;
-            npm) npm run ${{ inputs.test-command }} ;;
+          # shellcheck disable=SC2086 # test-command may carry arguments
+          case "$PACKAGE_MANAGER" in
+            pnpm) pnpm $TEST_COMMAND ;;
+            bun) bun run $TEST_COMMAND ;;
+            yarn) yarn $TEST_COMMAND ;;
+            npm) npm run $TEST_COMMAND ;;
           esac
 
       # Save container logs on failure

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -98,12 +98,17 @@ jobs:
 
       # Docker Compose Setup
       - name: Start E2E stack
+        env:
+          COMPOSE_FILE_PATH: ${{ inputs.compose-file }}
+          COMPOSE_PROFILE: ${{ inputs.compose-profile }}
         run: |
-          docker compose -f ${{ inputs.compose-file }} --profile ${{ inputs.compose-profile }} up -d --wait
+          docker compose -f "$COMPOSE_FILE_PATH" --profile "$COMPOSE_PROFILE" up -d --wait
           echo "✅ E2E stack started successfully"
 
       - name: Show running containers
-        run: docker compose -f ${{ inputs.compose-file }} ps
+        env:
+          COMPOSE_FILE_PATH: ${{ inputs.compose-file }}
+        run: docker compose -f "$COMPOSE_FILE_PATH" ps
 
       # Setup Node.js for Playwright
       - name: Setup Node.js
@@ -148,8 +153,9 @@ jobs:
             *) npx playwright install --with-deps $PLAYWRIGHT_BROWSERS ;;
           esac
 
-      # TEST_COMMAND stays unquoted: it may carry arguments after the script
-      # name and must word-split. See the same note in ci-js.yml.
+      # TEST_COMMAND stays unquoted: it may carry arguments after the script name
+      # and must word-split. As in ci-js.yml, that means it is no longer
+      # shell-parsed — quoted arguments inside the value are not honoured.
       # Run E2E Tests
       - name: Run Playwright tests
         working-directory: ${{ inputs.playwright-directory }}
@@ -168,8 +174,10 @@ jobs:
       # Save container logs on failure
       - name: Save container logs
         if: failure() && inputs.upload-artifacts
+        env:
+          COMPOSE_FILE_PATH: ${{ inputs.compose-file }}
         run: |
-          docker compose -f ${{ inputs.compose-file }} logs > container-logs.txt
+          docker compose -f "$COMPOSE_FILE_PATH" logs > container-logs.txt
           echo "📋 Container logs saved"
 
       # Upload Artifacts
@@ -203,21 +211,26 @@ jobs:
       # Stop Docker Compose
       - name: Stop E2E stack
         if: always()
+        env:
+          COMPOSE_FILE_PATH: ${{ inputs.compose-file }}
+          COMPOSE_PROFILE: ${{ inputs.compose-profile }}
         run: |
-          docker compose -f ${{ inputs.compose-file }} --profile ${{ inputs.compose-profile }} down
+          docker compose -f "$COMPOSE_FILE_PATH" --profile "$COMPOSE_PROFILE" down
           echo "🛑 E2E stack stopped"
 
       # PR Comment
       - name: Comment PR with test results
         if: github.event_name == 'pull_request' && always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          COMPOSE_PROFILE: ${{ inputs.compose-profile }}
         with:
           script: |
             const fs = require('fs');
             const path = require('path');
 
             let comment = '## 🎭 E2E Test Results (Docker Compose)\n\n';
-            comment += `**Profile**: \`${{ inputs.compose-profile }}\`\n\n`;
+            comment += `**Profile**: \`${process.env.COMPOSE_PROFILE}\`\n\n`;
 
             // Use job status instead of counting files
             const jobStatus = '${{ job.status }}';

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -153,10 +153,11 @@ jobs:
             *) npx playwright install --with-deps $PLAYWRIGHT_BROWSERS ;;
           esac
 
+      # Run E2E Tests
+      #
       # TEST_COMMAND stays unquoted: it may carry arguments after the script name
       # and must word-split. As in ci-js.yml, that means it is no longer
       # shell-parsed — quoted arguments inside the value are not honoured.
-      # Run E2E Tests
       - name: Run Playwright tests
         working-directory: ${{ inputs.playwright-directory }}
         env:

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -467,11 +467,6 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      # The heredoc delimiter is quoted ('EOF'), so nothing in the body is
-      # expanded by the shell. Every value the template needs is therefore
-      # computed into a variable first and substituted with envsubst-free
-      # `printf`-style assembly below, which keeps caller-controlled inputs
-      # out of both the expression layer and the shell's expansion pass.
       - name: Generate changelog
         if: inputs.generate-changelog
         id: changelog
@@ -495,10 +490,16 @@ jobs:
 
           # Resolved before the heredoc: the quoted delimiter below switches off
           # expansion inside the body, so a command substitution there would be
-          # emitted literally rather than evaluated.
-          PACKAGE_NAME=$(node -p "require(process.argv[1] + '/package.json').name" "$WORKING_DIRECTORY")
+          # emitted literally rather than evaluated. path.resolve() keeps a
+          # relative working-directory like `packages/foo` a path — bare
+          # require() would treat it as a node_modules specifier.
+          PACKAGE_NAME=$(node -p \
+            "require(require('path').resolve(process.argv[1], 'package.json')).name" \
+            "$WORKING_DIRECTORY")
 
-          # Save to file
+          # Delimiters below are quoted ('EOF'), so the shell expands nothing in
+          # the bodies — the static Markdown stays literal and the two dynamic
+          # lines are emitted by printf instead.
           {
             cat << 'EOF'
           ## What's Changed

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -173,8 +173,10 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ inputs.working-directory }}
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
         run: |
-          case "${{ inputs.package-manager }}" in
+          case "$PACKAGE_MANAGER" in
             pnpm)
               pnpm install --frozen-lockfile
               ;;
@@ -192,8 +194,10 @@ jobs:
       - name: Run tests
         if: inputs.run-tests
         working-directory: ${{ inputs.working-directory }}
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
         run: |
-          case "${{ inputs.package-manager }}" in
+          case "$PACKAGE_MANAGER" in
             pnpm)
               pnpm test
               ;;
@@ -211,8 +215,10 @@ jobs:
       - name: Run build
         if: inputs.run-build
         working-directory: ${{ inputs.working-directory }}
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
         run: |
-          case "${{ inputs.package-manager }}" in
+          case "$PACKAGE_MANAGER" in
             pnpm)
               pnpm build
               ;;
@@ -261,8 +267,10 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ inputs.working-directory }}
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
         run: |
-          case "${{ inputs.package-manager }}" in
+          case "$PACKAGE_MANAGER" in
             pnpm)
               pnpm install --frozen-lockfile
               ;;
@@ -280,8 +288,10 @@ jobs:
       - name: Build package
         if: inputs.run-build
         working-directory: ${{ inputs.working-directory }}
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
         run: |
-          case "${{ inputs.package-manager }}" in
+          case "$PACKAGE_MANAGER" in
             pnpm)
               pnpm build
               ;;
@@ -302,12 +312,13 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           CUSTOM_PUBLISH_CMD: ${{ inputs.publish-command }}
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
         run: |
           echo "🧪 Dry-run mode - not actually publishing"
 
           if [ -z "$CUSTOM_PUBLISH_CMD" ]; then
             # Use default publish command based on package manager
-            case "${{ inputs.package-manager }}" in
+            case "$PACKAGE_MANAGER" in
               pnpm)
                 pnpm publish --dry-run --no-git-checks
                 ;;
@@ -333,17 +344,20 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           CUSTOM_PUBLISH_CMD: ${{ inputs.publish-command }}
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
+          REGISTRY_URL: ${{ inputs.registry-url }}
+          ENABLE_PROVENANCE: ${{ inputs.enable-provenance }}
         run: |
-          echo "Publishing to NPM registry: ${{ inputs.registry-url }}"
+          echo "Publishing to NPM registry: $REGISTRY_URL"
 
           PUBLISH_ARGS=""
-          if [ "${{ inputs.enable-provenance }}" == "true" ]; then
+          if [ "$ENABLE_PROVENANCE" == "true" ]; then
             PUBLISH_ARGS="--provenance"
           fi
 
           if [ -z "$CUSTOM_PUBLISH_CMD" ]; then
             # Use default publish command based on package manager
-            case "${{ inputs.package-manager }}" in
+            case "$PACKAGE_MANAGER" in
               pnpm)
                 pnpm publish --no-git-checks --access public $PUBLISH_ARGS
                 ;;
@@ -453,11 +467,20 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      # The heredoc delimiter is quoted ('EOF'), so nothing in the body is
+      # expanded by the shell. Every value the template needs is therefore
+      # computed into a variable first and substituted with envsubst-free
+      # `printf`-style assembly below, which keeps caller-controlled inputs
+      # out of both the expression layer and the shell's expansion pass.
       - name: Generate changelog
         if: inputs.generate-changelog
         id: changelog
+        env:
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+          RELEASE_VERSION: ${{ needs.pre-release-checks.outputs.version }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          VERSION="v${{ needs.pre-release-checks.outputs.version }}"
+          VERSION="v$RELEASE_VERSION"
 
           # Get previous tag
           PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
@@ -470,20 +493,32 @@ jobs:
             CHANGELOG=$(git log --pretty=format:"- %s (%h)" HEAD)
           fi
 
+          # Resolved before the heredoc: the quoted delimiter below switches off
+          # expansion inside the body, so a command substitution there would be
+          # emitted literally rather than evaluated.
+          PACKAGE_NAME=$(node -p "require(process.argv[1] + '/package.json').name" "$WORKING_DIRECTORY")
+
           # Save to file
-          cat > /tmp/changelog.md << EOF
+          {
+            cat << 'EOF'
           ## What's Changed
 
-          $CHANGELOG
+          EOF
+            printf '%s\n' "$CHANGELOG"
+            cat << 'EOF'
 
           ## Installation
 
-          \`\`\`bash
-          npm install $(node -p "require('${{ inputs.working-directory }}/package.json').name")@${{ needs.pre-release-checks.outputs.version }}
-          \`\`\`
-
-          **Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREVIOUS_TAG}...${VERSION}
+          ```bash
           EOF
+            printf 'npm install %s@%s\n' "$PACKAGE_NAME" "$RELEASE_VERSION"
+            cat << 'EOF'
+          ```
+
+          EOF
+            printf '**Full Changelog**: https://github.com/%s/compare/%s...%s\n' \
+              "$REPOSITORY" "$PREVIOUS_TAG" "$VERSION"
+          } > /tmp/changelog.md
 
           echo "changelog_file=/tmp/changelog.md" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -553,25 +553,39 @@ jobs:
     if: always() && !cancelled()
     steps:
       - name: Generate Release Summary
+        env:
+          VERSION: ${{ needs.pre-release-checks.outputs.version }}
+          REGISTRY_URL: ${{ inputs.registry-url }}
+          PROVENANCE: ${{ inputs.enable-provenance && 'Enabled' || 'Disabled' }}
+          DRY_RUN: ${{ inputs.dry-run }}
+          CHECKS_RESULT: ${{ needs.pre-release-checks.result }}
+          PUBLISH_RESULT: ${{ needs.publish.result }}
+          RELEASE_RESULT: ${{ needs.github-release.result }}
+          SKIPPED_NOTE: ${{ needs.pre-release-checks.outputs.should-publish == 'false' && '> Version already published — publish step skipped.' || '' }}
+          DRY_RUN_NOTE: ${{ inputs.dry-run && '> Dry-run mode — package was NOT published.' || '' }}
+        # Every value arrives via `env:` and both heredoc delimiters are quoted,
+        # so nothing in the template bodies is expanded by the shell. The
+        # dynamic lines are emitted with `printf` between the heredocs.
         run: |
           TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
-          VERSION="${{ needs.pre-release-checks.outputs.version }}"
-
-          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+          {
+            cat << 'EOF'
           # Release — NPM Package
 
-          **Timestamp:** $TIMESTAMP
-          **Version:** \`v$VERSION\`
-          **Registry:** ${{ inputs.registry-url }}
-          **Provenance:** ${{ inputs.enable-provenance && 'Enabled' || 'Disabled' }}
-          **Dry Run:** ${{ inputs.dry-run }}
-
+          EOF
+            printf '**Timestamp:** %s\n' "$TIMESTAMP"
+            # shellcheck disable=SC2016  # backticks are literal Markdown here
+            printf '**Version:** `v%s`\n' "$VERSION"
+            printf '**Registry:** %s\n' "$REGISTRY_URL"
+            printf '**Provenance:** %s\n' "$PROVENANCE"
+            printf '**Dry Run:** %s\n\n' "$DRY_RUN"
+            cat << 'EOF'
           | Component | Status |
           | --- | --- |
-          | Pre-Release Checks | ${{ needs.pre-release-checks.result }} |
-          | NPM Publish | ${{ needs.publish.result }} |
-          | GitHub Release | ${{ needs.github-release.result }} |
-
-          ${{ needs.pre-release-checks.outputs.should-publish == 'false' && '> Version already published — publish step skipped.' || '' }}
-          ${{ inputs.dry-run && '> Dry-run mode — package was NOT published.' || '' }}
           EOF
+            printf '| Pre-Release Checks | %s |\n' "$CHECKS_RESULT"
+            printf '| NPM Publish | %s |\n' "$PUBLISH_RESULT"
+            printf '| GitHub Release | %s |\n\n' "$RELEASE_RESULT"
+            printf '%s\n' "$SKIPPED_NOTE"
+            printf '%s\n' "$DRY_RUN_NOTE"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,30 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ## 2026-08-03
 
+### ⚠ BREAKING
+
+- **`test-command` is word-split instead of shell-parsed in `ci-js.yml` and
+  `e2e-docker.yml`.** The input used to be interpolated into the `run:` block as
+  source text, so the shell parsed it and honoured quoting: a value of
+  `test -- --grep="two words"` reached the runner as a single `--grep=two words`
+  argument. It now travels through `env:` and is expanded unquoted, which does
+  IFS word-splitting and globbing but leaves quote characters literal — the same
+  value becomes two arguments with the quotes retained. Unquoted values such as
+  `test -- --shard=1/2` are unaffected.
+  **Migration:** if your `test-command` contains quoted arguments, escaped
+  spaces, or a `*` that relied on quoting, move it into a `package.json` script
+  and pass that script's name instead.
+
+- **`release-npm.yml` fails the `github-release` job when the package name
+  cannot be read.** The `node -p` call that resolves the name for the changelog
+  used to run during heredoc expansion, so its exit status was discarded: a
+  missing or unparseable `package.json` produced a release whose body read
+  `npm install @<version>`. The call now runs as its own assignment under
+  `set -e` and aborts the step instead.
+  **Migration:** none for a well-formed package; a release that previously went
+  out with a malformed changelog line now fails loudly and needs the
+  `package.json` fixed.
+
 ### Fixed
 
 - **The two justfile `customManagers` moved from `.github/renovate.json` to the
@@ -141,6 +165,25 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   set by the same actor — but the same mechanism. Not breaking: the defaults and
   any single-line value are unaffected, and `DATABASE_URL`, the input
   signatures and the defaults are unchanged.
+
+- **`ci-js.yml`, `deploy-cloudflare-workers.yml`, `e2e-docker.yml` and
+  `release-npm.yml` pass caller inputs through `env:` instead of interpolating
+  them into `run:` blocks.** Twenty-three `package-manager` switch sites
+  expanded a caller-controlled value into shell source, so a value
+  carrying a command substitution executed in the runner; the same applied to
+  `audit-level`, `registry-url`, `enable-provenance`, `playwright-browsers`,
+  `compose-file` and `compose-profile`. Same class and same fix as the `ci-go.yml`
+  change in the 2026-08-02 entry. `release-npm.yml` additionally opened its
+  changelog heredoc with an unquoted delimiter, so the body was expanded and a
+  command substitution built from `working-directory` ran there; the delimiter is
+  now quoted and the dynamic lines are emitted with `printf`.
+- **`e2e-docker.yml` reads `compose-profile` from `process.env` in its PR-comment
+  script.** The value was interpolated into a JavaScript template literal, where a
+  backtick or `${` escaped into the surrounding source.
+- **`release-npm.yml` resolves `working-directory` to an absolute path before
+  requiring `package.json`.** A relative directory without a leading `./` (e.g.
+  `packages/foo`) was treated as a bare specifier and looked up under
+  `node_modules`, so the lookup failed for monorepo callers.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,10 +173,20 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   carrying a command substitution executed in the runner; the same applied to
   `audit-level`, `registry-url`, `enable-provenance`, `playwright-browsers`,
   `compose-file` and `compose-profile`. Same class and same fix as the `ci-go.yml`
-  change in the 2026-08-02 entry. `release-npm.yml` additionally opened its
-  changelog heredoc with an unquoted delimiter, so the body was expanded and a
-  command substitution built from `working-directory` ran there; the delimiter is
-  now quoted and the dynamic lines are emitted with `printf`.
+  change in the 2026-08-02 entry.
+  **The step summaries were the exploitable half.** `release-npm.yml` opened both
+  its changelog and its release-summary heredoc with an unquoted delimiter and
+  `ci-js.yml` did the same in its CI summary, so the body was expanded and a
+  command substitution built from `working-directory` or `registry-url` ran
+  there. `deploy-cloudflare-workers.yml` quoted its delimiter but still
+  interpolated `matrix.worker` and two inputs into the body, which a quoted
+  delimiter does not cover: `${{ }}` is substituted into the script text before
+  the shell sees it, so a value carrying a newline followed by the delimiter ends
+  the heredoc early. Every delimiter is now quoted and the dynamic lines are
+  emitted with `printf`; the rendered summaries are byte-identical to before.
+  With this, all four workflows join `MIGRATED` in
+  `scripts/tests/test-workflow-input-injection.sh` (13 of them now), so the
+  pattern cannot regrow unnoticed in the files this change hardens.
 - **`e2e-docker.yml` reads `compose-profile` from `process.env` in its PR-comment
   script.** The value was interpolated into a JavaScript template literal, where a
   backtick or `${` escaped into the surrounding source.

--- a/scripts/tests/test-workflow-input-injection.sh
+++ b/scripts/tests/test-workflow-input-injection.sh
@@ -5,7 +5,7 @@
 # (`<< EOF`) the body is expanded too, so a value reaching a step summary that
 # way executes as well.
 #
-# The nine workflows below were migrated to pass such values through `env:` and
+# The workflows below were migrated to pass such values through `env:` and
 # reference them as shell variables. This asserts the migration holds: no
 # interpolated caller-controlled value left in a `run:` body — block-scalar,
 # folded or single-line — and no unquoted heredoc delimiter. It is a structural
@@ -15,10 +15,6 @@
 # leave a step again as a workflow-level output and be interpolated downstream,
 # which is why `security-code.yml` also constrains `package-manager` to a known
 # set before writing it to `$GITHUB_OUTPUT`.
-#
-# The four workflows still carrying the old pattern (ci-js, e2e-docker,
-# release-npm, deploy-cloudflare-workers) are deliberately out of scope — they
-# are migrated separately; see CHANGELOG.md.
 #
 # Run: scripts/tests/test-workflow-input-injection.sh
 set -euo pipefail
@@ -34,9 +30,13 @@ fail() {
 
 # The workflows this migration covers.
 MIGRATED=(
+  ci-js.yml
   ci-terraform.yml
+  deploy-cloudflare-workers.yml
   deploy-terraform.yml
+  e2e-docker.yml
   release-docker.yml
+  release-npm.yml
   security-code.yml
   security-config.yml
   security-containers.yml


### PR DESCRIPTION
## Summary

- Caller-controlled `inputs.*` were expanded directly into `run:` blocks in four workflows, so a value carrying a command substitution executed in the runner. All 23 `case "${{ inputs.package-manager }}" in` sites now read `case "$PACKAGE_MANAGER" in`, with the value supplied via `env:`.
- `release-npm.yml` additionally opened the changelog heredoc with an unquoted delimiter, so its body was expanded — including a command substitution built from `working-directory`. The delimiter is now quoted and the values are inserted with `printf`, and the package name is resolved before the heredoc since the quoted form no longer expands. That `node -p` call takes the directory as `process.argv[1]` rather than splicing it into the JS source, so the value cannot escape into JavaScript either.
- `audit-level`, `registry-url`, `enable-provenance`, `playwright-browsers` and `matrix.worker` were routed the same way where they appeared in the same blocks.
- Values that must word-split (`test-command`, `playwright-browsers`) stay unquoted and carry a local `# shellcheck disable=SC2086` naming the reason; passing them through `env:` still removes them from the expression-expansion layer, which is what closes the injection.

Same class and same fix shape as #285. Nine further workflows still interpolate inputs into `run:` blocks, including eight step-summary heredocs with unquoted delimiters — out of scope here, tracked separately.

## Test plan

- [x] `just lint` green (yamllint, actionlint incl. shellcheck, prettier)
- [x] `just test` green (6 script self-checks)
- [x] Behavioural check on the rewritten changelog block: output byte-identical to the previous template for a normal input
- [x] Injection check: a `working-directory` of `./pkg$(touch …)` executes under the old expanded heredoc and does not under the new form
- [x] Injection check: a `package-manager` of `npm$(touch …)` executes under the old interpolated `case` and does not when passed via `env:`
- [ ] CI green
