### PR TITLE
fix(ai-claude-review): report a workflow-validation skip as a skip

### DIFF
--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -141,7 +141,12 @@ jobs:
             echo "last-review-sha=$SHA" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
+      # The `id` is load-bearing, not cosmetic: the assertion step below reads
+      # this step's `skipped_due_to_workflow_validation_mismatch` output to tell
+      # a deliberate skip apart from a review that should have been posted.
+      # Without an `id`, `steps.*.outputs` has nothing to address it by.
+      - id: claude
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # claude-code-action@v1 blocks bot-initiated runs by default.
@@ -308,8 +313,39 @@ jobs:
           # Marker keeps the comment idempotent across re-runs and later pushes,
           # same upsert idea as ops-drift-issue.yml.
           MARKER: '<!-- claude-review-missing -->'
+          # A separate marker from MARKER above: "skipped, expected" and "should
+          # have run, no review here" are different states, and a shared marker
+          # would suppress whichever text landed second.
+          SKIP_MARKER: '<!-- claude-review-skipped -->'
+          SKIPPED: ${{ steps.claude.outputs.skipped_due_to_workflow_validation_mismatch }}
         run: |
           set -euo pipefail
+
+          # The action refuses to run when the PR changes a workflow file that
+          # differs from the default branch: the OIDC-to-app-token exchange
+          # answers `workflow_not_found_on_default_branch`, and the action
+          # treats that as a skip — warning, output set, no `setFailed`. The
+          # step ends `success` in seconds. Report that as the skip it is
+          # rather than as a missing review, which points at the wrong cause.
+          #
+          # Green rather than red: the skip is unavoidable for the PR author
+          # until the changed file is on the default branch, so a red check
+          # would be permanent and would destroy the signal this guard exists
+          # for. The accepted cost is that workflow-changing PRs merge without
+          # a Claude review; the PR comment keeps that visible on the PR
+          # instead of leaving it in the job log.
+          if [ "${SKIPPED:-}" = "true" ]; then
+            POSTED=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
+              | jq -s --arg m "$SKIP_MARKER" 'add // [] | [.[] | select(.body | contains($m))] | length')
+
+            if [ "$POSTED" -eq 0 ]; then
+              gh pr comment "$PR" --repo "$REPO" --body "$(printf '%s\n%s' "$SKIP_MARKER" \
+                'Claude Code Review was skipped: this pull request changes a workflow file that differs from the default branch, which the action refuses to run against. This diff is therefore unreviewed — review it manually before merging. The skip resolves once the workflow change is on the default branch.')"
+            fi
+
+            echo "::notice::Claude Code Review skipped — the PR changes a workflow file that differs from the default branch."
+            exit 0
+          fi
 
           # Same bot predicate as the `mode` step above rather than its
           # `bot-login` output: that output falls back to a hard-coded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,29 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   `--disallowedTools` entry blocks `which`, `command`, `whereis` and `type`
   outright. The prompt rule covers the reviewer asserting an inventory it never
   measured; the deny list covers the allowlist letting a probe through.
+- **`ai-claude-review.yml` reports a workflow-validation skip as a skip instead
+  of a missing review.** The guard added on 2026-08-04 turned every pull request
+  that changes a workflow file into a permanently red `claude-review` check, so
+  a real review finding was no longer distinguishable from the standing
+  failure — the signal the guard exists to protect. The cause is a deliberate
+  skip, not a failure: `anthropics/claude-code-action` exchanges an OIDC token
+  for an app token at startup, and when the pull request's workflow file differs
+  from the one on the default branch the exchange answers
+  `workflow_not_found_on_default_branch`. The action treats that as a skip —
+  warning, step output `skipped_due_to_workflow_validation_mismatch`, return
+  without `setFailed` — so the step ends `success` after a few seconds instead
+  of running for minutes. The guard never read that output and reported the
+  absent review instead, pointing at the symptom rather than the cause. The
+  action step now carries `id: claude` and the guard checks that output first:
+  on a skip it upserts a PR comment under its own
+  `<!-- claude-review-skipped -->` marker, emits a `::notice::` and exits 0. The
+  regular path is unchanged. **The accepted cost:** workflow-changing pull
+  requests merge without a Claude review, because the skip is unavoidable for
+  the author until the changed file is on the default branch. The PR comment
+  keeps that visible on the pull request rather than in the job log, which is
+  `Forbidden` over the API for these runs. `scripts/tests/test-claude-review-skip-guard.sh`
+  covers the wiring, which is a plain string reference that GitHub Actions
+  resolves to the empty string when broken.
 - **`ci-gitops.yml` and both Go workflows fall under the injection guard.**
   `scripts/tests/test-workflow-input-injection.sh` asserts structurally that no
   caller-controlled `${{ }}` reaches a `run:` body. `ci-go.yml` and

--- a/justfile
+++ b/justfile
@@ -111,6 +111,7 @@ test:
     scripts/tests/test-ci-go-postgres-env-guard.sh
     scripts/tests/test-github-env-guards.sh
     scripts/tests/test-validate-python-input.sh
+    scripts/tests/test-claude-review-skip-guard.sh
 
 # fmt → format Markdown and JSON in place
 fmt:

--- a/scripts/tests/test-claude-review-skip-guard.sh
+++ b/scripts/tests/test-claude-review-skip-guard.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Self-check for the workflow-validation skip branch in ai-claude-review.yml.
+#
+# The action refuses to run when the PR changes a workflow file that differs
+# from the default branch, and reports that as a *skip*: it sets the step
+# output `skipped_due_to_workflow_validation_mismatch` and returns without
+# failing. The assertion step reads that output to report a skip instead of a
+# missing review. The wiring is a plain string reference through
+# `steps.<id>.outputs.<name>` — GitHub Actions resolves an unknown `steps.*`
+# expression to the empty string rather than erroring, so every way of breaking
+# it is silent at runtime and only visible here.
+#
+# Everything is derived from the file, nothing is hardcoded: the step id is read
+# out of the workflow and then required in the guard, so renaming the id in one
+# place and not the other fails.
+#
+# Run: scripts/tests/test-claude-review-skip-guard.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+WORKFLOW="${1:-$REPO/.github/workflows/ai-claude-review.yml}"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+[ -f "$WORKFLOW" ] || fail "workflow not found: $WORKFLOW"
+
+SKIP_OUTPUT='skipped_due_to_workflow_validation_mismatch'
+
+# 1 — the action step carries an `id`.
+#
+# The candidate is reset at every step boundary (`      - `). Without that reset
+# a step with no `id` of its own would inherit the previous step's id from the
+# scan and the assertion would pass against a file where the wiring is in fact
+# broken.
+# `id:` is matched both as the first key of a step (`      - id: x`) and as a
+# later key (`        id: x`), because YAML allows either and the workflow uses
+# the former.
+STEP_ID="$(
+  awk '
+    /^      - / { id = "" }
+    /^ *-? *id: / { id = $NF }
+    /uses: anthropics\/claude-code-action@/ { print id; exit }
+  ' "$WORKFLOW"
+)"
+
+[ -n "$STEP_ID" ] || fail "the anthropics/claude-code-action step needs an \`id:\` — without it its outputs cannot be addressed and the skip branch can never fire"
+
+# The guard body: from the assertion step to the end of the file.
+GUARD="$(
+  awk '/^      - name: Assert a review was posted$/ { inside = 1 }
+       inside { print }' "$WORKFLOW"
+)"
+[ -n "$GUARD" ] || fail "step 'Assert a review was posted' not found"
+
+# 2 — the guard reads the skip output under exactly that id.
+grep -qF "steps.$STEP_ID.outputs.$SKIP_OUTPUT" <<<"$GUARD" ||
+  fail "the guard must read \`steps.$STEP_ID.outputs.$SKIP_OUTPUT\` — an unknown \`steps.*\` reference resolves to the empty string, so a renamed id disables the skip branch silently"
+
+# 3 — the skip branch ends in `exit 0`.
+#
+# Scoped to the branch, not the file: the guard already has an `exit 0` on the
+# "review found" path, so a bare `grep -q 'exit 0'` would have passed before
+# this change existed.
+SKIP_BRANCH="$(
+  awk '/if \[ "\$\{SKIPPED:-\}" = "true" \]; then/ { inside = 1 }
+       inside { print }
+       inside && /^          fi$/ { exit }' <<<"$GUARD"
+)"
+[ -n "$SKIP_BRANCH" ] || fail "no \`if [ \"\${SKIPPED:-}\" = \"true\" ]\` branch in the guard"
+grep -qE '^ *exit 0$' <<<"$SKIP_BRANCH" ||
+  fail "the skip branch must end in \`exit 0\` — otherwise it falls through into the missing-review path and the check goes red on exactly the runs it is meant to explain"
+
+# 4 — the regular path still fails.
+grep -qE '^ *exit 1$' <<<"$GUARD" ||
+  fail "the guard must still \`exit 1\` when no review was posted"
+
+# 5 — the two markers exist, appear once each, and differ. A shared marker would
+# make the upsert check see the other state's comment and suppress this one.
+MISSING_MARKER='<!-- claude-review-missing -->'
+SKIPPED_MARKER='<!-- claude-review-skipped -->'
+
+[ "$MISSING_MARKER" != "$SKIPPED_MARKER" ] || fail "the two comment markers must differ"
+
+for marker in "$MISSING_MARKER" "$SKIPPED_MARKER"; do
+  COUNT="$(grep -cF "$marker" "$WORKFLOW" || true)"
+  [ "$COUNT" -eq 1 ] ||
+    fail "marker '$marker' must be defined exactly once in the workflow (found $COUNT) — the branches reference it through their env var, not by repeating the literal"
+done
+
+echo "PASS: claude review skip guard wired through id '$STEP_ID'"


### PR DESCRIPTION
## Summary

- `ai-claude-review.yml` reported a deliberate skip as a missing review. When a pull request changes a workflow file that differs from the default branch, the action's OIDC-to-app-token exchange answers `workflow_not_found_on_default_branch`; the action treats that as a skip — step output `skipped_due_to_workflow_validation_mismatch`, return without `setFailed` — and ends `success` in seconds. The guard never read that output, so it reported the absent review and pointed at the symptom instead of the cause.
- The action step now carries `id: claude` (load-bearing: without it the output cannot be addressed) and the guard checks that output before anything else. On a skip it upserts a PR comment under its own `<!-- claude-review-skipped -->` marker, emits a `::notice::` and exits 0. The regular path is unchanged.
- Accepted cost: workflow-changing pull requests merge without a Claude review. The skip is unavoidable for the author until the change is on the default branch, so a red check would be permanent and would destroy the signal the guard exists to protect. The PR comment keeps it visible on the pull request rather than in the job log, which is `Forbidden` over the API for these runs.
- `scripts/tests/test-claude-review-skip-guard.sh` covers the wiring, which is a plain string reference that GitHub Actions resolves to the empty string when broken — every way of breaking it is silent at runtime.

## Test plan

- [x] `just lint` — yamllint, jq, actionlint (via container, with shellcheck), prettier
- [x] `just test` — full suite including the new self-check
- [x] Each of the new self-check's assertions broken individually against a copy of the workflow (id removed, id renamed, skip-branch `exit 0` flipped, regular `exit 1` removed, markers collided, skip branch removed) — all six regressions caught