### PR TITLE
fix(tests): derive injection guard's set from workflow_call trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,15 +59,23 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   default — and the reason for absence tended to be the very defect the guard
   exists to catch, as the `pre-build-commands` entry above shows. It now parses
   the `on:` block of every workflow and checks each one declaring a
-  `workflow_call` trigger, the same classification
-  `scripts/tests/test-workflow-counts.sh` already uses. Coverage goes from 15
-  hand-listed files to 22 of the 24 reusable workflows, and a new reusable
-  workflow is covered the day it lands. Two files are carved out in an
-  `EXCEPTIONS` array with the reason inline — `ops-drift-issue.yml` and
-  `ops-terraform-report.yml` build heredoc bodies out of values that already
+  `workflow_call` trigger. Coverage goes from 15 hand-listed files to all 24
+  reusable workflows, and a new reusable workflow is covered the day it lands.
+  `ops-drift-issue.yml` and `ops-terraform-report.yml` are exempt from the
+  heredoc rule only — both build heredoc bodies out of values that already
   arrived via `env:`, where the expansion is the intent and quoting the
-  delimiter would break them. A stale exception naming a file that is gone or no
-  longer reusable fails the test rather than passing as reviewed.
+  delimiter would break them. The interpolation rule, which is the primary
+  injection class, still runs on them. An exception that has outlived its reason
+  fails the test rather than passing as reviewed: whether its file is gone, is
+  no longer reusable, or has had its heredocs quoted since.
+- **The `workflow_call` classifier moved to
+  `scripts/list-reusable-workflows.sh`.** `test-workflow-counts.sh` and
+  `test-workflow-input-injection.sh` derive different things from the same
+  classification — the counts stated in the docs, and the set scanned for
+  injection sinks. Two copies could drift apart while both tests stayed green,
+  leaving the guard's coverage line claiming something the docs no longer said.
+  The shared script buffers its output and exits non-zero on an unparseable
+  workflow, so a partial classification is never mistaken for a complete one.
 - **`ci-gitops.yml` gained an opt-in `validate-python` job.** GitOps consumers'
   pytest suites ran only in a local `pre-push` hook — opt-in via
   `lefthook install`, and bypassed by `--no-verify`, web-UI edits and bot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,21 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ### Details
 
+- **The injection guard derives its checked set instead of maintaining an
+  allow-list.** `scripts/tests/test-workflow-input-injection.sh` used to iterate
+  a hand-kept `MIGRATED` array, so a workflow absent from it was unchecked by
+  default — and the reason for absence tended to be the very defect the guard
+  exists to catch, as the `pre-build-commands` entry above shows. It now parses
+  the `on:` block of every workflow and checks each one declaring a
+  `workflow_call` trigger, the same classification
+  `scripts/tests/test-workflow-counts.sh` already uses. Coverage goes from 15
+  hand-listed files to 22 of the 24 reusable workflows, and a new reusable
+  workflow is covered the day it lands. Two files are carved out in an
+  `EXCEPTIONS` array with the reason inline — `ops-drift-issue.yml` and
+  `ops-terraform-report.yml` build heredoc bodies out of values that already
+  arrived via `env:`, where the expansion is the intent and quoting the
+  delimiter would break them. A stale exception naming a file that is gone or no
+  longer reusable fails the test rather than passing as reviewed.
 - **`ci-gitops.yml` gained an opt-in `validate-python` job.** GitOps consumers'
   pytest suites ran only in a local `pre-push` hook — opt-in via
   `lefthook install`, and bypassed by `--no-verify`, web-UI edits and bot
@@ -63,17 +78,16 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   asserts the suite exists, so an empty collection fails rather than reporting
   green). `python-version` now selects the interpreter for both `validate-yaml`
   and this job. Opt in per repository.
-- **`ci-gitops.yml` joined the injection guard's `MIGRATED` list.**
-  `scripts/tests/test-workflow-input-injection.sh` now covers every job in the
-  file, so a job added there later is guarded without a separate check.
-- **Both Go workflows joined the injection guard's `MIGRATED` list.**
+- **`ci-gitops.yml` and both Go workflows fall under the injection guard.**
   `scripts/tests/test-workflow-input-injection.sh` asserts structurally that no
-  caller-controlled `${{ }}` reaches a `run:` body; `ci-go.yml` and
-  `release-go.yml` were absent from that list precisely because
-  `pre-build-commands` disqualified them. With the input gone they are covered,
+  caller-controlled `${{ }}` reaches a `run:` body. `ci-go.yml` and
+  `release-go.yml` were previously outside the guard's set precisely because
+  `pre-build-commands` disqualified them; with the input gone they are covered,
   which is what keeps the pattern from returning. This also resolves the caveat
   in the 2026-08-02 entry below, which named `pre-build-commands` as the one
   remaining `run:` interpolation in `ci-go.yml` that could not move to `env:`.
+  `ci-gitops.yml` is covered job-for-job, so a job added there later is guarded
+  without a separate check.
 - **`release-go.yml` validates the shape of each `extra-env` line before
   writing it to `$GITHUB_ENV`.** The `Parse extra environment variables` step
   appended the whole input unchecked. `extra-env` is a multi-line list, so its

--- a/scripts/list-reusable-workflows.sh
+++ b/scripts/list-reusable-workflows.sh
@@ -28,6 +28,15 @@ if [ -z "$DIR" ]; then
   exit 2
 fi
 
+# A typo'd mode must not fall through to the other output form: a caller asking
+# for bare basenames would silently parse tab-separated lines instead, which is
+# the same "quietly returns something other than what was asked for" the buffered
+# output below exists to prevent.
+if [ -n "$MODE" ] && [ "$MODE" != "--reusable" ]; then
+  echo "${0##*/}: unknown option '$MODE' (expected --reusable)" >&2
+  exit 2
+fi
+
 command -v python3 >/dev/null 2>&1 || {
   echo "python3 required to parse the workflow YAML" >&2
   exit 1

--- a/scripts/list-reusable-workflows.sh
+++ b/scripts/list-reusable-workflows.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Classify the workflows in a directory by whether they are reusable.
+#
+# Usage: scripts/list-reusable-workflows.sh <workflows-dir> [--reusable]
+#
+# Writes one "<class>\t<basename>" line per workflow to stdout, where <class>
+# is `reusable` (declares a `workflow_call` trigger) or `internal`. With
+# `--reusable`, writes only the basenames of the reusable ones — the form the
+# injection guard iterates.
+#
+# Single-sourced because two tests derive different things from the same
+# classification: test-workflow-counts.sh checks the counts stated in AGENTS.md
+# and README.md, test-workflow-input-injection.sh derives the set it scans for
+# injection sinks. Two copies could drift apart while both stayed green, and
+# then the guard's coverage line would stop meaning what the docs claim.
+#
+# Exits non-zero if a workflow cannot be parsed, so a caller using command
+# substitution (`OUT="$(...)" || fail`) sees the failure. A partial classification
+# is never written to stdout as if it were complete: the caller would report a
+# green run over a silently shortened set.
+set -euo pipefail
+
+DIR="${1:-}"
+MODE="${2:-}"
+
+if [ -z "$DIR" ]; then
+  echo "usage: ${0##*/} <workflows-dir> [--reusable]" >&2
+  exit 2
+fi
+
+command -v python3 >/dev/null 2>&1 || {
+  echo "python3 required to parse the workflow YAML" >&2
+  exit 1
+}
+
+# Classification is done on the parsed `on:` mapping, not by grepping for the
+# bare token: `workflow_call` also appears in prose comments (e.g.
+# ai-claude-review.yml, ops-drift-issue.yml), which would misclassify an
+# internal workflow as reusable. Both .yml and .yaml are collected — GitHub
+# loads either, and a workflow added with the other extension would otherwise
+# be invisible to every count while the check still passed.
+#
+# Output is buffered and printed only after every file has parsed, so a failure
+# on the last file cannot leave the earlier basenames on stdout looking whole.
+CLASSIFIED="$(
+  python3 - "$DIR" <<'PY'
+import glob
+import os
+import sys
+
+import yaml
+
+workflows = sys.argv[1]
+paths = sorted(glob.glob(os.path.join(workflows, "*.yml")) +
+               glob.glob(os.path.join(workflows, "*.yaml")))
+
+lines = []
+for path in paths:
+    try:
+        with open(path) as fh:
+            doc = yaml.safe_load(fh) or {}
+    except yaml.YAMLError as exc:
+        sys.exit(f"{os.path.basename(path)}: not valid YAML: {exc}")
+    # A workflow that parses to anything but a mapping has no `on:` block to
+    # read. Skipping it silently would drop it from the checked set, so it is
+    # an error rather than an `internal` classification.
+    if not isinstance(doc, dict):
+        sys.exit(f"{os.path.basename(path)}: top level is not a mapping")
+    # YAML 1.1 resolves an unquoted `on:` key to the boolean True.
+    triggers = doc.get("on", doc.get(True))
+    # All three trigger spellings count: the block mapping (`on:\n  workflow_call:`),
+    # the flow sequence (`on: [workflow_call]`) and the bare scalar
+    # (`on: workflow_call`). Accepting only the mapping would undercount.
+    if isinstance(triggers, (dict, list)):
+        reusable = "workflow_call" in triggers
+    else:
+        reusable = triggers == "workflow_call"
+    lines.append(f"{'reusable' if reusable else 'internal'}\t{os.path.basename(path)}")
+
+sys.stdout.write("".join(line + "\n" for line in lines))
+PY
+)" || exit 1
+
+if [ "$MODE" = "--reusable" ]; then
+  awk -F'\t' '$1 == "reusable" { print $2 }' <<<"$CLASSIFIED"
+else
+  printf '%s\n' "$CLASSIFIED"
+fi

--- a/scripts/tests/test-workflow-counts.sh
+++ b/scripts/tests/test-workflow-counts.sh
@@ -23,37 +23,12 @@ fail() {
   exit 1
 }
 
-command -v python3 >/dev/null 2>&1 || fail "python3 required to parse the workflow YAML"
-
-# Classification is done on the parsed `on:` mapping, not by grepping for the
-# bare token: `workflow_call` also appears in prose comments (e.g.
-# ai-claude-review.yml, ops-drift-issue.yml), which would misclassify an
-# internal workflow as reusable. Both .yml and .yaml are collected — GitHub
-# loads either, and a workflow added with the other extension would otherwise
-# be invisible to every count while the check still passed.
-CLASSIFIED="$(
-  python3 - "$WORKFLOWS" <<'PY'
-import os, sys, glob, yaml
-
-workflows = sys.argv[1]
-paths = sorted(glob.glob(os.path.join(workflows, "*.yml")) +
-               glob.glob(os.path.join(workflows, "*.yaml")))
-
-for path in paths:
-    with open(path) as fh:
-        doc = yaml.safe_load(fh) or {}
-    # YAML 1.1 resolves an unquoted `on:` key to the boolean True.
-    triggers = doc.get("on", doc.get(True))
-    # All three trigger spellings count: the block mapping (`on:\n  workflow_call:`),
-    # the flow sequence (`on: [workflow_call]`) and the bare scalar
-    # (`on: workflow_call`). Accepting only the mapping would undercount.
-    if isinstance(triggers, (dict, list)):
-        reusable = "workflow_call" in triggers
-    else:
-        reusable = triggers == "workflow_call"
-    print(f"{'reusable' if reusable else 'internal'}\t{os.path.basename(path)}")
-PY
-)" || fail "could not parse the workflow files"
+# Classification is shared with scripts/tests/test-workflow-input-injection.sh,
+# which derives the set it scans for injection sinks from the same `workflow_call`
+# trigger. Two copies could drift apart while both tests stayed green, and then
+# the guard's coverage line would stop meaning what the counts below assert.
+CLASSIFIED="$("$HERE/../list-reusable-workflows.sh" "$WORKFLOWS")" ||
+  fail "could not classify the workflow files"
 
 [ -n "$CLASSIFIED" ] || fail "no workflow files found in $WORKFLOWS"
 

--- a/scripts/tests/test-workflow-input-injection.sh
+++ b/scripts/tests/test-workflow-input-injection.sh
@@ -35,60 +35,54 @@ fail() {
   exit 1
 }
 
-command -v python3 >/dev/null 2>&1 || fail "python3 required to parse the workflow YAML"
-
-# Workflows excluded from the check, each with the reason inline. An exception is
+# Workflows exempt from rule 2 only, each with the reason inline. An exception is
 # a deliberate, argued carve-out — not a parking space for an unreviewed
 # workflow. Both entries below build a heredoc body out of values that already
 # arrived via `env:`; the expansion is the point, so quoting the delimiter would
 # break them, and rule 2 has no way to tell that apart from the unsafe case.
-EXCEPTIONS=(
+#
+# The exemption stops there. Rule 1 still runs on these files: it is the primary
+# injection class, has nothing to do with heredoc quoting, and these two are the
+# worst files to leave unchecked — their bodies already expand, so a substituted
+# `$(...)` would execute rather than merely mis-parse.
+HEREDOC_EXCEPTIONS=(
   ops-drift-issue.yml      # issue body + delta comment expand env-passed values
   ops-terraform-report.yml # deployment-metadata.json expands env-passed values
 )
 
-# The reusable set, derived from the `workflow_call` trigger. Classification runs
-# on the parsed `on:` mapping rather than a grep for the bare token, which also
-# appears in prose comments — same approach as scripts/tests/test-workflow-counts.sh.
+# The reusable set, derived from the `workflow_call` trigger. The classifier is
+# shared with scripts/tests/test-workflow-counts.sh so the set scanned here and
+# the counts stated in the docs cannot drift apart. Command substitution, not a
+# process substitution: `done < <(...)` would not propagate the classifier's exit
+# status, so a parse error would yield a silently shortened set and a green run.
+REUSABLE="$("$REPO/scripts/list-reusable-workflows.sh" "$WORKFLOWS" --reusable)" ||
+  fail "could not classify the workflow files"
+
 REUSABLE_FILES=()
 while IFS= read -r name; do
-  [ -n "$name" ] && REUSABLE_FILES+=("$name")
-done < <(
-  python3 - "$WORKFLOWS" <<'PY'
-import os, sys, glob, yaml
-
-workflows = sys.argv[1]
-paths = sorted(glob.glob(os.path.join(workflows, "*.yml")) +
-               glob.glob(os.path.join(workflows, "*.yaml")))
-
-for path in paths:
-    with open(path) as fh:
-        doc = yaml.safe_load(fh) or {}
-    # YAML 1.1 resolves an unquoted `on:` key to the boolean True.
-    triggers = doc.get("on", doc.get(True))
-    # All three trigger spellings count: the block mapping (`on:\n  workflow_call:`),
-    # the flow sequence (`on: [workflow_call]`) and the bare scalar
-    # (`on: workflow_call`). Accepting only the mapping would undercount.
-    if isinstance(triggers, (dict, list)):
-        reusable = "workflow_call" in triggers
-    else:
-        reusable = triggers == "workflow_call"
-    if reusable:
-        print(os.path.basename(path))
-PY
-) || fail "could not parse the workflow files"
+  [ -n "$name" ] || continue
+  REUSABLE_FILES+=("$name")
+done <<<"$REUSABLE"
 
 [ ${#REUSABLE_FILES[@]} -gt 0 ] || fail "no reusable workflows found in $WORKFLOWS"
 
-# A stale exception is a silent hole: the workflow it named is gone or no longer
-# reusable, so the carve-out protects nothing while still reading as reviewed.
-for exc in "${EXCEPTIONS[@]}"; do
+# An exception outlives its reason in two ways, and both read as "reviewed" while
+# protecting nothing. `${arr[@]+…}` guards the empty case: bash 3.2, which macOS
+# still ships as /bin/bash, treats an empty array as unset under `set -u`, and an
+# empty array is the intended end state here.
+for exc in ${HEREDOC_EXCEPTIONS[@]+"${HEREDOC_EXCEPTIONS[@]}"}; do
+  # 1 — the file is gone, or no longer reusable.
   found=0
   for wf in "${REUSABLE_FILES[@]}"; do
     [ "$wf" = "$exc" ] && found=1 && break
   done
   [ "$found" -eq 1 ] ||
-    fail "EXCEPTIONS lists '$exc', which is not a reusable workflow — drop the entry"
+    fail "HEREDOC_EXCEPTIONS lists '$exc', which is not a reusable workflow — drop the entry"
+
+  # 2 — the heredocs got quoted, so the carve-out is no longer buying anything.
+  #     This makes the array self-emptying as the files are fixed.
+  grep -qE '<<-?[[:space:]]*[A-Za-z_][A-Za-z0-9_]*([[:space:]]|$)' "$WORKFLOWS/$exc" ||
+    fail "HEREDOC_EXCEPTIONS lists '$exc', which no longer has an unquoted heredoc — drop the entry"
 done
 
 # Print every line inside a `run:` body, as "<line-number>:<text>".
@@ -131,16 +125,13 @@ run_block_lines() {
   ' "$1"
 }
 
-CHECKED=0
 for wf in "${REUSABLE_FILES[@]}"; do
-  skip=0
-  for exc in "${EXCEPTIONS[@]}"; do
-    [ "$wf" = "$exc" ] && skip=1 && break
+  heredoc_exempt=0
+  for exc in ${HEREDOC_EXCEPTIONS[@]+"${HEREDOC_EXCEPTIONS[@]}"}; do
+    [ "$wf" = "$exc" ] && heredoc_exempt=1 && break
   done
-  [ "$skip" -eq 0 ] || continue
 
   path="$WORKFLOWS/$wf"
-  CHECKED=$((CHECKED + 1))
 
   # 1. No caller-controlled value interpolated into a shell body. `inputs.*` is
   #    the class this migration closed; `secrets.*` and `github.event.*` are the
@@ -162,10 +153,14 @@ for wf in "${REUSABLE_FILES[@]}"; do
   #    called. `<<-` strips tabs but still expands, and the delimiter may be
   #    followed by a redirect (`cat <<EOF >"$f"`), so match the word itself
   #    rather than requiring it at end of line.
-  heredocs="$(grep -nE '<<-?[[:space:]]*[A-Za-z_][A-Za-z0-9_]*([[:space:]]|$)' "$path" || true)"
-  if [ -n "$heredocs" ]; then
-    echo "$heredocs" >&2
-    fail "$wf has an unquoted heredoc delimiter; quote it, e.g. << 'EOF'"
+  #    Skipped only for the argued carve-outs above, where the expansion is the
+  #    intent and every value in the body reached the shell through `env:`.
+  if [ "$heredoc_exempt" -eq 0 ]; then
+    heredocs="$(grep -nE '<<-?[[:space:]]*[A-Za-z_][A-Za-z0-9_]*([[:space:]]|$)' "$path" || true)"
+    if [ -n "$heredocs" ]; then
+      echo "$heredocs" >&2
+      fail "$wf has an unquoted heredoc delimiter; quote it, e.g. << 'EOF'"
+    fi
   fi
 done
 
@@ -188,4 +183,4 @@ IMAGE_REF="ghcr.io/org/app:\$(touch '$marker')" \
 grep -qF '$(touch' "$summary" ||
   fail "the env:+printf pattern dropped the literal value from the summary"
 
-echo "PASS: workflow inputs reach run: blocks via env: ($CHECKED of ${#REUSABLE_FILES[@]} reusable workflows, ${#EXCEPTIONS[@]} exceptions)"
+echo "PASS: workflow inputs reach run: blocks via env: (${#REUSABLE_FILES[@]} reusable workflows, ${#HEREDOC_EXCEPTIONS[@]} heredoc-exempt)"

--- a/scripts/tests/test-workflow-input-injection.sh
+++ b/scripts/tests/test-workflow-input-injection.sh
@@ -5,11 +5,18 @@
 # (`<< EOF`) the body is expanded too, so a value reaching a step summary that
 # way executes as well.
 #
-# The workflows below were migrated to pass such values through `env:` and
-# reference them as shell variables. This asserts the migration holds: no
-# interpolated caller-controlled value left in a `run:` body — block-scalar,
-# folded or single-line — and no unquoted heredoc delimiter. It is a structural
-# check on the YAML, so a regression fails here rather than on a runner.
+# Reusable workflows pass such values through `env:` and reference them as shell
+# variables. This asserts that holds: no interpolated caller-controlled value
+# left in a `run:` body — block-scalar, folded or single-line — and no unquoted
+# heredoc delimiter. It is a structural check on the YAML, so a regression fails
+# here rather than on a runner.
+#
+# The checked set is *derived* from the `workflow_call` trigger, not maintained
+# as a list. An allow-list inverts the guard: a workflow absent from it is
+# unchecked by default, and the reason for its absence tends to be the very
+# defect the guard exists to catch (PR #299 — two workflows sat outside the list
+# exactly as long as they were unsafe). Deriving it means a new reusable
+# workflow is covered the day it lands.
 #
 # A value that merely *travels* through `env:` is not automatically safe: it can
 # leave a step again as a workflow-level output and be interpolated downstream,
@@ -28,25 +35,61 @@ fail() {
   exit 1
 }
 
-# The workflows this migration covers.
-MIGRATED=(
-  ci-gitops.yml
-  ci-go.yml
-  ci-js.yml
-  ci-terraform.yml
-  deploy-cloudflare-workers.yml
-  deploy-terraform.yml
-  e2e-docker.yml
-  release-docker.yml
-  release-go.yml
-  release-npm.yml
-  security-code.yml
-  security-config.yml
-  security-containers.yml
-  security-deps.yml
-  security-sbom.yml
-  security-secrets.yml
+command -v python3 >/dev/null 2>&1 || fail "python3 required to parse the workflow YAML"
+
+# Workflows excluded from the check, each with the reason inline. An exception is
+# a deliberate, argued carve-out — not a parking space for an unreviewed
+# workflow. Both entries below build a heredoc body out of values that already
+# arrived via `env:`; the expansion is the point, so quoting the delimiter would
+# break them, and rule 2 has no way to tell that apart from the unsafe case.
+EXCEPTIONS=(
+  ops-drift-issue.yml      # issue body + delta comment expand env-passed values
+  ops-terraform-report.yml # deployment-metadata.json expands env-passed values
 )
+
+# The reusable set, derived from the `workflow_call` trigger. Classification runs
+# on the parsed `on:` mapping rather than a grep for the bare token, which also
+# appears in prose comments — same approach as scripts/tests/test-workflow-counts.sh.
+REUSABLE_FILES=()
+while IFS= read -r name; do
+  [ -n "$name" ] && REUSABLE_FILES+=("$name")
+done < <(
+  python3 - "$WORKFLOWS" <<'PY'
+import os, sys, glob, yaml
+
+workflows = sys.argv[1]
+paths = sorted(glob.glob(os.path.join(workflows, "*.yml")) +
+               glob.glob(os.path.join(workflows, "*.yaml")))
+
+for path in paths:
+    with open(path) as fh:
+        doc = yaml.safe_load(fh) or {}
+    # YAML 1.1 resolves an unquoted `on:` key to the boolean True.
+    triggers = doc.get("on", doc.get(True))
+    # All three trigger spellings count: the block mapping (`on:\n  workflow_call:`),
+    # the flow sequence (`on: [workflow_call]`) and the bare scalar
+    # (`on: workflow_call`). Accepting only the mapping would undercount.
+    if isinstance(triggers, (dict, list)):
+        reusable = "workflow_call" in triggers
+    else:
+        reusable = triggers == "workflow_call"
+    if reusable:
+        print(os.path.basename(path))
+PY
+) || fail "could not parse the workflow files"
+
+[ ${#REUSABLE_FILES[@]} -gt 0 ] || fail "no reusable workflows found in $WORKFLOWS"
+
+# A stale exception is a silent hole: the workflow it named is gone or no longer
+# reusable, so the carve-out protects nothing while still reading as reviewed.
+for exc in "${EXCEPTIONS[@]}"; do
+  found=0
+  for wf in "${REUSABLE_FILES[@]}"; do
+    [ "$wf" = "$exc" ] && found=1 && break
+  done
+  [ "$found" -eq 1 ] ||
+    fail "EXCEPTIONS lists '$exc', which is not a reusable workflow — drop the entry"
+done
 
 # Print every line inside a `run:` body, as "<line-number>:<text>".
 # Block scalars (`run: |`, `run: >`) open a block; a single-line `run: cmd` is a
@@ -88,9 +131,16 @@ run_block_lines() {
   ' "$1"
 }
 
-for wf in "${MIGRATED[@]}"; do
+CHECKED=0
+for wf in "${REUSABLE_FILES[@]}"; do
+  skip=0
+  for exc in "${EXCEPTIONS[@]}"; do
+    [ "$wf" = "$exc" ] && skip=1 && break
+  done
+  [ "$skip" -eq 0 ] || continue
+
   path="$WORKFLOWS/$wf"
-  [ -f "$path" ] || fail "$wf not found — update this test if it was renamed"
+  CHECKED=$((CHECKED + 1))
 
   # 1. No caller-controlled value interpolated into a shell body. `inputs.*` is
   #    the class this migration closed; `secrets.*` and `github.event.*` are the
@@ -138,4 +188,4 @@ IMAGE_REF="ghcr.io/org/app:\$(touch '$marker')" \
 grep -qF '$(touch' "$summary" ||
   fail "the env:+printf pattern dropped the literal value from the summary"
 
-echo "PASS: workflow inputs reach run: blocks via env: (${#MIGRATED[@]} workflows)"
+echo "PASS: workflow inputs reach run: blocks via env: ($CHECKED of ${#REUSABLE_FILES[@]} reusable workflows, ${#EXCEPTIONS[@]} exceptions)"


### PR DESCRIPTION
## Summary

- `scripts/tests/test-workflow-input-injection.sh` iterated a hand-kept `MIGRATED` array, so any workflow absent from it was unchecked by default — and the reason for absence tended to be the very defect the guard exists to catch (see #299, where two Go workflows sat outside the list exactly as long as they were unsafe).
- The checked set is now derived from the parsed `on:` block, covering every workflow that declares a `workflow_call` trigger — the same classification `scripts/tests/test-workflow-counts.sh` already uses. Coverage goes from 15 listed files to 22 of the 24 reusable workflows, and a new reusable workflow is covered the day it lands.
- `ops-drift-issue.yml` and `ops-terraform-report.yml` are carved out in an `EXCEPTIONS` array with the reason inline: both build heredoc bodies out of values that already arrived via `env:`, so the expansion is the intent and quoting the delimiter would break them. A stale exception naming a file that is gone or no longer reusable fails the test rather than passing as reviewed.

## Test plan

- [x] `just test` — all 9 self-checks pass; the guard reports `22 of 24 reusable workflows, 2 exceptions`
- [x] `just lint` — yamllint, actionlint and prettier clean
- [x] shellcheck and shfmt clean on the changed script
- [x] Negative check: a new reusable workflow interpolating `${{ inputs.* }}` in a `run:` body fails the guard (the case the allow-list missed)
- [x] Negative check: an unquoted heredoc in a new reusable workflow fails the guard
- [x] Negative check: the same file with a non-`workflow_call` trigger is not checked
- [x] Negative check: an `EXCEPTIONS` entry naming a non-reusable workflow fails the guard