### PR TITLE
refactor(ci-go): reject a CR byte in test-env-vars, not only an LF

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -246,11 +246,14 @@ jobs:
           fi
 
           if [ -n "${TEST_ENV_VARS:-}" ]; then
-            # $GITHUB_ENV is line-based: a newline inside a key or value would inject
-            # additional environment entries for every following step.
+            # $GITHUB_ENV is line-based: a line break inside a key or value would
+            # inject additional environment entries for every following step. The
+            # runner splits on LF and CRLF only, so `\n` covers both terminators;
+            # `\r` is rejected as defence in depth, so the guard does not depend on
+            # that parsing detail staying as it is.
             if ! printf '%s' "$TEST_ENV_VARS" \
-              | jq -e 'to_entries | any(.[]; ((.key, (.value | tostring)) | contains("\n"))) | not' >/dev/null; then
-              echo "Error: multi-line test-env-vars keys or values are not supported" >&2
+              | jq -e 'to_entries | any(.[]; (.key, (.value | tostring)) | test("[\n\r]")) | not' >/dev/null; then
+              printf 'Error: test-env-vars keys or values must not contain a CR or LF byte\n' >&2
               exit 1
             fi
             printf '%s' "$TEST_ENV_VARS" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,24 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   line-based, so a multi-line value can still add entries. That property belongs
   to the sink and is unchanged here.
 
+- **`ci-go.yml` rejects a CR byte in `test-env-vars`, not only an LF.** The
+  guard tested `contains("\n")`; it now tests `test("[\n\r]")`. **This is
+  defence in depth, not a closed hole.** The runner splits `$GITHUB_ENV` on LF
+  and CRLF only — `ReadLine` in `src/Runner.Worker/FileCommandManager.cs`
+  searches for `\n` — so rejecting `\n` already covered both terminators, and a
+  lone `\r` stayed a byte inside the value rather than starting a new entry. The
+  guard no longer depends on that parsing detail remaining as it is.
+  **What the guard protects is narrower than "a caller can set `GOFLAGS`":**
+  setting arbitrary variables is the input's documented purpose, so the
+  escalation is the case where the keys are the caller's but a value is
+  interpolated from untrusted data (a PR title, a branch name) and writes entries
+  of its own.
+  `scripts/tests/test-ci-go-test-env-guard.sh` gained the two genuinely new
+  cases (CR in a value, CR in a key), a CRLF regression case the old guard
+  already rejected, and an `accept` case for a literal backslash-r so the
+  escaped two-character sequence stays permitted. **No behaviour change for
+  valid input:** values without a CR or LF byte are written exactly as before.
+
 ---
 
 ## 2026-08-02

--- a/scripts/tests/test-ci-go-test-env-guard.sh
+++ b/scripts/tests/test-ci-go-test-env-guard.sh
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
-# $GITHUB_ENV is line-based, so a newline inside a `test-env-vars` value turns
-# one entry into several — whoever controls that input can set PATH, GOFLAGS or
-# LD_PRELOAD for every following step of the job, `go test` included. ci-go.yml
-# rejects such values before writing the file; this checks the rejecting jq
-# expression actually does that.
+# $GITHUB_ENV is line-based, so a line break inside a `test-env-vars` value turns
+# one entry into several. Setting arbitrary variables is what the input is for, so
+# the escalation is not "a caller can set GOFLAGS" — it is the narrower case where
+# the keys are the caller's but a value is interpolated from untrusted data (a PR
+# title, a branch name): that value then writes entries of its own, for every
+# following step of the job.
+#
+# The runner splits on LF and CRLF only (`ReadLine` in
+# `src/Runner.Worker/FileCommandManager.cs` searches for `\n`), so rejecting `\n`
+# already covers both terminators; `\r` is rejected as defence in depth, not
+# because a lone CR splits a line today.
+#
+# ci-go.yml rejects such values before writing the file; this checks the
+# rejecting jq expression actually does that.
 #
 # The expression is read out of ci-go.yml rather than repeated here, so the two
 # cannot drift: a guard edited in the workflow is the guard under test. The
@@ -35,13 +44,13 @@ COUNT="$(grep -c . <<<"$GUARDS")"
 
 GUARD="$(head -n 1 <<<"$GUARDS")"
 
-# accept <label> <json> — value has no newline, the step must proceed.
+# accept <label> <json> — value has no line break, the step must proceed.
 accept() {
   printf '%s' "$2" | jq -e "$GUARD" >/dev/null ||
     fail "guard rejects a legitimate input: $1"
 }
 
-# reject <label> <json> — value carries a newline, the step must stop.
+# reject <label> <json> — value carries a line break, the step must stop.
 reject() {
   if printf '%s' "$2" | jq -e "$GUARD" >/dev/null 2>&1; then
     fail "guard accepts an injecting input: $1"
@@ -52,6 +61,7 @@ accept "single-line entries" '{"API_URL":"http://localhost","MSG":"a b"}'
 accept "empty object" '{}'
 accept "non-string values" '{"PORT":5432,"DEBUG":true}'
 accept "value containing a literal backslash-n" '{"MSG":"a\\nb"}'
+accept "value containing a literal backslash-r" '{"MSG":"a\\rb"}'
 reject "newline in a value" '{"MSG":"harmless\nPATH=/tmp/evil"}'
 reject "newline in the second of two values" '{"API":"a b","MSG":"x\nGOFLAGS=-tags=evil"}'
 reject "trailing newline in a value" '{"MSG":"value\n"}'
@@ -61,8 +71,18 @@ reject "trailing newline in a value" '{"MSG":"value\n"}'
 reject "newline in a key" '{"MSG\nPATH=/tmp/evil":"x"}'
 reject "newline in the second of two keys" '{"API":"a b","MSG\nLD_PRELOAD=/tmp/evil.so":"x"}'
 
+# A lone CR is not a terminator for today's runner, so these two are defence in
+# depth rather than a closed hole: the guard stops depending on how the runner
+# splits lines. The old `contains("\n")` accepted both.
+reject "carriage return in a value" '{"MSG":"harmless\rPATH=/tmp/evil"}'
+reject "carriage return in a key" '{"MSG\rPATH=/tmp/evil":"x"}'
+
+# CRLF contains an LF, so the old guard already rejected it. Kept as a regression
+# test: it is the case a future rewrite of the expression is most likely to drop.
+reject "CRLF in a value" '{"MSG":"harmless\r\nPATH=/tmp/evil"}'
+
 # Invalid JSON already failed the step before the guard existed (`set -euo
 # pipefail` plus a non-zero jq); it must keep failing rather than fall through.
 reject "invalid JSON" 'not-json'
 
-echo "PASS: ci-go.yml test-env-vars newline guard"
+echo "PASS: ci-go.yml test-env-vars line-break guard"


### PR DESCRIPTION
## Summary

- The `test-env-vars` guard in `ci-go.yml` tested `contains("\n")`; it now tests `test("[\n\r]")`, so a CR byte in a key or value is rejected too.
- **This is defence in depth, not a closed hole.** The runner splits `$GITHUB_ENV` on LF and CRLF only — `ReadLine` in `src/Runner.Worker/FileCommandManager.cs` searches for `\n` — so rejecting `\n` already covered both terminators, and a lone `\r` stayed a byte inside the value rather than starting a new entry. The guard no longer depends on that parsing detail remaining as it is.
- `scripts/tests/test-ci-go-test-env-guard.sh` gained the two genuinely new cases (CR in a value, CR in a key), a CRLF regression case the old guard already rejected, and an `accept` case for a literal backslash-r so the escaped two-character sequence stays permitted.

## Test plan

- [x] `scripts/tests/test-ci-go-test-env-guard.sh` passes; the test reads the guard out of the workflow, so it exercises the edited expression
- [x] `just test` green (all script self-checks)
- [x] `just lint` green (yamllint, actionlint + shellcheck, prettier)
- [ ] CI green