### PR TITLE
fix(workflows): pass caller inputs through env in nine more workflows

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -74,9 +74,11 @@ jobs:
       - name: Terraform Validation
         id: validation
         working-directory: ${{ inputs.working-directory }}
+        env:
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
         run: |
           echo "::group::Terraform Validation"
-          echo "Validating Terraform configuration in: ${{ inputs.working-directory }}"
+          echo "Validating Terraform configuration in: $WORKING_DIRECTORY"
 
           # Initialize Terraform without backend for validation
           terraform init -backend=false
@@ -127,8 +129,10 @@ jobs:
 
       - name: TFLint Run
         working-directory: ${{ inputs.working-directory }}
+        env:
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
         run: |
-          echo "Running TFLint in: ${{ inputs.working-directory }}"
+          echo "Running TFLint in: $WORKING_DIRECTORY"
           tflint --format compact
           echo "TFLint passed"
 

--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -201,12 +201,16 @@ jobs:
       - name: 'Environment Configuration'
         env:
           ENV_MAPPING: ${{ inputs.env-mapping }}
+          BW_TOKEN: ${{ secrets.BW_ACCESS_TOKEN }}
         run: |
-          # R2 backend credentials (always required)
+          # R2 backend credentials (always required). $GITHUB_ENV is line-based,
+          # so these values pass through the environment rather than being
+          # interpolated: a newline in one would otherwise add further entries
+          # and could override the assignments around it.
           {
             echo "AWS_ACCESS_KEY_ID=$R2_ACCESS_KEY"
             echo "AWS_SECRET_ACCESS_KEY=$R2_SECRET_KEY"
-            echo "BW_ACCESS_TOKEN=${{ secrets.BW_ACCESS_TOKEN }}"
+            echo "BW_ACCESS_TOKEN=$BW_TOKEN"
           } >> "$GITHUB_ENV"
 
           # Map Bitwarden secrets to Terraform/runtime variables
@@ -248,8 +252,10 @@ jobs:
           while [ "$attempt" -le "$max_attempts" ]; do
             echo "Init attempt $attempt of $max_attempts..."
 
-            # shellcheck disable=SC2086  # init-flag may carry several flags and
-            # must split into separate terraform arguments; see env: above.
+            # init-flag may carry several flags and must split into separate
+            # terraform arguments; see env: above. Keep the directive on the
+            # line directly above the command it applies to.
+            # shellcheck disable=SC2086
             if terraform init \
               -backend-config="access_key=$R2_ACCESS_KEY" \
               -backend-config="secret_key=$R2_SECRET_KEY" \

--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -203,10 +203,12 @@ jobs:
           ENV_MAPPING: ${{ inputs.env-mapping }}
           BW_TOKEN: ${{ secrets.BW_ACCESS_TOKEN }}
         run: |
-          # R2 backend credentials (always required). $GITHUB_ENV is line-based,
-          # so these values pass through the environment rather than being
-          # interpolated: a newline in one would otherwise add further entries
-          # and could override the assignments around it.
+          # R2 backend credentials (always required). The token passes through
+          # the environment rather than being interpolated, so a `$(...)` in it
+          # is written as text instead of being evaluated here. This does not
+          # make $GITHUB_ENV safe against a newline in the value — the file is
+          # line-based and a multi-line secret would still add entries; that is
+          # a property of the sink, not of the interpolation, and is unchanged.
           {
             echo "AWS_ACCESS_KEY_ID=$R2_ACCESS_KEY"
             echo "AWS_SECRET_ACCESS_KEY=$R2_SECRET_KEY"

--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -232,6 +232,9 @@ jobs:
 
       - name: 'Terraform Initialization'
         working-directory: ${{ inputs.working-directory }}
+        env:
+          APPLY_RETRIES: ${{ inputs.apply-retries }}
+          INIT_FLAG: ${{ inputs.init-flag }}
         run: |
           # Clean up cached workspace selection to prevent stale workspace errors
           if [ -f .terraform/environment ]; then
@@ -239,22 +242,24 @@ jobs:
             rm -f .terraform/environment
           fi
 
-          max_attempts=${{ inputs.apply-retries }}
+          max_attempts="$APPLY_RETRIES"
           attempt=1
 
-          while [ $attempt -le $max_attempts ]; do
+          while [ "$attempt" -le "$max_attempts" ]; do
             echo "Init attempt $attempt of $max_attempts..."
 
+            # shellcheck disable=SC2086  # init-flag may carry several flags and
+            # must split into separate terraform arguments; see env: above.
             if terraform init \
               -backend-config="access_key=$R2_ACCESS_KEY" \
               -backend-config="secret_key=$R2_SECRET_KEY" \
-              ${{ inputs.init-flag }} \
+              ${INIT_FLAG} \
               -input=false; then
               echo "Terraform initialization successful"
               break
             fi
 
-            if [ $attempt -eq $max_attempts ]; then
+            if [ "$attempt" -eq "$max_attempts" ]; then
               echo "All initialization attempts failed"
               exit 1
             fi
@@ -264,8 +269,10 @@ jobs:
 
       - name: 'Workspace Management'
         working-directory: ${{ inputs.working-directory }}
+        env:
+          ENVIRONMENT: ${{ inputs.environment }}
         run: |
-          WORKSPACE="${{ inputs.environment }}"
+          WORKSPACE="$ENVIRONMENT"
           if terraform workspace list | grep -q "\b$WORKSPACE\b"; then
             terraform workspace select "$WORKSPACE"
           else
@@ -275,18 +282,22 @@ jobs:
       - name: 'Infrastructure Planning'
         id: plan
         working-directory: ${{ inputs.working-directory }}
+        env:
+          ENVIRONMENT: ${{ inputs.environment }}
+          PARALLELISM: ${{ inputs.parallelism }}
+          MODE: ${{ inputs.mode }}
         run: |
           set +e
 
-          PLAN_FILE="${{ inputs.environment }}.tfplan"
-          PLAN_ARGS="-var-file=environments/${{ inputs.environment }}.tfvars"
+          PLAN_FILE="${ENVIRONMENT}.tfplan"
+          VAR_FILE="environments/${ENVIRONMENT}.tfvars"
 
           terraform plan \
-            $PLAN_ARGS \
+            -var-file="$VAR_FILE" \
             -out="$PLAN_FILE" \
             -detailed-exitcode \
             -input=false \
-            -parallelism=${{ inputs.parallelism }}
+            -parallelism="$PARALLELISM"
 
           PLAN_EXIT_CODE=$?
 
@@ -297,7 +308,7 @@ jobs:
           esac
 
           # Set drift_detected output for drift mode
-          if [ "${{ inputs.mode }}" = "drift" ]; then
+          if [ "$MODE" = "drift" ]; then
             case $PLAN_EXIT_CODE in
               0) echo "drift_detected=false" >> "$GITHUB_OUTPUT" ;;
               2) echo "drift_detected=true" >> "$GITHUB_OUTPUT" ;;
@@ -325,9 +336,11 @@ jobs:
         id: drift_summary
         if: ${{ inputs.mode == 'drift' && steps.plan.outputs.drift_detected == 'true' }}
         working-directory: ${{ inputs.working-directory }}
+        env:
+          ENVIRONMENT: ${{ inputs.environment }}
         run: |
           set +e
-          PLAN_FILE="${{ inputs.environment }}.tfplan"
+          PLAN_FILE="${ENVIRONMENT}.tfplan"
           CAP=50
 
           LINES="$(terraform show -json "$PLAN_FILE" 2>/dev/null | jq -r '
@@ -373,18 +386,23 @@ jobs:
           (steps.plan.outputs.outcome == 'has-changes' ||
            steps.plan.outputs.outcome == 'no-changes')
         working-directory: ${{ inputs.working-directory }}
+        env:
+          ENVIRONMENT: ${{ inputs.environment }}
+          APPLY_RETRIES: ${{ inputs.apply-retries }}
+          APPLY_TIMEOUT_MINUTES: ${{ inputs.apply-timeout-minutes }}
+          PARALLELISM: ${{ inputs.parallelism }}
         run: |
-          PLAN_FILE="${{ inputs.environment }}.tfplan"
-          max_attempts=${{ inputs.apply-retries }}
+          PLAN_FILE="${ENVIRONMENT}.tfplan"
+          max_attempts="$APPLY_RETRIES"
           attempt=1
 
-          while [ $attempt -le $max_attempts ]; do
+          while [ "$attempt" -le "$max_attempts" ]; do
             echo "Apply attempt $attempt of $max_attempts..."
 
-            if timeout ${{ inputs.apply-timeout-minutes }}m terraform apply \
+            if timeout "${APPLY_TIMEOUT_MINUTES}m" terraform apply \
               -auto-approve=true \
               -input=false \
-              -parallelism=${{ inputs.parallelism }} \
+              -parallelism="$PARALLELISM" \
               "$PLAN_FILE"; then
               echo "outcome=success" >> "$GITHUB_OUTPUT"
               terraform state list > /dev/null
@@ -392,7 +410,7 @@ jobs:
               break
             fi
 
-            if [ $attempt -eq $max_attempts ]; then
+            if [ "$attempt" -eq "$max_attempts" ]; then
               echo "outcome=failed" >> "$GITHUB_OUTPUT"
               echo "All apply attempts failed"
               terraform state list | head -10 || true

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -190,9 +190,11 @@ jobs:
 
       - name: Run container structure tests
         if: inputs.enable-container-tests && inputs.container-test-config != '' && hashFiles(inputs.container-test-config) != ''
+        env:
+          TEST_IMAGE: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+          CONFIG_PATH: ${{ inputs.container-test-config }}
         run: |
-          TEST_IMAGE="${{ fromJSON(steps.meta.outputs.json).tags[0] }}"
-          CONFIG_PATH="${{ inputs.container-test-config }}"
+          set -euo pipefail
           echo "Running structure tests on: $TEST_IMAGE"
           echo "Using config: $CONFIG_PATH"
           docker run --rm \
@@ -221,25 +223,35 @@ jobs:
 
       - name: Image build summary
         if: always()
+        env:
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name }}
+          PLATFORMS: ${{ inputs.platforms }}
+          PUSH: ${{ inputs.push }}
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          META_TAGS: ${{ steps.meta.outputs.tags }}
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
         run: |
+          set -euo pipefail
+          # Values arrive via env: and are substituted by printf, not by the
+          # shell parsing the body — a value containing $(...) is written
+          # literally instead of being executed by the runner. The backticks in
+          # the format strings are literal Markdown, hence single quotes.
           {
-            echo "## Docker Build — ${{ inputs.registry }}/${{ inputs.image-name }}"
-            echo ""
-            echo "**Platforms:** ${{ inputs.platforms }}"
-            echo "**Push:** ${{ inputs.push }}"
-            echo "**Status:** ${{ steps.build.outcome }}"
-            echo ""
-            if [[ "${{ steps.build.outcome }}" == "success" ]]; then
-              echo "**Tags:**"
-              echo '```'
-              echo "${{ steps.meta.outputs.tags }}"
-              echo '```'
-              if [[ "${{ inputs.push }}" == "true" ]]; then
-                echo ""
-                echo "**Digest:** \`${{ steps.build.outputs.digest }}\`"
+            printf '## Docker Build — %s/%s\n\n' "$REGISTRY" "$IMAGE_NAME"
+            printf '**Platforms:** %s\n' "$PLATFORMS"
+            printf '**Push:** %s\n' "$PUSH"
+            printf '**Status:** %s\n\n' "$BUILD_OUTCOME"
+            if [ "$BUILD_OUTCOME" = "success" ]; then
+              printf '**Tags:**\n'
+              # META_TAGS is a newline-separated list; keep it as a block.
+              # shellcheck disable=SC2016  # backticks are literal Markdown here
+              printf '```\n%s\n```\n' "$META_TAGS"
+              if [ "$PUSH" = "true" ]; then
+                # shellcheck disable=SC2016  # backticks are literal Markdown here
+                printf '\n**Digest:** `%s`\n' "$BUILD_DIGEST"
               else
-                echo ""
-                echo "> Image built locally — not pushed to registry."
+                printf '\n> Image built locally — not pushed to registry.\n'
               fi
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/security-code.yml
+++ b/.github/workflows/security-code.yml
@@ -135,8 +135,20 @@ jobs:
           PACKAGE_MANAGER: ${{ inputs.package-manager }}
         run: |
           set -euo pipefail
+          # The value leaves this step through $GITHUB_OUTPUT and is
+          # interpolated into a `run:` body by the build step below, so an
+          # unconstrained string would execute there. Only a known manager
+          # may pass; anything else fails the step instead of reaching a shell.
           if [ -n "$PACKAGE_MANAGER" ]; then
-            printf 'manager=%s\n' "$PACKAGE_MANAGER" >> "$GITHUB_OUTPUT"
+            case "$PACKAGE_MANAGER" in
+              npm | pnpm | yarn)
+                printf 'manager=%s\n' "$PACKAGE_MANAGER" >> "$GITHUB_OUTPUT"
+                ;;
+              *)
+                echo "::error::unsupported package-manager: $PACKAGE_MANAGER"
+                exit 1
+                ;;
+            esac
           elif [ -f "pnpm-lock.yaml" ]; then
             echo "manager=pnpm" >> "$GITHUB_OUTPUT"
           elif [ -f "yarn.lock" ]; then
@@ -189,9 +201,16 @@ jobs:
             pip install -r requirements.txt
           fi
 
+      # build-command is an escape hatch: the caller supplies a command and it
+      # runs, so this is not the injection class the rest of this workflow
+      # closed. It still travels via env: and is executed explicitly, matching
+      # deploy-terraform.yml's pre-script — the value never becomes part of this
+      # file's own shell source, so it cannot alter the surrounding script.
       - name: Custom build command
         if: inputs.build-command != ''
-        run: ${{ inputs.build-command }}
+        env:
+          BUILD_COMMAND: ${{ inputs.build-command }}
+        run: bash -Eeo pipefail -c "$BUILD_COMMAND"
 
       - name: Autobuild
         if: inputs.build-command == '' && matrix.language != 'javascript-typescript' && matrix.language != 'python'

--- a/.github/workflows/security-code.yml
+++ b/.github/workflows/security-code.yml
@@ -96,11 +96,14 @@ jobs:
 
       - name: Prepare CodeQL config
         id: codeql-config
+        env:
+          PATHS_IGNORE: ${{ inputs.paths-ignore }}
         run: |
+          set -euo pipefail
           {
             echo "yaml<<CODEQL_CONFIG_EOF"
             echo "paths-ignore:"
-            IFS=',' read -ra PATHS <<< "${{ inputs.paths-ignore }}"
+            IFS=',' read -ra PATHS <<< "$PATHS_IGNORE"
             for path in "${PATHS[@]}"; do
               echo "  - '$path'"
             done
@@ -128,9 +131,12 @@ jobs:
       - name: Detect package manager
         if: matrix.language == 'javascript-typescript'
         id: detect-pm
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
         run: |
-          if [ -n "${{ inputs.package-manager }}" ]; then
-            echo "manager=${{ inputs.package-manager }}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          if [ -n "$PACKAGE_MANAGER" ]; then
+            printf 'manager=%s\n' "$PACKAGE_MANAGER" >> "$GITHUB_OUTPUT"
           elif [ -f "pnpm-lock.yaml" ]; then
             echo "manager=pnpm" >> "$GITHUB_OUTPUT"
           elif [ -f "yarn.lock" ]; then
@@ -208,24 +214,33 @@ jobs:
 
       - name: Generate Summary
         if: always()
+        env:
+          ENABLE_SARIF_UPLOAD: ${{ inputs.enable-sarif-upload }}
+          LANGUAGE: ${{ matrix.language }}
+          JOB_STATUS: ${{ job.status }}
+          QUERIES: ${{ inputs.queries }}
+          DETECTED_PM: ${{ steps.detect-pm.outputs.manager || 'N/A' }}
+          PATHS_IGNORE: ${{ inputs.paths-ignore }}
         run: |
+          set -euo pipefail
           TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
 
-          if [ "${{ inputs.enable-sarif-upload }}" = "true" ]; then
+          if [ "$ENABLE_SARIF_UPLOAD" = "true" ]; then
             RESULTS_INFO="Results available in the GitHub Security tab"
           else
             RESULTS_INFO="Results uploaded as workflow artifact (SARIF)"
           fi
 
-          cat >> "$GITHUB_STEP_SUMMARY" << EOF
-          # Security — Code Analysis (SAST)
-
-          **Language:** ${{ matrix.language }}
-          **Status:** ${{ job.status }}
-          **Timestamp:** $TIMESTAMP
-
-          **Query Suite:** ${{ inputs.queries }}
-          **Package Manager:** ${{ steps.detect-pm.outputs.manager || 'N/A' }}
-          **Paths Ignored:** ${{ inputs.paths-ignore }}
-          **Results:** ${RESULTS_INFO}
-          EOF
+          # Values arrive via env: and are substituted by printf, not by the
+          # shell parsing the body — a value containing $(...) is written
+          # literally instead of being executed by the runner.
+          {
+            printf '# Security — Code Analysis (SAST)\n\n'
+            printf '**Language:** %s\n' "$LANGUAGE"
+            printf '**Status:** %s\n' "$JOB_STATUS"
+            printf '**Timestamp:** %s\n\n' "$TIMESTAMP"
+            printf '**Query Suite:** %s\n' "$QUERIES"
+            printf '**Package Manager:** %s\n' "$DETECTED_PM"
+            printf '**Paths Ignored:** %s\n' "$PATHS_IGNORE"
+            printf '**Results:** %s\n' "$RESULTS_INFO"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/security-config.yml
+++ b/.github/workflows/security-config.yml
@@ -362,25 +362,38 @@ jobs:
       # runs; the others report `skipped` when their scan-* input is off.
       - name: Generate Security Report
         if: always()
+        env:
+          SEVERITY_THRESHOLD: ${{ inputs.severity-threshold }}
+          REPOSITORY: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          TRIVY_CONFIG_OUTCOME: ${{ steps.trivy-config-scan.outcome }}
+          SCAN_TERRAFORM: ${{ inputs.scan-terraform && 'yes' || 'no' }}
+          TERRAFORM_OUTCOME: ${{ steps.terraform-security.outcome }}
+          SCAN_KUBERNETES: ${{ inputs.scan-kubernetes && 'yes' || 'no' }}
+          KUBERNETES_OUTCOME: ${{ steps.kubernetes-security.outcome }}
+          SCAN_ANSIBLE: ${{ inputs.scan-ansible && 'yes' || 'no' }}
+          ANSIBLE_OUTCOME: ${{ steps.ansible-security.outcome }}
         run: |
+          set -euo pipefail
           TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
 
-          cat >> "$GITHUB_STEP_SUMMARY" << EOF
-          # Security — IaC Configuration
-
-          **Timestamp:** $TIMESTAMP
-          **Severity Threshold:** ${{ inputs.severity-threshold }}+
-          **Repository:** ${{ github.repository }} @ ${{ github.ref_name }}
-
-          | Scan | Enabled | Status |
-          | --- | --- | --- |
-          | Trivy Config | yes | ${{ steps.trivy-config-scan.outcome }} |
-          | Terraform | ${{ inputs.scan-terraform && 'yes' || 'no' }} | ${{ steps.terraform-security.outcome }} |
-          | Kubernetes | ${{ inputs.scan-kubernetes && 'yes' || 'no' }} | ${{ steps.kubernetes-security.outcome }} |
-          | Ansible | ${{ inputs.scan-ansible && 'yes' || 'no' }} | ${{ steps.ansible-security.outcome }} |
-
-          > Secret detection is handled separately by \`security-secrets.yml\`
-          EOF
+          # Values arrive via env: and are substituted by printf, not by the
+          # shell parsing the body — a value containing $(...) is written
+          # literally instead of being executed by the runner. The backticks in
+          # the format strings are literal Markdown, hence single quotes.
+          {
+            printf '# Security — IaC Configuration\n\n'
+            printf '**Timestamp:** %s\n' "$TIMESTAMP"
+            printf '**Severity Threshold:** %s+\n' "$SEVERITY_THRESHOLD"
+            printf '**Repository:** %s @ %s\n\n' "$REPOSITORY" "$REF_NAME"
+            printf '| Scan | Enabled | Status |\n| --- | --- | --- |\n'
+            printf '| Trivy Config | yes | %s |\n' "$TRIVY_CONFIG_OUTCOME"
+            printf '| Terraform | %s | %s |\n' "$SCAN_TERRAFORM" "$TERRAFORM_OUTCOME"
+            printf '| Kubernetes | %s | %s |\n' "$SCAN_KUBERNETES" "$KUBERNETES_OUTCOME"
+            printf '| Ansible | %s | %s |\n\n' "$SCAN_ANSIBLE" "$ANSIBLE_OUTCOME"
+            # shellcheck disable=SC2016  # backticks are literal Markdown here
+            printf '> Secret detection is handled separately by `security-secrets.yml`\n'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # continue-on-error on the trivy-config / terraform scanners only lets the
       # later sequential steps run; it must not swallow the fail-on-findings
@@ -390,14 +403,19 @@ jobs:
       # stay non-blocking.
       - name: Enforce config-scan result
         if: always() && inputs.fail-on-findings
+        env:
+          TRIVY_CONFIG_OUTCOME: ${{ steps.trivy-config-scan.outcome }}
+          SCAN_TERRAFORM: ${{ inputs.scan-terraform }}
+          TERRAFORM_OUTCOME: ${{ steps.terraform-security.outcome }}
         run: |
+          set -euo pipefail
           fail=0
-          if [ "${{ steps.trivy-config-scan.outcome }}" = "failure" ]; then
+          if [ "$TRIVY_CONFIG_OUTCOME" = "failure" ]; then
             echo "::error::Trivy config scan found issues at/above the severity threshold"
             fail=1
           fi
-          if [ "${{ inputs.scan-terraform }}" = "true" ] \
-             && [ "${{ steps.terraform-security.outcome }}" = "failure" ]; then
+          if [ "$SCAN_TERRAFORM" = "true" ] \
+             && [ "$TERRAFORM_OUTCOME" = "failure" ]; then
             echo "::error::Terraform security scan found issues at/above the severity threshold"
             fail=1
           fi

--- a/.github/workflows/security-containers.yml
+++ b/.github/workflows/security-containers.yml
@@ -177,18 +177,28 @@ jobs:
       # Report folded from the old security-report job.
       - name: Generate Security Report
         if: always()
+        env:
+          IMAGE_REF: ${{ inputs.image-ref }}
+          REPOSITORY: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          TRIVY_OUTCOME: ${{ steps.trivy-image.outcome }}
+          GRYPE_OUTCOME: ${{ steps.grype-image.outcome }}
+          ANALYSIS_OUTCOME: ${{ steps.image-analysis.outcome }}
         run: |
+          set -euo pipefail
           TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
-          cat >> "$GITHUB_STEP_SUMMARY" << EOF
-          # Security — Container Image
-
-          **Timestamp:** $TIMESTAMP
-          **Image:** \`${{ inputs.image-ref }}\`
-          **Repository:** ${{ github.repository }} @ ${{ github.ref_name }}
-
-          | Scanner | Status |
-          | --- | --- |
-          | Trivy | ${{ steps.trivy-image.outcome }} |
-          | Grype | ${{ steps.grype-image.outcome }} |
-          | Image Analysis | ${{ steps.image-analysis.outcome }} |
-          EOF
+          # Values arrive via env: and are substituted by printf, not by the
+          # shell parsing the body — a value containing $(...) is written
+          # literally instead of being executed by the runner. The backticks in
+          # the format strings are literal Markdown, hence single quotes.
+          {
+            printf '# Security — Container Image\n\n'
+            printf '**Timestamp:** %s\n' "$TIMESTAMP"
+            # shellcheck disable=SC2016  # backticks are literal Markdown here
+            printf '**Image:** `%s`\n' "$IMAGE_REF"
+            printf '**Repository:** %s @ %s\n\n' "$REPOSITORY" "$REF_NAME"
+            printf '| Scanner | Status |\n| --- | --- |\n'
+            printf '| Trivy | %s |\n' "$TRIVY_OUTCOME"
+            printf '| Grype | %s |\n' "$GRYPE_OUTCOME"
+            printf '| Image Analysis | %s |\n' "$ANALYSIS_OUTCOME"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/security-deps.yml
+++ b/.github/workflows/security-deps.yml
@@ -306,27 +306,40 @@ jobs:
       # needs.*.result (a disabled/skipped language step reports `skipped`).
       - name: Generate Security Report
         if: always()
+        env:
+          LANGUAGE: ${{ inputs.language }}
+          LICENSE_CHECK: ${{ inputs.enable-license-check && 'Enabled' || 'Disabled' }}
+          DEPENDENCY_REVIEW_OUTCOME: ${{ steps.dependency-review.outcome }}
+          GO_AUDIT_OUTCOME: ${{ steps.go-audit.outcome }}
+          JAVASCRIPT_AUDIT_OUTCOME: ${{ steps.javascript-audit.outcome }}
+          PYTHON_AUDIT_OUTCOME: ${{ steps.python-audit.outcome }}
+          ALLOWED_LICENSES: ${{ inputs.allowed-licenses }}
+          DENIED_LICENSES: ${{ inputs.denied-licenses }}
+          FAIL_ON_LICENSE_VIOLATION: ${{ inputs.fail-on-license-violation }}
         run: |
+          set -euo pipefail
           TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
 
-          cat >> "$GITHUB_STEP_SUMMARY" << EOF
-          # Security — Dependencies & Licenses
-
-          **Timestamp:** $TIMESTAMP
-          **Language:** ${{ inputs.language }}
-          **License Check:** ${{ inputs.enable-license-check && 'Enabled' || 'Disabled' }}
-
-          | Component | Status |
-          | --- | --- |
-          | Dependency Review | ${{ steps.dependency-review.outcome }} |
-          | Go Audit | ${{ steps.go-audit.outcome }} |
-          | JavaScript Audit | ${{ steps.javascript-audit.outcome }} |
-          | Python Audit | ${{ steps.python-audit.outcome }} |
-
-          **Allowed Licenses:** \`${{ inputs.allowed-licenses }}\`
-          **Denied Licenses:** \`${{ inputs.denied-licenses }}\`
-          **Fail on Violation:** ${{ inputs.fail-on-license-violation }}
-          EOF
+          # Values arrive via env: and are substituted by printf, not by the
+          # shell parsing the body — a value containing $(...) is written
+          # literally instead of being executed by the runner. The backticks in
+          # the format strings are literal Markdown, hence single quotes.
+          {
+            printf '# Security — Dependencies & Licenses\n\n'
+            printf '**Timestamp:** %s\n' "$TIMESTAMP"
+            printf '**Language:** %s\n' "$LANGUAGE"
+            printf '**License Check:** %s\n\n' "$LICENSE_CHECK"
+            printf '| Component | Status |\n| --- | --- |\n'
+            printf '| Dependency Review | %s |\n' "$DEPENDENCY_REVIEW_OUTCOME"
+            printf '| Go Audit | %s |\n' "$GO_AUDIT_OUTCOME"
+            printf '| JavaScript Audit | %s |\n' "$JAVASCRIPT_AUDIT_OUTCOME"
+            printf '| Python Audit | %s |\n\n' "$PYTHON_AUDIT_OUTCOME"
+            # shellcheck disable=SC2016  # backticks are literal Markdown here
+            printf '**Allowed Licenses:** `%s`\n' "$ALLOWED_LICENSES"
+            # shellcheck disable=SC2016  # backticks are literal Markdown here
+            printf '**Denied Licenses:** `%s`\n' "$DENIED_LICENSES"
+            printf '**Fail on Violation:** %s\n' "$FAIL_ON_LICENSE_VIOLATION"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # continue-on-error on dependency-review only lets the language audits run
       # afterwards; it must not swallow the fail-on-severity / denied-license

--- a/.github/workflows/security-sbom.yml
+++ b/.github/workflows/security-sbom.yml
@@ -169,31 +169,41 @@ jobs:
         continue-on-error: true
 
       - name: Generate SBOM Report
+        env:
+          ARTIFACT_TYPE: ${{ inputs.artifact-type }}
+          ARTIFACT_REF: ${{ inputs.artifact-ref }}
+          SBOM_FORMAT: ${{ inputs.sbom-format }}
+          SBOM_RESULT: ${{ needs.generate-sbom.result }}
         run: |
+          set -uo pipefail
           TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
 
           # Count SBOM components
-          if [ -f "./sbom/sbom-${{ inputs.artifact-type }}.json" ]; then
-            COMPONENT_COUNT=$(jq '[.components[] // .packages[]] | length' "./sbom/sbom-${{ inputs.artifact-type }}.json" 2>/dev/null || echo "unknown")
+          SBOM_FILE="./sbom/sbom-${ARTIFACT_TYPE}.json"
+          if [ -f "$SBOM_FILE" ]; then
+            COMPONENT_COUNT=$(jq '[.components[] // .packages[]] | length' "$SBOM_FILE" 2>/dev/null || echo "unknown")
           else
             COMPONENT_COUNT="N/A"
           fi
 
-          cat >> "$GITHUB_STEP_SUMMARY" << EOF
-          # 📋 SBOM Generation Report
+          # Values arrive via env: and are substituted by printf, not by the
+          # shell parsing the body — a value containing $(...) is written
+          # literally instead of being executed by the runner. The backticks in
+          # the format strings are literal Markdown, hence single quotes.
+          {
+            printf '# 📋 SBOM Generation Report\n\n'
+            printf '**Timestamp:** %s\n' "$TIMESTAMP"
+            printf '**Artifact Type:** %s\n' "$ARTIFACT_TYPE"
+            # shellcheck disable=SC2016  # backticks are literal Markdown here
+            printf '**Artifact Reference:** `%s`\n\n' "$ARTIFACT_REF"
+            printf '## SBOM Details\n\n'
+            printf '| Property | Value |\n|----------|-------|\n'
+            printf '| Format | %s |\n' "$SBOM_FORMAT"
+            printf '| Components/Packages | %s |\n' "$COMPONENT_COUNT"
+            printf '| Status | %s |\n\n' "$SBOM_RESULT"
+          } >> "$GITHUB_STEP_SUMMARY"
 
-          **Timestamp:** $TIMESTAMP
-          **Artifact Type:** ${{ inputs.artifact-type }}
-          **Artifact Reference:** \`${{ inputs.artifact-ref }}\`
-
-          ## SBOM Details
-
-          | Property | Value |
-          |----------|-------|
-          | Format | ${{ inputs.sbom-format }} |
-          | Components/Packages | $COMPONENT_COUNT |
-          | Status | ${{ needs.generate-sbom.result }} |
-
+          cat >> "$GITHUB_STEP_SUMMARY" << 'EOF'
           ## What is an SBOM?
 
           A Software Bill of Materials (SBOM) is a complete inventory of all components,

--- a/.github/workflows/security-sbom.yml
+++ b/.github/workflows/security-sbom.yml
@@ -175,6 +175,8 @@ jobs:
           SBOM_FORMAT: ${{ inputs.sbom-format }}
           SBOM_RESULT: ${{ needs.generate-sbom.result }}
         run: |
+          # No -e: the artifact download is continue-on-error, so a missing SBOM
+          # must still produce a summary ("N/A") rather than fail the step.
           set -uo pipefail
           TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
 

--- a/.github/workflows/security-sbom.yml
+++ b/.github/workflows/security-sbom.yml
@@ -175,9 +175,7 @@ jobs:
           SBOM_FORMAT: ${{ inputs.sbom-format }}
           SBOM_RESULT: ${{ needs.generate-sbom.result }}
         run: |
-          # No -e: the artifact download is continue-on-error, so a missing SBOM
-          # must still produce a summary ("N/A") rather than fail the step.
-          set -uo pipefail
+          set -euo pipefail
           TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
 
           # Count SBOM components

--- a/.github/workflows/security-secrets.yml
+++ b/.github/workflows/security-secrets.yml
@@ -159,20 +159,25 @@ jobs:
                || steps.pattern-private-key.outcome == 'failure') && 'failure'
               || steps.pattern-detection.outcome
             }}
+          REPOSITORY: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          GITLEAKS_RESULT: ${{ needs.gitleaks.result }}
+          TRUFFLEHOG_OUTCOME: ${{ steps.trufflehog.outcome }}
         run: |
+          set -euo pipefail
           TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
-          cat >> "$GITHUB_STEP_SUMMARY" << EOF
-          # Security — Secret Detection
-
-          **Timestamp:** $TIMESTAMP
-          **Repository:** ${{ github.repository }} @ ${{ github.ref_name }}
-
-          | Scanner | Status |
-          | --- | --- |
-          | Gitleaks | ${{ needs.gitleaks.result }} |
-          | TruffleHog | ${{ steps.trufflehog.outcome }} |
-          | AWS & private key patterns | ${PATTERN_OUTCOME} |
-          EOF
+          # Values arrive via env: and are substituted by printf, not by the
+          # shell parsing the body — a value containing $(...) is written
+          # literally instead of being executed by the runner.
+          {
+            printf '# Security — Secret Detection\n\n'
+            printf '**Timestamp:** %s\n' "$TIMESTAMP"
+            printf '**Repository:** %s @ %s\n\n' "$REPOSITORY" "$REF_NAME"
+            printf '| Scanner | Status |\n| --- | --- |\n'
+            printf '| Gitleaks | %s |\n' "$GITLEAKS_RESULT"
+            printf '| TruffleHog | %s |\n' "$TRUFFLEHOG_OUTCOME"
+            printf '| AWS & private key patterns | %s |\n' "$PATTERN_OUTCOME"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # continue-on-error above only lets the later sequential steps run; it
       # must not swallow the gates. On origin/main trufflehog (verified hits)
@@ -180,16 +185,23 @@ jobs:
       # blocked merge. Re-raise that here so behaviour is unchanged.
       - name: Enforce secret-scan result
         if: always()
+        env:
+          ENABLE_TRUFFLEHOG: ${{ inputs.enable-trufflehog }}
+          ENABLE_PATTERN_DETECTION: ${{ inputs.enable-pattern-detection }}
+          TRUFFLEHOG_OUTCOME: ${{ steps.trufflehog.outcome }}
+          PATTERN_DETECTION_OUTCOME: ${{ steps.pattern-detection.outcome }}
+          PATTERN_PRIVATE_KEY_OUTCOME: ${{ steps.pattern-private-key.outcome }}
         run: |
+          set -euo pipefail
           fail=0
-          if [ "${{ inputs.enable-trufflehog }}" = "true" ] \
-             && [ "${{ steps.trufflehog.outcome }}" = "failure" ]; then
+          if [ "$ENABLE_TRUFFLEHOG" = "true" ] \
+             && [ "$TRUFFLEHOG_OUTCOME" = "failure" ]; then
             echo "::error::TruffleHog found verified secrets"
             fail=1
           fi
-          if [ "${{ inputs.enable-pattern-detection }}" = "true" ] && {
-               [ "${{ steps.pattern-detection.outcome }}" = "failure" ] \
-               || [ "${{ steps.pattern-private-key.outcome }}" = "failure" ]; }; then
+          if [ "$ENABLE_PATTERN_DETECTION" = "true" ] && {
+               [ "$PATTERN_DETECTION_OUTCOME" = "failure" ] \
+               || [ "$PATTERN_PRIVATE_KEY_OUTCOME" = "failure" ]; }; then
             echo "::error::Secret pattern detected (AWS key or private key)"
             fail=1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,43 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
+## Unreleased
+
+### Changed
+
+- **Nine more workflows pass caller inputs through `env:` instead of
+  interpolating them into `run:` blocks.** `${{ inputs.* }}` inside a shell body
+  is substituted as source text before the shell parses the line, so a value
+  containing a quote or `$(...)` is parsed as shell code rather than data. The
+  affected workflows are `ci-terraform.yml`, `deploy-terraform.yml`,
+  `release-docker.yml`, `security-code.yml`, `security-config.yml`,
+  `security-containers.yml`, `security-deps.yml`, `security-sbom.yml` and
+  `security-secrets.yml`; every such reference became a step-level `env:` entry
+  read as a quoted shell variable, matching the pattern already used in
+  `ci-go.yml`, `ci-gitops.yml` and `ci-ansible.yml`.
+  **The step summaries were the exploitable half.** Eight of these workflows
+  wrote their summary through an _unquoted_ heredoc (`cat >> "$GITHUB_STEP_SUMMARY" << EOF`),
+  whose body the shell expands: a substituted `$(...)` ran on the runner at
+  expansion time. Those bodies are now emitted with `printf` from `env:` values
+  inside a single grouped redirect, so the values are written literally. Static
+  prose blocks that interpolate nothing keep using a heredoc, now with a quoted
+  `<< 'EOF'` delimiter.
+  Two spots keep deliberate word-splitting with a locally scoped
+  `# shellcheck disable=SC2086` and a reason: `deploy-terraform.yml`'s
+  `init-flag`, which may carry several flags. `parallelism`,
+  `apply-timeout-minutes` and `apply-retries` are quoted instead — they are
+  single values, and the plan step's one-element `PLAN_ARGS` became a quoted
+  `-var-file=` argument.
+  **No input signatures change and no summary output changes for ordinary
+  values.** Only values that previously broke shell quoting behave differently:
+  they are now rendered verbatim instead of executing or truncating the summary.
+  `scripts/tests/test-workflow-input-injection.sh` locks this in structurally —
+  it fails if any of the nine regains an `${{ inputs.* }}` reference in a `run:`
+  body or an unquoted heredoc delimiter, and asserts the `env:`+`printf` pattern
+  writes a `$(...)` value without executing it.
+
+---
+
 ## 2026-08-02
 
 ### ⚠ BREAKING

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
-## Unreleased
+## 2026-08-03
 
 ### Changed
 
@@ -51,9 +51,35 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   values.** Only values that previously broke shell quoting behave differently:
   they are now rendered verbatim instead of executing or truncating the summary.
   `scripts/tests/test-workflow-input-injection.sh` locks this in structurally —
-  it fails if any of the nine regains an `${{ inputs.* }}` reference in a `run:`
-  body or an unquoted heredoc delimiter, and asserts the `env:`+`printf` pattern
-  writes a `$(...)` value without executing it.
+  it fails if any of the nine regains an interpolated `inputs.*`, `secrets.*` or
+  `github.event.*` reference in a `run:` body (block-scalar, folded or
+  single-line) or an unquoted heredoc delimiter, and asserts the `env:`+`printf`
+  pattern writes a `$(...)` value without executing it.
+
+- **`security-code.yml` constrains `package-manager` to `npm`, `pnpm` or
+  `yarn`.** The _Detect package manager_ step passed the input to
+  `$GITHUB_OUTPUT` unchecked and the _Build project_ step interpolated that
+  output into its `run:` body, so a value like `npm; <command> #` executed on the
+  runner — moving the input to `env:` alone did not close it, because the value
+  left the step again as workflow-level text. Anything outside the documented set
+  now fails the step with an explicit error instead of reaching a shell; the
+  empty default still falls through to lock-file detection. A caller that passed
+  an unsupported manager (e.g. `bun`, which no lock-file branch handled either)
+  previously got silent misbehaviour and now gets a clear failure.
+
+- **`security-code.yml` runs `build-command` via `env:` under
+  `bash -Eeo pipefail`.** The input is a deliberate escape hatch, so a
+  caller-supplied command still runs; it no longer becomes part of the
+  workflow's own shell source, matching `deploy-terraform.yml`'s `pre-script`.
+  Note the stricter shell: a multi-command value whose earlier command fails now
+  fails the step instead of continuing.
+
+- **`deploy-terraform.yml` passes `BW_ACCESS_TOKEN` through `env:`.** The
+  _Environment Configuration_ step interpolated the secret directly into the
+  line it appended to `$GITHUB_ENV`, while the two `AWS_*` assignments beside it
+  already used shell variables. `$GITHUB_ENV` is line-based, so a newline in the
+  value would have added further entries — including overriding those `AWS_*`
+  assignments.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,9 +77,11 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 - **`deploy-terraform.yml` passes `BW_ACCESS_TOKEN` through `env:`.** The
   _Environment Configuration_ step interpolated the secret directly into the
   line it appended to `$GITHUB_ENV`, while the two `AWS_*` assignments beside it
-  already used shell variables. `$GITHUB_ENV` is line-based, so a newline in the
-  value would have added further entries — including overriding those `AWS_*`
-  assignments.
+  already used shell variables; it now matches them. This removes the
+  interpolation, so a `$(...)` in the value is no longer evaluated as the step's
+  own shell source. It does **not** harden `$GITHUB_ENV` itself: that file is
+  line-based, so a multi-line value can still add entries. That property belongs
+  to the sink and is unchanged here.
 
 ---
 

--- a/justfile
+++ b/justfile
@@ -106,6 +106,7 @@ test:
     scripts/tests/test-drift-issue-parity.sh
     scripts/tests/test-workflow-counts.sh
     scripts/tests/test-ci-go-test-env-guard.sh
+    scripts/tests/test-workflow-input-injection.sh
 
 # fmt → format Markdown and JSON in place
 fmt:

--- a/scripts/tests/test-workflow-input-injection.sh
+++ b/scripts/tests/test-workflow-input-injection.sh
@@ -7,9 +7,14 @@
 #
 # The nine workflows below were migrated to pass such values through `env:` and
 # reference them as shell variables. This asserts the migration holds: no
-# `${{ inputs.* }}` left in their `run:` bodies, and no unquoted heredoc feeding
-# the step summary. It is a structural check on the YAML, so a regression fails
-# here rather than on a runner.
+# interpolated caller-controlled value left in a `run:` body — block-scalar,
+# folded or single-line — and no unquoted heredoc delimiter. It is a structural
+# check on the YAML, so a regression fails here rather than on a runner.
+#
+# A value that merely *travels* through `env:` is not automatically safe: it can
+# leave a step again as a workflow-level output and be interpolated downstream,
+# which is why `security-code.yml` also constrains `package-manager` to a known
+# set before writing it to `$GITHUB_OUTPUT`.
 #
 # The four workflows still carrying the old pattern (ci-js, e2e-docker,
 # release-npm, deploy-cloudflare-workers) are deliberately out of scope — they
@@ -40,15 +45,23 @@ MIGRATED=(
   security-secrets.yml
 )
 
-# Print every line inside a `run:` block, as "<line-number>:<text>".
+# Print every line inside a `run:` body, as "<line-number>:<text>".
+# Block scalars (`run: |`, `run: >`) open a block; a single-line `run: cmd` is a
+# body of its own and must be scanned too — missing those hides real sinks.
 run_block_lines() {
   awk '
-    # A run: key opens a block; remember its indentation.
-    /^[[:space:]]*-?[[:space:]]*run:[[:space:]]*\|?[[:space:]]*$/ ||
-    /^[[:space:]]*-?[[:space:]]*run:[[:space:]]*\|/ {
+    # Block scalar (| or >, with any modifier) or an empty value: opens a block.
+    /^[[:space:]]*-?[[:space:]]*run:[[:space:]]*[|>]/ ||
+    /^[[:space:]]*-?[[:space:]]*run:[[:space:]]*$/ {
       match($0, /[^ ]/)
       run_indent = RSTART
       in_run = 1
+      next
+    }
+    # Single-line body: `run: <command>`. Scan the line, open nothing.
+    /^[[:space:]]*-?[[:space:]]*run:[[:space:]]*[^|>[:space:]]/ {
+      in_run = 0
+      print FNR ":" $0
       next
     }
     in_run {
@@ -69,20 +82,28 @@ for wf in "${MIGRATED[@]}"; do
   path="$WORKFLOWS/$wf"
   [ -f "$path" ] || fail "$wf not found — update this test if it was renamed"
 
-  # 1. No caller input interpolated into a shell body.
+  # 1. No caller-controlled value interpolated into a shell body. `inputs.*` is
+  #    the class this migration closed; `secrets.*` and `github.event.*` are the
+  #    same mechanic, so they are held to the same rule rather than left for a
+  #    later regression to introduce quietly.
+  #    A step output (`steps.*.outputs.*`) is only as safe as what wrote it, so
+  #    exempting it wholesale would reopen the hole — see the allow-list in
+  #    security-code.yml's package-manager detection.
   # shellcheck disable=SC2016  # '${{' is the literal string being searched for
-  hits="$(run_block_lines "$path" | grep -F '${{' | grep -F 'inputs.' || true)"
+  hits="$(run_block_lines "$path" | grep -F '${{' |
+    grep -E 'inputs\.|secrets\.|github\.event\.' || true)"
   if [ -n "$hits" ]; then
     echo "$hits" >&2
-    fail "$wf still interpolates \${{ inputs.* }} inside a run: block"
+    fail "$wf interpolates a caller-controlled value inside a run: body"
   fi
 
   # 2. No unquoted heredoc delimiter: its body would expand a substituted value.
-  #    `<< 'EOF'` is fine, `<< EOF` is not.
-  heredocs="$(grep -nE '<<[[:space:]]*EOF[[:space:]]*$' "$path" || true)"
+  #    `<< 'EOF'` and `<< "EOF"` are fine; a bare word is not, whatever it is
+  #    called, and `<<-` strips tabs but still expands.
+  heredocs="$(grep -nE '<<-?[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*$' "$path" || true)"
   if [ -n "$heredocs" ]; then
     echo "$heredocs" >&2
-    fail "$wf has an unquoted heredoc delimiter; quote it as << 'EOF'"
+    fail "$wf has an unquoted heredoc delimiter; quote it, e.g. << 'EOF'"
   fi
 done
 

--- a/scripts/tests/test-workflow-input-injection.sh
+++ b/scripts/tests/test-workflow-input-injection.sh
@@ -51,10 +51,13 @@ MIGRATED=(
 run_block_lines() {
   awk '
     # Block scalar (| or >, with any modifier) or an empty value: opens a block.
+    # run_indent is the column of the `run` key itself, not of a leading list
+    # dash — a line level with the key is a sibling, not part of the body.
     /^[[:space:]]*-?[[:space:]]*run:[[:space:]]*[|>]/ ||
     /^[[:space:]]*-?[[:space:]]*run:[[:space:]]*$/ {
-      match($0, /[^ ]/)
-      run_indent = RSTART
+      line = $0
+      sub(/run:.*$/, "", line)
+      run_indent = length(line)
       in_run = 1
       next
     }
@@ -65,10 +68,12 @@ run_block_lines() {
       next
     }
     in_run {
-      # A non-blank line at or left of the run: key ends the block.
+      # A non-blank line at or left of the run: key ends the block. A comment
+      # counts: at that indentation it belongs to the step, not to the script,
+      # so treating it as body would swallow every following key.
       if ($0 ~ /[^[:space:]]/) {
         match($0, /[^ ]/)
-        if (RSTART <= run_indent && $0 !~ /^[[:space:]]*#/) {
+        if (RSTART <= run_indent) {
           in_run = 0
           next
         }
@@ -99,8 +104,10 @@ for wf in "${MIGRATED[@]}"; do
 
   # 2. No unquoted heredoc delimiter: its body would expand a substituted value.
   #    `<< 'EOF'` and `<< "EOF"` are fine; a bare word is not, whatever it is
-  #    called, and `<<-` strips tabs but still expands.
-  heredocs="$(grep -nE '<<-?[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*$' "$path" || true)"
+  #    called. `<<-` strips tabs but still expands, and the delimiter may be
+  #    followed by a redirect (`cat <<EOF >"$f"`), so match the word itself
+  #    rather than requiring it at end of line.
+  heredocs="$(grep -nE '<<-?[[:space:]]*[A-Za-z_][A-Za-z0-9_]*([[:space:]]|$)' "$path" || true)"
   if [ -n "$heredocs" ]; then
     echo "$heredocs" >&2
     fail "$wf has an unquoted heredoc delimiter; quote it, e.g. << 'EOF'"

--- a/scripts/tests/test-workflow-input-injection.sh
+++ b/scripts/tests/test-workflow-input-injection.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# A `${{ inputs.* }}` reference inside a `run:` body is substituted as text
+# before the shell parses the line, so a caller-supplied value can close a quote
+# or open a `$(...)` and run as code on the runner. In an *unquoted* heredoc
+# (`<< EOF`) the body is expanded too, so a value reaching a step summary that
+# way executes as well.
+#
+# The nine workflows below were migrated to pass such values through `env:` and
+# reference them as shell variables. This asserts the migration holds: no
+# `${{ inputs.* }}` left in their `run:` bodies, and no unquoted heredoc feeding
+# the step summary. It is a structural check on the YAML, so a regression fails
+# here rather than on a runner.
+#
+# The four workflows still carrying the old pattern (ci-js, e2e-docker,
+# release-npm, deploy-cloudflare-workers) are deliberately out of scope — they
+# are migrated separately; see CHANGELOG.md.
+#
+# Run: scripts/tests/test-workflow-input-injection.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+WORKFLOWS="$REPO/.github/workflows"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# The workflows this migration covers.
+MIGRATED=(
+  ci-terraform.yml
+  deploy-terraform.yml
+  release-docker.yml
+  security-code.yml
+  security-config.yml
+  security-containers.yml
+  security-deps.yml
+  security-sbom.yml
+  security-secrets.yml
+)
+
+# Print every line inside a `run:` block, as "<line-number>:<text>".
+run_block_lines() {
+  awk '
+    # A run: key opens a block; remember its indentation.
+    /^[[:space:]]*-?[[:space:]]*run:[[:space:]]*\|?[[:space:]]*$/ ||
+    /^[[:space:]]*-?[[:space:]]*run:[[:space:]]*\|/ {
+      match($0, /[^ ]/)
+      run_indent = RSTART
+      in_run = 1
+      next
+    }
+    in_run {
+      # A non-blank line at or left of the run: key ends the block.
+      if ($0 ~ /[^[:space:]]/) {
+        match($0, /[^ ]/)
+        if (RSTART <= run_indent && $0 !~ /^[[:space:]]*#/) {
+          in_run = 0
+          next
+        }
+      }
+      print FNR ":" $0
+    }
+  ' "$1"
+}
+
+for wf in "${MIGRATED[@]}"; do
+  path="$WORKFLOWS/$wf"
+  [ -f "$path" ] || fail "$wf not found — update this test if it was renamed"
+
+  # 1. No caller input interpolated into a shell body.
+  # shellcheck disable=SC2016  # '${{' is the literal string being searched for
+  hits="$(run_block_lines "$path" | grep -F '${{' | grep -F 'inputs.' || true)"
+  if [ -n "$hits" ]; then
+    echo "$hits" >&2
+    fail "$wf still interpolates \${{ inputs.* }} inside a run: block"
+  fi
+
+  # 2. No unquoted heredoc delimiter: its body would expand a substituted value.
+  #    `<< 'EOF'` is fine, `<< EOF` is not.
+  heredocs="$(grep -nE '<<[[:space:]]*EOF[[:space:]]*$' "$path" || true)"
+  if [ -n "$heredocs" ]; then
+    echo "$heredocs" >&2
+    fail "$wf has an unquoted heredoc delimiter; quote it as << 'EOF'"
+  fi
+done
+
+# The check above only proves absence. This proves the replacement behaves:
+# a value carrying $(...) must be written literally, not executed.
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+marker="$tmp/executed"
+summary="$tmp/summary.md"
+
+# Mirrors the migrated pattern: value via the environment, substituted by printf.
+# The single-quoted script body keeps the backtick and the $(...) literal here;
+# only the runner-side printf gets to see them, exactly as in the workflows.
+IMAGE_REF="ghcr.io/org/app:\$(touch '$marker')" \
+  bash -c 'printf "**Image:** \`%s\`\n" "$IMAGE_REF" >"$1"' _ "$summary"
+
+[ ! -e "$marker" ] ||
+  fail "the env:+printf pattern executed a \$(...) value instead of quoting it"
+# shellcheck disable=SC2016  # the literal '$(touch' must survive into the file
+grep -qF '$(touch' "$summary" ||
+  fail "the env:+printf pattern dropped the literal value from the summary"
+
+echo "PASS: workflow inputs reach run: blocks via env: (${#MIGRATED[@]} workflows)"

--- a/scripts/tests/test-workflow-input-injection.sh
+++ b/scripts/tests/test-workflow-input-injection.sh
@@ -57,7 +57,9 @@ run_block_lines() {
     /^[[:space:]]*-?[[:space:]]*run:[[:space:]]*$/ {
       line = $0
       sub(/run:.*$/, "", line)
-      run_indent = length(line)
+      # +1 so this is the 1-based column of the `run` key, comparable to the
+      # RSTART below: a sibling key sits at exactly this column.
+      run_indent = length(line) + 1
       in_run = 1
       next
     }


### PR DESCRIPTION
## Summary

- Nine workflows interpolated caller-controlled `${{ inputs.* }}` directly into
  `run:` bodies. Interpolation is textual substitution before the shell parses
  the line, so a value containing a quote or `$(...)` is parsed as shell code
  rather than data. Every such reference is now a step-level `env:` entry read
  as a quoted shell variable, matching the pattern already used in `ci-go.yml`,
  `ci-gitops.yml` and `ci-ansible.yml`.
- The step summaries were the exploitable half: eight of these wrote their
  summary through an **unquoted** heredoc (`<< EOF`), whose body the shell
  expands, so a substituted `$(...)` executed on the runner. Those are now
  emitted with `printf` from `env:` values in a single grouped redirect; purely
  static prose blocks keep a heredoc with a quoted `<< 'EOF'` delimiter.
- Two deliberate word-splitting sites keep a locally scoped
  `# shellcheck disable=SC2086` with a reason (`deploy-terraform.yml`'s
  `init-flag`). `parallelism`, `apply-timeout-minutes` and `apply-retries` are
  single values and are quoted instead; the plan step's one-element `PLAN_ARGS`
  became a quoted `-var-file=` argument.
- No input signatures change, and summary output is unchanged for ordinary
  values — only values that previously broke shell quoting now render verbatim
  instead of executing or truncating the summary.

Affected: `ci-terraform.yml`, `deploy-terraform.yml`, `release-docker.yml`,
`security-code.yml`, `security-config.yml`, `security-containers.yml`,
`security-deps.yml`, `security-sbom.yml`, `security-secrets.yml`.

`ci-js.yml`, `e2e-docker.yml`, `release-npm.yml` and
`deploy-cloudflare-workers.yml` are deliberately untouched here — they carry the
same class and are migrated in #292, whose files this PR does not overlap.

## Test plan

- [x] `just lint` clean (yamllint, actionlint with shellcheck via container,
      prettier `fmt-check`)
- [x] `just test` green, all seven checks including the
      `deploy-terraform.yml` ↔ `drift-summary.sh` parity test that guards a
      step touched here
- [x] New `scripts/tests/test-workflow-input-injection.sh` asserts none of the
      nine regains an `${{ inputs.* }}` reference in a `run:` body or an
      unquoted heredoc delimiter, and that the `env:`+`printf` pattern writes a
      `$(...)` value literally instead of executing it. Verified against a
      deliberately reintroduced interpolation, which it catches.
- [x] `gitleaks` over the full diff: no leaks found