### PR TITLE
fix(ci-go): guard postgres inputs against newline injection

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -241,10 +241,13 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$ENABLE_POSTGRES" = "true" ]; then
-            # $GITHUB_ENV is line-based: a newline inside a value would inject
-            # additional environment entries for every following step.
+            # $GITHUB_ENV is line-based: a line break inside a value would inject
+            # additional environment entries for every following step. CR is
+            # rejected alongside LF — the runner reads the file on the .NET side,
+            # whose line readers treat a lone CR as a terminator too, and a stray
+            # CR corrupts DATABASE_URL either way.
             for value in "$POSTGRES_USER" "$POSTGRES_PASSWORD" "$POSTGRES_DB"; do
-              if [ "$value" != "${value//$'\n'/}" ]; then
+              if [ "$value" != "${value//[$'\n\r']/}" ]; then
                 echo "Error: multi-line postgres-user, postgres-password or postgres-db values are not supported" >&2
                 exit 1
               fi

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -241,6 +241,14 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$ENABLE_POSTGRES" = "true" ]; then
+            # $GITHUB_ENV is line-based: a newline inside a value would inject
+            # additional environment entries for every following step.
+            for value in "$POSTGRES_USER" "$POSTGRES_PASSWORD" "$POSTGRES_DB"; do
+              if [ "$value" != "${value//$'\n'/}" ]; then
+                echo "Error: multi-line postgres-user, postgres-password or postgres-db values are not supported" >&2
+                exit 1
+              fi
+            done
             printf 'DATABASE_URL=postgres://%s:%s@localhost:5432/%s?sslmode=disable\n' \
               "$POSTGRES_USER" "$POSTGRES_PASSWORD" "$POSTGRES_DB" >> "$GITHUB_ENV"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,9 +130,13 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   earlier, two lines below in the same block, but left open for these three. A
   loop over the three values now fails the step with
   `Error: multi-line postgres-user, postgres-password or postgres-db values are not supported`
-  before the write happens. `scripts/tests/test-ci-go-postgres-env-guard.sh`
-  reads the loop out of the workflow, so the check cannot drift from it, and
-  asserts the guard sits above the write it protects. Lower severity than the
+  before the write happens. CR is rejected alongside LF: the runner reads the
+  file on the .NET side, whose line readers treat a lone CR as a terminator, and
+  a stray CR corrupts `DATABASE_URL` regardless.
+  `scripts/tests/test-ci-go-postgres-env-guard.sh` reads the loop out of the
+  workflow so the check cannot drift from it, and asserts that all three inputs
+  are covered, that the guard aborts rather than warns, and that it sits in the
+  same step as the write it protects. Lower severity than the
   `test-env-vars` case — the three inputs have defaults and are typically not
   set by the same actor — but the same mechanism. Not breaking: the defaults and
   any single-line value are unaffected, and `DATABASE_URL`, the input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,7 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 - **`ci-go.yml` rejects `postgres-user`, `postgres-password` and `postgres-db`
   values containing a newline instead of writing them to `$GITHUB_ENV`.** The
-  `Set test environment variables` step of `test-and-lint-postgres` builds the
+  `Set test environment variables` step of `test-and-lint` builds the
   `DATABASE_URL` line from the three inputs with `printf` and appends it to
   `$GITHUB_ENV`. That file is line-based, so a newline inside one of the values
   splits the line and injects further environment entries for every following

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,24 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   escaped two-character sequence stays permitted. **No behaviour change for
   valid input:** values without a CR or LF byte are written exactly as before.
 
+- **`ci-go.yml` rejects `postgres-user`, `postgres-password` and `postgres-db`
+  values containing a newline instead of writing them to `$GITHUB_ENV`.** The
+  `Set test environment variables` step of `test-and-lint-postgres` builds the
+  `DATABASE_URL` line from the three inputs with `printf` and appends it to
+  `$GITHUB_ENV`. That file is line-based, so a newline inside one of the values
+  splits the line and injects further environment entries for every following
+  step of the job — the same path the `test-env-vars` guard closed one release
+  earlier, two lines below in the same block, but left open for these three. A
+  loop over the three values now fails the step with
+  `Error: multi-line postgres-user, postgres-password or postgres-db values are not supported`
+  before the write happens. `scripts/tests/test-ci-go-postgres-env-guard.sh`
+  reads the loop out of the workflow, so the check cannot drift from it, and
+  asserts the guard sits above the write it protects. Lower severity than the
+  `test-env-vars` case — the three inputs have defaults and are typically not
+  set by the same actor — but the same mechanism. Not breaking: the defaults and
+  any single-line value are unaffected, and `DATABASE_URL`, the input
+  signatures and the defaults are unchanged.
+
 ---
 
 ## 2026-08-02

--- a/justfile
+++ b/justfile
@@ -107,6 +107,7 @@ test:
     scripts/tests/test-workflow-counts.sh
     scripts/tests/test-ci-go-test-env-guard.sh
     scripts/tests/test-workflow-input-injection.sh
+    scripts/tests/test-ci-go-postgres-env-guard.sh
 
 # fmt → format Markdown and JSON in place
 fmt:

--- a/scripts/tests/test-ci-go-postgres-env-guard.sh
+++ b/scripts/tests/test-ci-go-postgres-env-guard.sh
@@ -63,10 +63,10 @@ WRITE_LINE="$(grep -n "^ *printf 'DATABASE_URL=postgres" "$WORKFLOW" | cut -d: -
 [ "$GUARD_LINE" -lt "$WRITE_LINE" ] ||
   fail "postgres guard is at line $GUARD_LINE, below the write at $WRITE_LINE"
 
-# Above the write is not enough — both must be in the *same* step. ci-go.yml has
-# a second `Set test environment variables` step in the `test-and-lint` job, so
-# a guard moved there would still be "above" this write while leaving it
-# unprotected: the one-job-hardened-one-behind mode the sibling test covers.
+# Above the write is not enough — both must be in the *same* step. A guard moved
+# into any earlier step would still be "above" this write while leaving it
+# unprotected, because each `run:` block is its own shell: the check would pass
+# while the value reaching `printf` had never been tested.
 if sed -n "${GUARD_LINE},${WRITE_LINE}p" "$WORKFLOW" | grep -q '^ *- name:'; then
   fail "postgres guard and the DATABASE_URL write are in different steps"
 fi

--- a/scripts/tests/test-ci-go-postgres-env-guard.sh
+++ b/scripts/tests/test-ci-go-postgres-env-guard.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# The `postgres-user`, `postgres-password` and `postgres-db` inputs are joined
+# into the DATABASE_URL line that ci-go.yml writes to $GITHUB_ENV. That file is
+# line-based, so a newline inside one of the three turns one entry into several
+# and whoever controls the input can set PATH, GOFLAGS or LD_PRELOAD for every
+# following step. ci-go.yml rejects such values before the write; this checks
+# the rejecting loop actually does that.
+#
+# The loop is read out of ci-go.yml rather than repeated here, so the two cannot
+# drift: a guard edited in the workflow is the guard under test. This is the
+# same arrangement as test-ci-go-test-env-guard.sh, which covers the
+# `test-env-vars` guard in the same file.
+#
+# Run: scripts/tests/test-ci-go-postgres-env-guard.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+WORKFLOW="$REPO/.github/workflows/ci-go.yml"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# The guard is a `for` loop over the three variables wrapping an `if` that tests
+# for a newline. Both lines are read from the workflow, so a rename or a changed
+# test surfaces here rather than silently diverging.
+# shellcheck disable=SC2016 # the $VAR text is matched literally in the YAML
+FOR_LINE="$(sed -n 's/^ *\(for value in "\$POSTGRES_USER".*\); do$/\1/p' "$WORKFLOW")"
+[ -n "$FOR_LINE" ] || fail "no postgres guard loop found in ci-go.yml"
+[ "$(grep -c . <<<"$FOR_LINE")" -eq 1 ] ||
+  fail "expected exactly one postgres guard loop in ci-go.yml"
+
+# shellcheck disable=SC2016 # the $value text is matched literally in the YAML
+IF_LINE="$(sed -n 's/^ *if \(\[ "\$value" != .*\]\); then$/\1/p' "$WORKFLOW")"
+[ -n "$IF_LINE" ] || fail "no postgres guard newline test found in ci-go.yml"
+[ "$(grep -c . <<<"$IF_LINE")" -eq 1 ] ||
+  fail "expected exactly one postgres guard newline test in ci-go.yml"
+
+# All three inputs must be covered — one hardened and another left behind is the
+# failure mode this repo already had with the two test-env-vars occurrences.
+for var in POSTGRES_USER POSTGRES_PASSWORD POSTGRES_DB; do
+  case "$FOR_LINE" in
+  *"\$$var"*) ;;
+  *) fail "postgres guard does not cover \$$var" ;;
+  esac
+done
+
+# The guard must sit above the write it protects, otherwise the injected line is
+# already in $GITHUB_ENV by the time it runs.
+# shellcheck disable=SC2016 # the $POSTGRES_USER text is matched literally
+GUARD_LINE="$(grep -n 'for value in "\$POSTGRES_USER"' "$WORKFLOW" | cut -d: -f1)"
+WRITE_LINE="$(grep -n "^ *printf 'DATABASE_URL=postgres" "$WORKFLOW" | cut -d: -f1)"
+[ -n "$WRITE_LINE" ] || fail "no DATABASE_URL write found in ci-go.yml"
+[ "$GUARD_LINE" -lt "$WRITE_LINE" ] ||
+  fail "postgres guard is at line $GUARD_LINE, below the write at $WRITE_LINE"
+
+# The newline test itself, exercised against real values. The condition comes
+# from the workflow via $IF_LINE, so the behaviour under test is the shipped one.
+# `eval` on a line just read from a tracked file in this repo, not on input.
+run_guard() {
+  local value
+  # shellcheck disable=SC2034 # $value is read by the guard inside the eval below
+  for value in "$1" "$2" "$3"; do
+    if eval "$IF_LINE"; then
+      return 1
+    fi
+  done
+  return 0
+}
+
+# accept <label> <user> <password> <db> — no newline, the step must proceed.
+accept() {
+  local label="$1"
+  shift
+  run_guard "$@" || fail "guard rejects a legitimate input: $label"
+}
+
+# reject <label> <user> <password> <db> — a newline, the step must stop.
+reject() {
+  local label="$1"
+  shift
+  if run_guard "$@"; then
+    fail "guard accepts an injecting input: $label"
+  fi
+}
+
+# "x", newline, "y" — command substitution strips trailing newlines, not inner.
+NL="$(printf 'x\ny')"
+
+accept "workflow defaults" postgres postgres testdb
+accept "empty values" "" "" ""
+accept "values with spaces and shell metacharacters" "us er" 'p@ss=w#rd$`' 'test db'
+accept "value containing a literal backslash-n" 'a\nb' 'c\nd' 'e\nf'
+accept "value containing a tab" "$(printf 'a\tb')" postgres testdb
+
+reject "newline in postgres-user" "$NL" postgres testdb
+reject "newline in postgres-password" postgres "$NL" testdb
+reject "newline in postgres-db" postgres postgres "$NL"
+reject "newline carrying a complete assignment" \
+  postgres "$(printf 'pw\nPATH=/tmp/evil')" testdb
+reject "newline in all three" "$NL" "$NL" "$NL"
+# Not tested: a value that is only a trailing newline. Command substitution
+# strips those, so it cannot be constructed here — and the injection needs a
+# following assignment anyway, which "newline carrying a complete assignment"
+# above covers.
+
+echo "PASS: ci-go.yml postgres newline guard"

--- a/scripts/tests/test-ci-go-postgres-env-guard.sh
+++ b/scripts/tests/test-ci-go-postgres-env-guard.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # The `postgres-user`, `postgres-password` and `postgres-db` inputs are joined
 # into the DATABASE_URL line that ci-go.yml writes to $GITHUB_ENV. That file is
-# line-based, so a newline inside one of the three turns one entry into several
-# and whoever controls the input can set PATH, GOFLAGS or LD_PRELOAD for every
-# following step. ci-go.yml rejects such values before the write; this checks
-# the rejecting loop actually does that.
+# line-based, so a line break inside one of the three turns one entry into
+# several and whoever controls the input can set PATH, GOFLAGS or LD_PRELOAD for
+# every following step. ci-go.yml rejects such values before the write; this
+# checks the rejecting loop actually does that, that it aborts rather than warns,
+# and that it sits in the same step as the write it protects.
 #
 # The loop is read out of ci-go.yml rather than repeated here, so the two cannot
 # drift: a guard edited in the workflow is the guard under test. This is the
@@ -48,13 +49,32 @@ for var in POSTGRES_USER POSTGRES_PASSWORD POSTGRES_DB; do
 done
 
 # The guard must sit above the write it protects, otherwise the injected line is
-# already in $GITHUB_ENV by the time it runs.
+# already in $GITHUB_ENV by the time it runs. `|| true` on both greps: under
+# `set -euo pipefail` a non-matching grep would abort the script at the
+# assignment, so the drift this file exists to catch would surface as a bare
+# non-zero exit instead of the diagnostic below.
 # shellcheck disable=SC2016 # the $POSTGRES_USER text is matched literally
-GUARD_LINE="$(grep -n 'for value in "\$POSTGRES_USER"' "$WORKFLOW" | cut -d: -f1)"
-WRITE_LINE="$(grep -n "^ *printf 'DATABASE_URL=postgres" "$WORKFLOW" | cut -d: -f1)"
+GUARD_LINE="$(grep -n 'for value in "\$POSTGRES_USER"' "$WORKFLOW" | cut -d: -f1 || true)"
+[ -n "$GUARD_LINE" ] || fail "no postgres guard loop line found in ci-go.yml"
+WRITE_LINE="$(grep -n "^ *printf 'DATABASE_URL=postgres" "$WORKFLOW" | cut -d: -f1 || true)"
 [ -n "$WRITE_LINE" ] || fail "no DATABASE_URL write found in ci-go.yml"
+[ "$(grep -c . <<<"$WRITE_LINE")" -eq 1 ] ||
+  fail "expected exactly one DATABASE_URL write in ci-go.yml"
 [ "$GUARD_LINE" -lt "$WRITE_LINE" ] ||
   fail "postgres guard is at line $GUARD_LINE, below the write at $WRITE_LINE"
+
+# Above the write is not enough — both must be in the *same* step. ci-go.yml has
+# a second `Set test environment variables` step in the `test-and-lint` job, so
+# a guard moved there would still be "above" this write while leaving it
+# unprotected: the one-job-hardened-one-behind mode the sibling test covers.
+if sed -n "${GUARD_LINE},${WRITE_LINE}p" "$WORKFLOW" | grep -q '^ *- name:'; then
+  fail "postgres guard and the DATABASE_URL write are in different steps"
+fi
+
+# The guard must abort, not just detect. Without this, turning the `exit 1` into
+# a warning would leave every other assertion here green and the injection open.
+sed -n "${GUARD_LINE},$((WRITE_LINE - 1))p" "$WORKFLOW" | grep -q '^ *exit 1$' ||
+  fail "postgres guard does not exit on a rejected value"
 
 # The newline test itself, exercised against real values. The condition comes
 # from the workflow via $IF_LINE, so the behaviour under test is the shipped one.
@@ -101,6 +121,9 @@ reject "newline in postgres-db" postgres postgres "$NL"
 reject "newline carrying a complete assignment" \
   postgres "$(printf 'pw\nPATH=/tmp/evil')" testdb
 reject "newline in all three" "$NL" "$NL" "$NL"
+reject "carriage return in postgres-user" "$(printf 'a\rPATH=/tmp/evil')" postgres testdb
+reject "carriage return in postgres-password" postgres "$(printf 'a\rb')" testdb
+reject "CRLF in postgres-db" postgres postgres "$(printf 'a\r\nb')"
 # Not tested: a value that is only a trailing newline. Command substitution
 # strips those, so it cannot be constructed here — and the injection needs a
 # following assignment anyway, which "newline carrying a complete assignment"


### PR DESCRIPTION
## Summary

- `postgres-user`, `postgres-password` and `postgres-db` are joined into the `DATABASE_URL` line that `test-and-lint-postgres` appends to `$GITHUB_ENV`. That file is line-based, so a newline in one of the three split the line and injected further environment entries — `PATH`, `GOFLAGS`, `LD_PRELOAD` — for every following step of the job, `go test` included.
- A loop over the three values now fails the step before the write, with the same shape and wording as the `test-env-vars` guard two lines below in the same block. No new mechanism, no change to `DATABASE_URL`, the input signatures or the defaults.
- `scripts/tests/test-ci-go-postgres-env-guard.sh` reads the loop out of the workflow so the check cannot drift from it, asserts all three inputs are covered, and asserts the guard sits above the write it protects.

## Test plan

- [x] `just test` — new `test-ci-go-postgres-env-guard.sh` passes alongside the existing six
- [x] Negative control: removing the guard from `ci-go.yml` turns the new test red (`no postgres guard loop found`), restoring it turns it green
- [x] `just lint` — yamllint, `jq empty`, actionlint (container, with shellcheck) and prettier all clean
- [ ] CI green