### PR TITLE
feat(ci-gitops): add opt-in validate-python job

### DIFF
--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -8,7 +8,10 @@ on:
   workflow_call:
     inputs:
       python-version:
-        description: 'Python version for yamllint'
+        description: |
+          Python version used by both `validate-yaml` (yamllint) and
+          `validate-python` (pytest). Shared deliberately — one interpreter per
+          repo — so bumping it moves the test runner too.
         type: string
         required: false
         default: '3.14'
@@ -129,6 +132,19 @@ on:
         type: string
         required: false
         default: 'pytest pyyaml'
+      allow-no-python-tests:
+        description: |
+          Treat "no tests collected" (pytest exit 5) as success instead of a
+          failure. Default `false`: a caller that sets `enable-python-tests`
+          asserts the suite exists, so an empty collection is a configuration
+          error — a renamed test file or a broken `conftest.py` would otherwise
+          report green, which is the silent pass this job exists to close.
+
+          Same "nothing to validate" question as `require-gitrepo-file`, and
+          resolved the same way: strict by default, tolerance is opt-in.
+        type: boolean
+        required: false
+        default: false
       fleet-paths:
         description: |
           Space-separated paths to search for fleet.yaml files.
@@ -663,7 +679,15 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-pytest-${{ hashFiles('**/requirements*.txt', '**/pyproject.toml') }}
+          # The requirements list is part of the key: the target repos have no
+          # requirements file, so a hashFiles()-only key would collapse to one
+          # constant for every caller — and cache entries are immutable, so the
+          # first run's entry would be pinned forever while two callers with
+          # different requirements shared it.
+          key: >-
+            ${{ runner.os }}-pip-pytest-${{
+              hashFiles('**/requirements*.txt', '**/pyproject.toml')
+            }}-${{ inputs.python-test-requirements }}
           restore-keys: |
             ${{ runner.os }}-pip-
 
@@ -681,30 +705,48 @@ jobs:
         env:
           # Same word-splitting contract as above.
           TEST_PATHS: ${{ inputs.python-test-paths }}
+          ALLOW_NO_TESTS: ${{ inputs.allow-no-python-tests }}
           # `-q` keeps the log readable; failures print in full regardless.
           PYTEST_ADDOPTS: '-q'
         run: |
           set -euo pipefail
+          # Empty or whitespace-only word-splits to nothing, which would leave a
+          # bare `pytest` collecting the whole checkout instead of the given
+          # paths. `set -u` does not catch it — empty is not unset.
+          if [ -z "${TEST_PATHS//[[:space:]]/}" ]; then
+            echo "::error::python-test-paths is empty; pass at least one path"
+            exit 1
+          fi
           # A path that does not exist is a caller configuration error, not
           # "nothing to test" — pytest would exit 4 with a usage error that
           # reads like an infrastructure fault. Say so plainly instead.
+          # `${path}` needs no newline guard below: it comes out of default-IFS
+          # word splitting, which cannot leave a newline inside it.
           for path in ${TEST_PATHS}; do
             if [ ! -e "$path" ]; then
               echo "::error::python-test-paths entry not found: ${path}"
               exit 1
             fi
           done
-          # Collecting nothing exits 5. That is green here: a repo can enable
-          # the job before its first test exists, and the paths were just
-          # checked, so exit 5 means "no tests yet", not "tests went missing".
           set +e
           # shellcheck disable=SC2086  # must split into one word per path
           python3 -m pytest ${TEST_PATHS}
           status=$?
           set -e
+          # Collecting nothing exits 5. Strict by default: the paths above all
+          # exist, so an empty collection means the tests stopped being found
+          # (renamed file, broken conftest.py), not that there are none.
           if [ "$status" -eq 5 ]; then
-            echo "::notice::No tests collected under: ${TEST_PATHS}"
-            exit 0
+            if [ "$ALLOW_NO_TESTS" = "true" ]; then
+              # Unsplit value reaching a `::` sink: strip at the first newline
+              # so it cannot smuggle a second workflow command, as the
+              # gitrepo-file notices in this file do.
+              echo "::notice::No tests collected under: ${TEST_PATHS%%$'\n'*}"
+              exit 0
+            fi
+            echo "::error::No tests collected under: ${TEST_PATHS%%$'\n'*}"
+            echo "::error::Set allow-no-python-tests to treat this as success."
+            exit 1
           fi
           exit "$status"
 

--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -675,11 +675,25 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
 
+      - name: Derive requirements cache key
+        id: reqs
+        env:
+          REQUIREMENTS: ${{ inputs.python-test-requirements }}
+        run: |
+          set -euo pipefail
+          # The value goes into a cache key, which rejects commas — and a pip
+          # range (`pytest>=8.0,<9.0`) has one. Hash it: the key still changes
+          # when the requirements do, without constraining what a caller passes,
+          # and the length stays bounded.
+          printf 'hash=%s\n' \
+            "$(printf '%s' "$REQUIREMENTS" | sha256sum | cut -c1-16)" \
+            >>"$GITHUB_OUTPUT"
+
       - name: Cache pip dependencies
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pip
-          # The requirements list is part of the key: the target repos have no
+          # The requirements are part of the key: the target repos have no
           # requirements file, so a hashFiles()-only key would collapse to one
           # constant for every caller — and cache entries are immutable, so the
           # first run's entry would be pinned forever while two callers with
@@ -687,7 +701,7 @@ jobs:
           key: >-
             ${{ runner.os }}-pip-pytest-${{
               hashFiles('**/requirements*.txt', '**/pyproject.toml')
-            }}-${{ inputs.python-test-requirements }}
+            }}-${{ steps.reqs.outputs.hash }}
           restore-keys: |
             ${{ runner.os }}-pip-
 

--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -99,6 +99,36 @@ on:
         type: boolean
         required: false
         default: true
+      enable-python-tests:
+        description: |
+          Run the repository's pytest suite.
+
+          Defaults to `false`, unlike the other `enable-*` inputs here: the job
+          was added after the fact, so enabling it by default would hand every
+          existing caller a job it never asked for, and a repo without Python
+          tests would go red on nothing but the upgrade. Opt in per caller.
+        type: boolean
+        required: false
+        default: false
+      python-test-paths:
+        description: |
+          Space-separated paths to search for tests.
+          Expanded unquoted so the separate paths survive word splitting —
+          pass static caller configuration only, never event-controlled data.
+        type: string
+        required: false
+        default: 'scripts'
+      python-test-requirements:
+        description: |
+          Space-separated pip requirements installed before the tests run.
+          Expanded unquoted so the separate requirements survive word splitting —
+          pass static caller configuration only, never event-controlled data.
+
+          A plain list rather than a requirements file: the consumers have no
+          `pyproject.toml`, `requirements*.txt` or `pytest.ini` to point at.
+        type: string
+        required: false
+        default: 'pytest pyyaml'
       fleet-paths:
         description: |
           Space-separated paths to search for fleet.yaml files.
@@ -607,6 +637,77 @@ jobs:
 
           echo "All required documentation files present!"
 
+  validate-python:
+    name: Validate Python Tests
+    # Gate behind validate-yaml, like the other post-YAML jobs: the gate is
+    # conditional, so always()/!failure()/!cancelled() runs this job when the
+    # gate succeeds OR is skipped, and blocks only on a gate failure.
+    needs: [validate-yaml]
+    if: >-
+      always() && !failure() && !cancelled()
+      && inputs.enable-python-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Cache pip dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-pytest-${{ hashFiles('**/requirements*.txt', '**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install test requirements
+        env:
+          # Unquoted at the call site below so the separate requirements split
+          # into argv words; see the input description.
+          REQUIREMENTS: ${{ inputs.python-test-requirements }}
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC2086  # must split into one word per requirement
+          pip install ${REQUIREMENTS}
+
+      - name: Run pytest
+        env:
+          # Same word-splitting contract as above.
+          TEST_PATHS: ${{ inputs.python-test-paths }}
+          # `-q` keeps the log readable; failures print in full regardless.
+          PYTEST_ADDOPTS: '-q'
+        run: |
+          set -euo pipefail
+          # A path that does not exist is a caller configuration error, not
+          # "nothing to test" — pytest would exit 4 with a usage error that
+          # reads like an infrastructure fault. Say so plainly instead.
+          for path in ${TEST_PATHS}; do
+            if [ ! -e "$path" ]; then
+              echo "::error::python-test-paths entry not found: ${path}"
+              exit 1
+            fi
+          done
+          # Collecting nothing exits 5. That is green here: a repo can enable
+          # the job before its first test exists, and the paths were just
+          # checked, so exit 5 means "no tests yet", not "tests went missing".
+          set +e
+          # shellcheck disable=SC2086  # must split into one word per path
+          python3 -m pytest ${TEST_PATHS}
+          status=$?
+          set -e
+          if [ "$status" -eq 5 ]; then
+            echo "::notice::No tests collected under: ${TEST_PATHS}"
+            exit 0
+          fi
+          exit "$status"
+
   summary:
     name: Validation Summary
     runs-on: ubuntu-latest
@@ -620,6 +721,7 @@ jobs:
         validate-helm-template,
         validate-kubernetes,
         check-documentation,
+        validate-python,
       ]
     if: always()
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,13 +195,13 @@ consumers have an escape hatch.
 
 **Purpose**: Validate code quality, tests, and security before merge
 
-| Workflow       | File               | Description               | Languages/Tools                 |
-| -------------- | ------------------ | ------------------------- | ------------------------------- |
-| CI (Ansible)   | `ci-ansible.yml`   | Ansible syntax & lint     | Ansible, ansible-lint           |
-| CI (GitOps)    | `ci-gitops.yml`    | Fleet & K8s validation    | Fleet, Helm, kubeconform        |
-| CI (Go)        | `ci-go.yml`        | Go build, test & security | Go, golangci-lint, gosec        |
-| CI (JS/TS)     | `ci-js.yml`        | Quality, tests & security | JS/TS, Prettier, ESLint, Vitest |
-| CI (Terraform) | `ci-terraform.yml` | Terraform validation      | Terraform, tflint               |
+| Workflow       | File               | Description               | Languages/Tools                  |
+| -------------- | ------------------ | ------------------------- | -------------------------------- |
+| CI (Ansible)   | `ci-ansible.yml`   | Ansible syntax & lint     | Ansible, ansible-lint            |
+| CI (GitOps)    | `ci-gitops.yml`    | Fleet & K8s validation    | Fleet, Helm, kubeconform, pytest |
+| CI (Go)        | `ci-go.yml`        | Go build, test & security | Go, golangci-lint, gosec         |
+| CI (JS/TS)     | `ci-js.yml`        | Quality, tests & security | JS/TS, Prettier, ESLint, Vitest  |
+| CI (Terraform) | `ci-terraform.yml` | Terraform validation      | Terraform, tflint                |
 
 **Key Features**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,19 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ### Details
 
+- **`ci-gitops.yml` gained an opt-in `validate-python` job.** GitOps consumers'
+  pytest suites ran only in a local `pre-push` hook — opt-in via
+  `lefthook install`, and bypassed by `--no-verify`, web-UI edits and bot
+  branches. New inputs: `enable-python-tests` (default `false`, so existing
+  callers are unaffected), `python-test-paths` (default `scripts`),
+  `python-test-requirements` (default `pytest pyyaml`) and
+  `allow-no-python-tests` (default `false` — a caller that enables the job
+  asserts the suite exists, so an empty collection fails rather than reporting
+  green). `python-version` now selects the interpreter for both `validate-yaml`
+  and this job. Opt in per repository.
+- **`ci-gitops.yml` joined the injection guard's `MIGRATED` list.**
+  `scripts/tests/test-workflow-input-injection.sh` now covers every job in the
+  file, so a job added there later is guarded without a separate check.
 - **Both Go workflows joined the injection guard's `MIGRATED` list.**
   `scripts/tests/test-workflow-input-injection.sh` asserts structurally that no
   caller-controlled `${{ }}` reaches a `run:` body; `ci-go.yml` and

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ All files live in [.github/workflows/](./.github/workflows/).
 | File                                                       | Purpose                                  |
 | ---------------------------------------------------------- | ---------------------------------------- |
 | [`ci-ansible.yml`](./.github/workflows/ci-ansible.yml)     | Ansible syntax & ansible-lint            |
-| [`ci-gitops.yml`](./.github/workflows/ci-gitops.yml)       | Fleet, Helm, kubeconform validation      |
+| [`ci-gitops.yml`](./.github/workflows/ci-gitops.yml)       | Fleet, Helm, kubeconform, pytest         |
 | [`ci-go.yml`](./.github/workflows/ci-go.yml)               | Build, test, golangci-lint, gosec        |
 | [`ci-js.yml`](./.github/workflows/ci-js.yml)               | Quality, tests, audit (multi-pm)         |
 | [`ci-terraform.yml`](./.github/workflows/ci-terraform.yml) | `terraform fmt`, validate, tflint, Trivy |

--- a/justfile
+++ b/justfile
@@ -109,6 +109,7 @@ test:
     scripts/tests/test-workflow-input-injection.sh
     scripts/tests/test-ci-go-postgres-env-guard.sh
     scripts/tests/test-github-env-guards.sh
+    scripts/tests/test-validate-python-input.sh
 
 # fmt → format Markdown and JSON in place
 fmt:

--- a/justfile
+++ b/justfile
@@ -24,8 +24,9 @@ default:
 # 34 were plain unquoted `$GITHUB_OUTPUT` / `$GITHUB_ENV` redirects and an
 # unquoted `${BINARY_NAME}` — ordinary defects, not deliberate splitting, and
 # inconsistent with the 40 sites that already quoted the same redirect. Those
-# are fixed. The 5 genuinely deliberate sites are all in ci-gitops.yml, where
-# fleet-paths and the yamllint `-c <file>` argument must word-split, and each
+# are fixed. The 7 genuinely deliberate sites are all in ci-gitops.yml, where
+# fleet-paths, the yamllint `-c <file>` argument, python-test-paths and
+# python-test-requirements must word-split, and each
 # now carries a local `# shellcheck disable=SC2086` naming the reason. The
 # class therefore catches new occurrences again.
 #

--- a/scripts/tests/test-validate-python-input.sh
+++ b/scripts/tests/test-validate-python-input.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# The pytest suites of the GitOps consumers ran only in a local `pre-push` hook,
+# which is opt-in (`lefthook install`) and bypassed by `--no-verify`, web-UI
+# edits and bot branches. `ci-gitops.yml` gained a `validate-python` job so those
+# paths are covered by CI instead.
+#
+# This asserts the three parts that have to hold together, because each is silent
+# when it breaks:
+#
+#   1. The inputs exist with the right type and default. `enable-python-tests`
+#      defaults to `false` — unlike every other `enable-*` here — so existing
+#      callers do not get a job they never asked for and a repo without Python
+#      tests does not turn red on upgrade.
+#   2. The job exists, is gated on that input, and interpolates no `inputs.*`
+#      into a `run:` body (same class of hole as test-workflow-input-injection.sh
+#      closes for the other workflows).
+#   3. `summary.needs` lists the job. `summary` runs with `if: always()` and is
+#      what the branch protection reads; a job missing from `needs` still runs,
+#      but its red never reaches the gate — green PR, failing tests.
+#
+# Assertions run against the parsed YAML, not the raw text: a `grep` for
+# `validate-python` is satisfied by a mention in a comment, which would let this
+# test pass over a workflow that lost the job.
+#
+# Run: scripts/tests/test-validate-python-input.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+WORKFLOW="$REPO/.github/workflows/ci-gitops.yml"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+[ -f "$WORKFLOW" ] || fail "ci-gitops.yml not found — update this test if it was renamed"
+command -v python3 >/dev/null 2>&1 || fail "python3 required to parse the workflow YAML"
+
+# One parser pass reports every violation it finds, so a run shows the whole list
+# instead of surfacing them one re-run at a time.
+ERRORS="$(
+  python3 - "$WORKFLOW" <<'PY'
+import sys, yaml
+
+with open(sys.argv[1]) as fh:
+    doc = yaml.safe_load(fh) or {}
+
+errors = []
+
+# YAML 1.1 resolves an unquoted `on:` key to the boolean True.
+triggers = doc.get("on", doc.get(True)) or {}
+inputs = (triggers.get("workflow_call") or {}).get("inputs") or {}
+jobs = doc.get("jobs") or {}
+
+# 1 — the inputs. Default is compared after normalising, because the YAML
+# scalars `false` and `'false'` mean the same thing to a caller here.
+EXPECTED = {
+    "enable-python-tests": ("boolean", False),
+    "python-test-paths": ("string", "scripts"),
+    "python-test-requirements": ("string", "pytest pyyaml"),
+}
+
+def norm(value):
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str) and value.lower() in ("true", "false"):
+        return value.lower() == "true"
+    return value
+
+for name, (want_type, want_default) in EXPECTED.items():
+    spec = inputs.get(name)
+    if spec is None:
+        errors.append(f"input `{name}` is missing")
+        continue
+    if spec.get("type") != want_type:
+        errors.append(f"input `{name}`: type is {spec.get('type')!r}, expected {want_type!r}")
+    if norm(spec.get("default")) != want_default:
+        errors.append(
+            f"input `{name}`: default is {spec.get('default')!r}, expected {want_default!r}"
+        )
+    # `required: false` must be explicit. Omitting it leaves the default to
+    # GitHub rather than stating the contract at the call site.
+    if spec.get("required") is not False:
+        errors.append(f"input `{name}`: must be declared `required: false`")
+    if not (spec.get("description") or "").strip():
+        errors.append(f"input `{name}`: needs a description")
+
+# Both string inputs are expanded unquoted in the shell, so they carry the same
+# warning as `fleet-paths`. The sentence is the contract for callers; without it
+# the next reader has no reason not to wire an event value through.
+WARNING = "never event-controlled data"
+for name in ("python-test-paths", "python-test-requirements"):
+    spec = inputs.get(name) or {}
+    if WARNING not in (spec.get("description") or ""):
+        errors.append(f"input `{name}`: description must warn {WARNING!r}")
+
+# 2 — the job.
+job = jobs.get("validate-python")
+if job is None:
+    errors.append("job `validate-python` is missing")
+else:
+    if "inputs.enable-python-tests" not in str(job.get("if", "")):
+        errors.append("job `validate-python`: `if:` must gate on inputs.enable-python-tests")
+
+    steps = job.get("steps") or []
+    checkout = next(
+        (s for s in steps if str(s.get("uses", "")).startswith("actions/checkout@")),
+        None,
+    )
+    if checkout is None:
+        errors.append("job `validate-python`: no actions/checkout step")
+    elif (checkout.get("with") or {}).get("persist-credentials") is not False:
+        errors.append("job `validate-python`: checkout needs `persist-credentials: false`")
+
+    # The actual hardening: a caller-supplied value substituted into a `run:`
+    # body is text before the shell sees it, so it can close a quote and execute.
+    # Values must travel via `env:` and be referenced as shell variables.
+    for step in steps:
+        if "inputs." in str(step.get("run", "")):
+            errors.append(
+                f"job `validate-python`: step {step.get('name', '?')!r} "
+                "interpolates inputs.* into a run: body — pass it via env:"
+            )
+
+# 3 — the gate. `needs` accepts a string or a list; both are checked so a
+# single-entry rewrite cannot slip past.
+summary = jobs.get("summary") or {}
+needs = summary.get("needs") or []
+if isinstance(needs, str):
+    needs = [needs]
+if "validate-python" not in needs:
+    errors.append("job `summary`: `needs` must include validate-python")
+
+for error in errors:
+    print(error)
+PY
+)" || fail "could not parse $WORKFLOW"
+
+if [ -n "$ERRORS" ]; then
+  echo "$ERRORS" >&2
+  fail "ci-gitops.yml: validate-python is not wired up correctly"
+fi
+
+echo "PASS: ci-gitops.yml wires validate-python (inputs, job, summary gate)"

--- a/scripts/tests/test-validate-python-input.sh
+++ b/scripts/tests/test-validate-python-input.sh
@@ -11,9 +11,11 @@
 #      defaults to `false` — unlike every other `enable-*` here — so existing
 #      callers do not get a job they never asked for and a repo without Python
 #      tests does not turn red on upgrade.
-#   2. The job exists, is gated on that input, and interpolates no `inputs.*`
-#      into a `run:` body (same class of hole as test-workflow-input-injection.sh
-#      closes for the other workflows).
+#   2. The job exists and is gated on that input, with a credential-less
+#      checkout. The `inputs.*`-in-a-`run:`-body hole is *not* re-checked here:
+#      `ci-gitops.yml` is in the MIGRATED list of
+#      test-workflow-input-injection.sh, which covers every job in the file
+#      rather than this one, so a job added here later stays guarded.
 #   3. `summary.needs` lists the job. `summary` runs with `if: always()` and is
 #      what the branch protection reads; a job missing from `needs` still runs,
 #      but its red never reaches the gate — green PR, failing tests.
@@ -59,6 +61,10 @@ EXPECTED = {
     "enable-python-tests": ("boolean", False),
     "python-test-paths": ("string", "scripts"),
     "python-test-requirements": ("string", "pytest pyyaml"),
+    # Strict by default: an empty collection is a configuration error unless the
+    # caller opts out. Flipping this default would turn a suite that stopped
+    # being collected back into a silent green.
+    "allow-no-python-tests": ("boolean", False),
 }
 
 def norm(value):
@@ -112,16 +118,6 @@ else:
         errors.append("job `validate-python`: no actions/checkout step")
     elif (checkout.get("with") or {}).get("persist-credentials") is not False:
         errors.append("job `validate-python`: checkout needs `persist-credentials: false`")
-
-    # The actual hardening: a caller-supplied value substituted into a `run:`
-    # body is text before the shell sees it, so it can close a quote and execute.
-    # Values must travel via `env:` and be referenced as shell variables.
-    for step in steps:
-        if "inputs." in str(step.get("run", "")):
-            errors.append(
-                f"job `validate-python`: step {step.get('name', '?')!r} "
-                "interpolates inputs.* into a run: body — pass it via env:"
-            )
 
 # 3 — the gate. `needs` accepts a string or a list; both are checked so a
 # single-entry rewrite cannot slip past.

--- a/scripts/tests/test-workflow-input-injection.sh
+++ b/scripts/tests/test-workflow-input-injection.sh
@@ -30,6 +30,7 @@ fail() {
 
 # The workflows this migration covers.
 MIGRATED=(
+  ci-gitops.yml
   ci-go.yml
   ci-js.yml
   ci-terraform.yml


### PR DESCRIPTION
## Summary

- Adds a `validate-python` job to `ci-gitops.yml` so consumer pytest suites run in CI. They previously ran only in a local `pre-push` hook, which is opt-in (`lefthook install`) and bypassed by `--no-verify`, web-UI edits and bot branches.
- Gated behind a new `enable-python-tests` input defaulting to `false` — unlike the other `enable-*` inputs here — so existing callers get nothing they did not ask for and a repo without Python tests does not go red on the upgrade. `python-test-paths` and `python-test-requirements` configure it.
- Zero collected tests fails rather than passing: the configured paths are checked first, so an empty collection means the tests stopped being found (renamed file, broken `conftest.py`), not that there are none. `allow-no-python-tests` (default `false`) opts out, following the `require-gitrepo-file` precedent.
- Adds the job to `summary.needs` for ordering. Note that `summary` echoes fixed text and never inspects `needs.*.result`, so it is not itself the gate — a failing `validate-python` fails the caller's `uses:` job, whose conclusion GitHub derives from all jobs in the called workflow.

## Test plan

- [ ] `just test` — new `scripts/tests/test-validate-python-input.sh` asserts the inputs, job gating, `persist-credentials: false` and the `summary.needs` entry against the parsed YAML rather than raw text; `ci-gitops.yml` joins the `MIGRATED` list of `test-workflow-input-injection.sh`, which covers every job in the file
- [ ] `just lint` — yamllint, jq, actionlint and prettier
- [ ] CI green
