### PR TITLE
fix(ci-gitops): report real job results in summary

### DIFF
--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -797,9 +797,11 @@ jobs:
         # so nothing in the template bodies is expanded by the shell. The
         # dynamic lines are emitted with `printf` between the heredocs.
         #
-        # Results are printed verbatim: every job below is gated by an
-        # `enable-*` input, so `skipped` is a normal state rather than a
-        # failure and is not rewritten into `success`.
+        # Results are printed verbatim. `skipped` has two causes here and the
+        # table does not distinguish them: the job's `enable-*` input is false,
+        # or `validate-yaml` failed — the seven downstream jobs are gated on
+        # `always() && !failure() && !cancelled()`, so a gate failure skips all
+        # of them. Read the `Validate YAML Syntax` row before the rest.
         run: |
           TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
           {

--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -782,9 +782,43 @@ jobs:
     if: always()
     steps:
       - name: Summary
+        env:
+          REPOSITORY: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          YAML_RESULT: ${{ needs.validate-yaml.result }}
+          FLEET_RESULT: ${{ needs.validate-fleet-configs.result }}
+          GITREPO_RESULT: ${{ needs.validate-gitrepo.result }}
+          HELM_RESULT: ${{ needs.validate-helm.result }}
+          HELM_TEMPLATE_RESULT: ${{ needs.validate-helm-template.result }}
+          KUBERNETES_RESULT: ${{ needs.validate-kubernetes.result }}
+          DOCUMENTATION_RESULT: ${{ needs.check-documentation.result }}
+          PYTHON_RESULT: ${{ needs.validate-python.result }}
+        # Every value arrives via `env:` and both heredoc delimiters are quoted,
+        # so nothing in the template bodies is expanded by the shell. The
+        # dynamic lines are emitted with `printf` between the heredocs.
+        #
+        # Results are printed verbatim: every job below is gated by an
+        # `enable-*` input, so `skipped` is a normal state rather than a
+        # failure and is not rewritten into `success`.
         run: |
-          echo "## GitOps Validation Summary"
-          echo ""
-          echo "All validation checks completed!"
-          echo ""
-          echo "Please review any warnings above before merging."
+          TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
+          {
+            cat << 'EOF'
+          # CI — GitOps Validation
+
+          EOF
+            printf '**Timestamp:** %s\n**Repository:** %s @ %s\n\n' \
+              "$TIMESTAMP" "$REPOSITORY" "$REF_NAME"
+            cat << 'EOF'
+          | Job | Status |
+          | --- | --- |
+          EOF
+            printf '| Validate YAML Syntax | %s |\n' "$YAML_RESULT"
+            printf '| Validate Fleet Configurations | %s |\n' "$FLEET_RESULT"
+            printf '| Validate GitRepo Configuration | %s |\n' "$GITREPO_RESULT"
+            printf '| Validate Helm Charts | %s |\n' "$HELM_RESULT"
+            printf '| Validate Rendered Helm Output | %s |\n' "$HELM_TEMPLATE_RESULT"
+            printf '| Validate Kubernetes Manifests | %s |\n' "$KUBERNETES_RESULT"
+            printf '| Check Documentation | %s |\n' "$DOCUMENTATION_RESULT"
+            printf '| Validate Python Tests | %s |\n' "$PYTHON_RESULT"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,17 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   leaving the guard's coverage line claiming something the docs no longer said.
   The shared script buffers its output and exits non-zero on an unparseable
   workflow, so a partial classification is never mistaken for a complete one.
+- **`ci-gitops.yml`'s `summary` job reports the real job results.** It printed
+  five fixed lines including `All validation checks completed!` without ever
+  reading `needs.*.result`, so a run in which every needed job failed still
+  told anyone reading the job that validation had passed. It now writes a
+  Markdown table of all eight results to `$GITHUB_STEP_SUMMARY`, the same shape
+  `ci-js.yml` already used. Results are printed verbatim — `skipped` means
+  either the job's `enable-*` input is off or `validate-yaml` failed, and the
+  table does not distinguish the two. The job stays exit 0 and is still not a
+  gate; a failed job fails the called run and therefore the caller's job.
+  Consumer-visible only in where the output appears: the stdout log lines move
+  to the run's step summary.
 - **`ci-gitops.yml` gained an opt-in `validate-python` job.** GitOps consumers'
   pytest suites ran only in a local `pre-push` hook — opt-in via
   `lefthook install`, and bypassed by `--no-verify`, web-UI edits and bot


### PR DESCRIPTION
## Summary

- The `summary` job in `ci-gitops.yml` printed five fixed lines including `All validation checks completed!` without ever reading `needs.*.result`, so a run where every needed job failed still reported success to anyone reading the job.
- The step now reads all eight `needs.<job>.result` values via `env:` and writes a Markdown table to `$GITHUB_STEP_SUMMARY`, matching the pattern already used in `ci-js.yml`.
- Results are printed verbatim: every job is gated by an `enable-*` input, so `skipped` is a normal state and is not rewritten. Exit code stays 0 — the real gate is the caller's conclusion, not this job.

## Test plan

- [x] `just lint` green (yamllint, jq, actionlint/shellcheck, prettier fmt-check)
- [x] `grep -c 'needs\..*\.result'` returns 8 and the job names match the `needs:` list exactly
- [x] `All validation checks completed` no longer present anywhere in the repo
- [ ] CI green
- [ ] First real run shows the table with verbatim results; a run with a failed job shows `failure` in the table while `summary` itself stays green