### PR TITLE
fix(ai-claude-review): stop the reviewer describing machines it cannot see

### DIFF
--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -181,6 +181,24 @@ jobs:
 
             ---
 
+            ## Environment constraints
+
+            You are running inside an ephemeral GitHub Actions runner. It is not
+            the developer machine, the build host, or any deployment target the
+            pull request may describe, and its installed tooling is unrelated to
+            theirs. Therefore:
+
+            - Never infer tool availability on another machine from your own
+              environment, and never run a command to probe it.
+            - Never claim a tool is missing, present, or installed at some path
+              outside this runner.
+            - Judge claims about tool availability against the repository's
+              documentation, workflow files and hook configuration only.
+            - When the repository states that a tool is unavailable somewhere,
+              treat that as the source of truth.
+
+            ---
+
             ## If MODE == first (no previous review by you on this PR)
 
             Perform a thorough, detailed code review:

--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -153,13 +153,13 @@ jobs:
           classify_inline_comments: 'false'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
+          # Environment probing is denied on top of the allowlist below: the
+          # runner is not the machine a PR talks about, so its tool inventory
+          # says nothing about the developer or build host.
           claude_args: |
             --max-turns ${{ steps.mode.outputs.mode == 'first' && format('{0}', inputs.max-turns-first) || format('{0}', inputs.max-turns-followup) }}
             --model ${{ inputs.model }}
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Agent,Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git log:*),Bash(gh api repos/*/pulls/*/comments*),Bash(gh api repos/*/pulls/comments*),Bash(gh api repos/*/pulls/*/comments/*/replies*),Bash(gh api repos/*/pulls/*/reviews*),Bash(gh api repos/*/compare/*),Bash(gh api graphql:*)"
-            # Environment probing is denied on top of the allowlist above: the
-            # runner is not the machine a PR talks about, so its tool inventory
-            # says nothing about the developer or build host.
             --disallowedTools "Bash(which:*),Bash(command:*),Bash(whereis:*),Bash(type:*)"
           prompt: |
             REPO: ${{ github.repository }}

--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -157,6 +157,10 @@ jobs:
             --max-turns ${{ steps.mode.outputs.mode == 'first' && format('{0}', inputs.max-turns-first) || format('{0}', inputs.max-turns-followup) }}
             --model ${{ inputs.model }}
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Agent,Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git log:*),Bash(gh api repos/*/pulls/*/comments*),Bash(gh api repos/*/pulls/comments*),Bash(gh api repos/*/pulls/*/comments/*/replies*),Bash(gh api repos/*/pulls/*/reviews*),Bash(gh api repos/*/compare/*),Bash(gh api graphql:*)"
+            # Environment probing is denied on top of the allowlist above: the
+            # runner is not the machine a PR talks about, so its tool inventory
+            # says nothing about the developer or build host.
+            --disallowedTools "Bash(which:*),Bash(command:*),Bash(whereis:*),Bash(type:*)"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,19 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   asserts the suite exists, so an empty collection fails rather than reporting
   green). `python-version` now selects the interpreter for both `validate-yaml`
   and this job. Opt in per repository.
+- **`ai-claude-review.yml` no longer lets the reviewer describe machines it
+  cannot see.** A review claimed one tool was missing and another installed at
+  a specific path on the build host, with both statements matching the hosted
+  runner instead — the inverse of what the host actually had, turning a correct
+  pull request into a `CHANGES_REQUESTED` verdict. The runner is not the machine
+  a pull request talks about, so its tool inventory says nothing about the
+  developer or build host. Two independent measures, because the job log had
+  already expired and the cause could not be pinned down: a new environment
+  section in the prompt scopes tool-availability claims to the
+  repository's own documentation, workflow files and hook configuration, and a
+  `--disallowedTools` entry blocks `which`, `command`, `whereis` and `type`
+  outright. The prompt rule covers the reviewer asserting an inventory it never
+  measured; the deny list covers the allowlist letting a probe through.
 - **`ci-gitops.yml` and both Go workflows fall under the injection guard.**
   `scripts/tests/test-workflow-input-injection.sh` asserts structurally that no
   caller-controlled `${{ }}` reaches a `run:` body. `ci-go.yml` and


### PR DESCRIPTION
## Summary

- The automated reviewer runs in an ephemeral hosted runner, but reported tool availability as if it had measured the build host. One review called a tool missing and another installed at a specific path, both matching the runner and inverting the host's actual state, which turned a correct pull request into a `CHANGES_REQUESTED` verdict.
- Adds an environment section to the prompt that scopes tool-availability claims to the repository's own documentation, workflow files and hook configuration.
- Adds `--disallowedTools` for `which`, `command`, `whereis` and `type`. Two measures rather than one because the job log had expired and the cause could not be pinned down: the prompt rule covers the reviewer asserting an inventory it never measured, the deny list covers the allowlist letting a probe through.
- Not a breaking change under the policy at the top of `CHANGELOG.md`: no required input changes, no input or output removed, no default behaviour altered.

## Test plan

- [x] `just lint` green (yamllint, jq, actionlint, prettier)
- [x] `just test` green (9/9 script self-checks, including the workflow-count and injection guards)
- [x] `yaml.safe_load` confirms the new section lands inside the `prompt:` scalar with the heading flush-left, and that all four patterns reach the `claude_args` scalar
- [x] `gitleaks` clean on the branch diff
- [ ] Effect is only observable on the next review run after a date tag is cut