### PR TITLE
fix(workflows)!: remove pre-build-commands from the Go workflows

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -44,11 +44,6 @@ on:
         required: false
         default: './cmd'
         description: 'Path to main binary entrypoint (e.g. ./cmd/app)'
-      pre-build-commands:
-        type: string
-        required: false
-        default: ''
-        description: 'Commands to run before build (e.g. code generation)'
       enable-postgres:
         type: boolean
         required: false
@@ -203,10 +198,6 @@ jobs:
           check-latest: true
           cache: true
           cache-dependency-path: go.sum
-
-      - name: Run pre-build commands
-        if: inputs.pre-build-commands != ''
-        run: ${{ inputs.pre-build-commands }}
 
       - name: Download and verify dependencies
         run: |

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -24,11 +24,6 @@ on:
         required: false
         default: '.'
         description: 'Working directory'
-      pre-build-commands:
-        type: string
-        required: false
-        default: ''
-        description: 'Commands to run before GoReleaser (e.g. code generation)'
       extra-env:
         type: string
         required: false
@@ -89,10 +84,6 @@ jobs:
           key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-build-
-
-      - name: Run pre-build commands
-        if: inputs.pre-build-commands != ''
-        run: ${{ inputs.pre-build-commands }}
 
       - name: Parse extra environment variables
         if: inputs.extra-env != ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,34 +20,21 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
-## 2026-08-05
+## 2026-08-04
 
 ### ⚠ BREAKING
 
 - **`ci-go.yml` and `release-go.yml` no longer accept `pre-build-commands`.**
-  The input was interpolated straight into a `run:` body, so whoever set it ran
-  arbitrary shell on the runner — a wider hole than the `$GITHUB_ENV` writes
-  fixed in the entries below, since it did not even go through the environment
-  file. No repository in the organisation passed the input, so it is removed
-  rather than wrapped in a trust model nobody relies on.
-  **Migration:** run those commands as your own step in the calling workflow,
-  before the `uses:` call. The command then lives in the calling repository
-  instead of travelling as a string through a workflow input.
-
-### Details
-
-- **Both Go workflows joined the injection guard's `MIGRATED` list.**
-  `scripts/tests/test-workflow-input-injection.sh` asserts structurally that no
-  caller-controlled `${{ }}` reaches a `run:` body; `ci-go.yml` and
-  `release-go.yml` were absent from that list precisely because
-  `pre-build-commands` disqualified them. With the input gone they are covered,
-  which is what keeps the pattern from returning. This also resolves the caveat
-  in the 2026-08-02 entry below, which named `pre-build-commands` as the one
-  remaining `run:` interpolation in `ci-go.yml` that could not move to `env:`.
-
-## 2026-08-04
-
-### ⚠ BREAKING
+  The input was arbitrary shell by design — it was interpolated straight into a
+  `run:` body — which is why neither workflow could be covered by the injection
+  guard. A caller forwarding untrusted event data into it turned that into
+  injection. No repository in the organisation passed the input, so it is
+  removed rather than wrapped in a trust model nobody relies on.
+  **Migration:** there is no in-workflow replacement — a job with `uses:` cannot
+  carry `steps:`, and a preceding job's workspace does not survive into the
+  reusable workflow's own checkout. Commit the generated code, produce it from a
+  checked-in `//go:generate` directive whose result is committed, or stop using
+  the reusable workflow for that repository and inline the Go pipeline.
 
 - **`release-go.yml` rejects an `extra-env` line that is not a `KEY=VALUE`
   assignment or a `NAME<<DELIM` block.** Such a line was previously appended to
@@ -66,6 +53,14 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ### Details
 
+- **Both Go workflows joined the injection guard's `MIGRATED` list.**
+  `scripts/tests/test-workflow-input-injection.sh` asserts structurally that no
+  caller-controlled `${{ }}` reaches a `run:` body; `ci-go.yml` and
+  `release-go.yml` were absent from that list precisely because
+  `pre-build-commands` disqualified them. With the input gone they are covered,
+  which is what keeps the pattern from returning. This also resolves the caveat
+  in the 2026-08-02 entry below, which named `pre-build-commands` as the one
+  remaining `run:` interpolation in `ci-go.yml` that could not move to `env:`.
 - **`release-go.yml` validates the shape of each `extra-env` line before
   writing it to `$GITHUB_ENV`.** The `Parse extra environment variables` step
   appended the whole input unchecked. `extra-env` is a multi-line list, so its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,31 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
+## 2026-08-05
+
+### ⚠ BREAKING
+
+- **`ci-go.yml` and `release-go.yml` no longer accept `pre-build-commands`.**
+  The input was interpolated straight into a `run:` body, so whoever set it ran
+  arbitrary shell on the runner — a wider hole than the `$GITHUB_ENV` writes
+  fixed in the entries below, since it did not even go through the environment
+  file. No repository in the organisation passed the input, so it is removed
+  rather than wrapped in a trust model nobody relies on.
+  **Migration:** run those commands as your own step in the calling workflow,
+  before the `uses:` call. The command then lives in the calling repository
+  instead of travelling as a string through a workflow input.
+
+### Details
+
+- **Both Go workflows joined the injection guard's `MIGRATED` list.**
+  `scripts/tests/test-workflow-input-injection.sh` asserts structurally that no
+  caller-controlled `${{ }}` reaches a `run:` body; `ci-go.yml` and
+  `release-go.yml` were absent from that list precisely because
+  `pre-build-commands` disqualified them. With the input gone they are covered,
+  which is what keeps the pattern from returning. This also resolves the caveat
+  in the 2026-08-02 entry below, which named `pre-build-commands` as the one
+  remaining `run:` interpolation in `ci-go.yml` that could not move to `env:`.
+
 ## 2026-08-04
 
 ### ⚠ BREAKING

--- a/scripts/tests/test-workflow-input-injection.sh
+++ b/scripts/tests/test-workflow-input-injection.sh
@@ -30,12 +30,14 @@ fail() {
 
 # The workflows this migration covers.
 MIGRATED=(
+  ci-go.yml
   ci-js.yml
   ci-terraform.yml
   deploy-cloudflare-workers.yml
   deploy-terraform.yml
   e2e-docker.yml
   release-docker.yml
+  release-go.yml
   release-npm.yml
   security-code.yml
   security-config.yml


### PR DESCRIPTION
## Summary

- `pre-build-commands` was interpolated straight into a `run:` body in
  `ci-go.yml` and `release-go.yml`, so whoever set the input ran arbitrary
  shell on the runner. This is wider than the `$GITHUB_ENV` injections closed
  in #288 and #293, because it never went through the environment file.
- No repository in the organisation passes the input, so it is removed rather
  than wrapped in a trust model nobody relies on. Callers that need a pre-build
  step run it in their own workflow before the `uses:` call.
- Both workflows now sit in the `MIGRATED` list of
  `scripts/tests/test-workflow-input-injection.sh`, which asserts structurally
  that no caller-controlled `${{ }}` reaches a `run:` body. They were absent
  from that list precisely because this input disqualified them.

Breaking change, flagged with `### ⚠ BREAKING` in `CHANGELOG.md` including the
migration step. This deliberately skips the deprecation round that `AGENTS.md`
asks for: a deprecation buys consumers migration time, and there are no
consumers to buy it for, while the arbitrary-code path would stay open for a
release cycle. Worth a look during review.

## Test plan

- [x] `scripts/tests/test-workflow-input-injection.sh` fails before the removal
      and passes after: `PASS: workflow inputs reach run: blocks via env: (15 workflows)`
- [x] `scripts/tests/test-workflow-counts.sh` unchanged:
      `PASS: workflow counts (28 files = 24 reusable + 4 internal)`
- [x] `grep -rn "pre-build-commands" .github/workflows/` returns nothing
- [x] `just lint && just test` both green locally
- [ ] CI green