### PR TITLE
fix(ai-claude-review): report a workflow-validation skip as a skip

### DIFF
--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -318,11 +318,24 @@ jobs:
           # would suppress whichever text came second.
           SKIP_MARKER: '<!-- claude-review-skipped -->'
           # Skip detection channel. On a workflow-validation skip the action
-          # returns before its token is exchanged, so this declared output
+          # returns before its token is exchanged, so its `github_token` output
           # arrives empty; on a regular run it carries the app token. It is an
           # undocumented implementation detail of the action — the self-check in
           # scripts/tests/ pins the wiring on this side, not the action's.
-          SKIPPED_TOKEN: ${{ steps.claude.outputs.github_token }}
+          #
+          # `outcome == 'success'` is part of the condition, not decoration: an
+          # empty token also describes a step that *failed* before the exchange
+          # (rejected token, plugin install failure, transport error), and this
+          # step runs under `!cancelled()`, so those runs reach the branch too.
+          # Without the outcome test they would get the skip comment — the same
+          # wrong-cause message this change removes, pointing the other way.
+          #
+          # The comparison happens in the expression, so only its result reaches
+          # the step: a live app token never enters the environment, where only
+          # its emptiness is ever used (REVIEW.md, "Secret handling").
+          SKIPPED: >-
+            ${{ steps.claude.outcome == 'success'
+              && steps.claude.outputs.github_token == '' }}
         run: |
           set -euo pipefail
 
@@ -338,6 +351,19 @@ jobs:
                     and .commit_id == env.HEAD_SHA)] | length')
 
           if [ "$COUNT" -gt 0 ]; then
+            # A review on the head SHA proves the action ran and exchanged its
+            # token, so the detection channel must report "not skipped" here. If
+            # it reports a skip on this path, the channel is broken — an id
+            # rename, or the action dropping the output — and the skip branch
+            # below would then fire on every run and take the check green on
+            # unreviewed diffs. This is the one branch where that is provable at
+            # runtime, so it is asserted where it is free rather than left to
+            # the self-check alone. A warning, not a failure: the review is
+            # there and the diff is reviewed.
+            if [ "$SKIPPED" = "true" ]; then
+              echo "::warning::A review exists on $HEAD_SHA but the skip channel reports a skip — steps.claude.outputs.github_token is no longer a reliable signal; see scripts/tests/test-claude-review-skip-guard.sh."
+            fi
+
             echo "Review found on $HEAD_SHA."
             exit 0
           fi
@@ -353,10 +379,12 @@ jobs:
           # place this shows up, and its API endpoints answer `Forbidden`.
           #
           # An unknown `steps.*` resolves to the empty string, and empty means
-          # "skipped" here, so a broken channel fails green. The review check
-          # above bounds that: it only slips through when a review is missing
-          # for a real reason *and* the channel is broken at the same time.
-          if [ -z "$SKIPPED_TOKEN" ]; then
+          # "skipped" here, so a broken channel fails green on exactly this
+          # guard's population — a review missing for a real reason (turns
+          # exhausted, model error, failed post). The review branch above is
+          # where that break is provable and warns about it; the self-check
+          # pins the wiring statically.
+          if [ "$SKIPPED" = "true" ]; then
             SKIP_POSTED=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
               | jq -s --arg m "$SKIP_MARKER" 'add // [] | [.[] | select(.body | contains($m))] | length')
 

--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -141,7 +141,12 @@ jobs:
             echo "last-review-sha=$SHA" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
+      # `id:` is load-bearing, not decoration: the assertion step below reads
+      # `steps.claude.outputs.github_token` to tell a workflow-validation skip
+      # apart from a genuinely missing review. Without an id those outputs are
+      # not addressable and the skip branch can never fire.
+      - id: claude
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # claude-code-action@v1 blocks bot-initiated runs by default.
@@ -308,6 +313,16 @@ jobs:
           # Marker keeps the comment idempotent across re-runs and later pushes,
           # same upsert idea as ops-drift-issue.yml.
           MARKER: '<!-- claude-review-missing -->'
+          # A separate marker, not the one above: "skipped, expected" and "should
+          # have run, no review" are different states, and one shared marker
+          # would suppress whichever text came second.
+          SKIP_MARKER: '<!-- claude-review-skipped -->'
+          # Skip detection channel. On a workflow-validation skip the action
+          # returns before its token is exchanged, so this declared output
+          # arrives empty; on a regular run it carries the app token. It is an
+          # undocumented implementation detail of the action — the self-check in
+          # scripts/tests/ pins the wiring on this side, not the action's.
+          SKIPPED_TOKEN: ${{ steps.claude.outputs.github_token }}
         run: |
           set -euo pipefail
 
@@ -324,6 +339,33 @@ jobs:
 
           if [ "$COUNT" -gt 0 ]; then
             echo "Review found on $HEAD_SHA."
+            exit 0
+          fi
+
+          # The action skips itself when the triggering workflow file differs
+          # from the one on the default branch: the token exchange answers
+          # `workflow_not_found_on_default_branch`, the action warns and returns
+          # without failing, so the step ends green in seconds with no review.
+          # That is unavoidable for the PR author while the changed file is not
+          # on the default branch yet, so a permanent red check here would
+          # destroy the signal the assertion exists for. Report it as a skip and
+          # leave a comment on the PR instead — the job log is the only other
+          # place this shows up, and its API endpoints answer `Forbidden`.
+          #
+          # An unknown `steps.*` resolves to the empty string, and empty means
+          # "skipped" here, so a broken channel fails green. The review check
+          # above bounds that: it only slips through when a review is missing
+          # for a real reason *and* the channel is broken at the same time.
+          if [ -z "$SKIPPED_TOKEN" ]; then
+            SKIP_POSTED=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
+              | jq -s --arg m "$SKIP_MARKER" 'add // [] | [.[] | select(.body | contains($m))] | length')
+
+            if [ "$SKIP_POSTED" -eq 0 ]; then
+              gh pr comment "$PR" --repo "$REPO" --body "$(printf '%s\n%s' "$SKIP_MARKER" \
+                'Claude Code Review skipped this pull request: the action only runs when the triggering workflow file matches the one on the default branch. This diff was not reviewed — review it manually before merging.')"
+            fi
+
+            echo "::notice::Review skipped on $HEAD_SHA — the workflow file differs from the default branch."
             exit 0
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,32 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
+## 2026-08-06
+
+### Details
+
+- **`ai-claude-review.yml` reports a workflow-validation skip as a skip instead
+  of a missing review.** The guard added on 2026-08-04 was correct — the diff
+  really was unreviewed — but it could not tell the two causes apart, so every
+  pull request whose triggering workflow file differs from the default branch
+  carried a permanent red check with a message pointing at the wrong thing. That
+  is unavoidable for the author while the changed file is not on `main` yet, and
+  a permanently red check destroys the signal the guard exists for. The action
+  returns before its token exchange on such a skip, so its `github_token` output
+  arrives empty; the guard now reads that output — the action step gained the
+  id this requires — and, after the existing head-SHA review check, reports
+  the skip via `::notice::` plus a PR comment under its own
+  `<!-- claude-review-skipped -->` marker and exits 0. The regular path is
+  unchanged and still exits 1. `scripts/tests/test-claude-review-skip-guard.sh`
+  pins the wiring: the detection channel is an undocumented implementation
+  detail of the action whose failure direction is green, so a rename on this
+  side would otherwise take the check green on unreviewed diffs in silence.
+  Affected pull requests now merge without a Claude review rather than with a
+  red check — the comment keeps that visible on the PR, where the job log is
+  not: its API endpoints answer `Forbidden` for these runs.
+
+---
+
 ## 2026-08-05
 
 ### Details

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
-## 2026-08-06
+## 2026-08-05
 
 ### Details
 
@@ -32,23 +32,24 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   is unavoidable for the author while the changed file is not on `main` yet, and
   a permanently red check destroys the signal the guard exists for. The action
   returns before its token exchange on such a skip, so its `github_token` output
-  arrives empty; the guard now reads that output — the action step gained the
-  id this requires — and, after the existing head-SHA review check, reports
-  the skip via `::notice::` plus a PR comment under its own
-  `<!-- claude-review-skipped -->` marker and exits 0. The regular path is
-  unchanged and still exits 1. `scripts/tests/test-claude-review-skip-guard.sh`
-  pins the wiring: the detection channel is an undocumented implementation
-  detail of the action whose failure direction is green, so a rename on this
-  side would otherwise take the check green on unreviewed diffs in silence.
-  Affected pull requests now merge without a Claude review rather than with a
-  red check — the comment keeps that visible on the PR, where the job log is
-  not: its API endpoints answer `Forbidden` for these runs.
-
----
-
-## 2026-08-05
-
-### Details
+  arrives empty; the guard now treats a step that succeeded _and_ produced no
+  token as a skip — the action step gained the id this requires — and, after
+  the existing head-SHA review check, reports it via `::notice::` plus a pull
+  request comment under its own `<!-- claude-review-skipped -->` marker, then
+  exits 0. The success test is part of the condition: an empty token also
+  describes a step that failed before the exchange, and the assertion runs under
+  `!cancelled()`, so those runs reach the branch too and must keep the red path.
+  The regular path is otherwise unchanged and still exits 1.
+  `scripts/tests/test-claude-review-skip-guard.sh` pins the wiring, because the
+  detection channel is an undocumented implementation detail of the action whose
+  failure direction is green — a rename on this side would otherwise take the
+  check green on unreviewed diffs in silence. The branch where a review _was_
+  posted additionally warns when the channel still reports a skip: a review on
+  the head SHA proves the action ran, so that combination can only mean the
+  wiring broke, and it is the one place that is provable at runtime. Affected
+  pull requests now merge without a Claude review rather than with a red check —
+  the comment keeps that visible on the pull request, where the job log is not:
+  its API endpoints answer `Forbidden` for these runs.
 
 - **`ci-gitops.yml`'s `summary` job reports the real job results.** It printed
   five fixed lines including `All validation checks completed!` without ever

--- a/justfile
+++ b/justfile
@@ -111,6 +111,7 @@ test:
     scripts/tests/test-ci-go-postgres-env-guard.sh
     scripts/tests/test-github-env-guards.sh
     scripts/tests/test-validate-python-input.sh
+    scripts/tests/test-claude-review-skip-guard.sh
 
 # fmt → format Markdown and JSON in place
 fmt:

--- a/scripts/tests/test-claude-review-skip-guard.sh
+++ b/scripts/tests/test-claude-review-skip-guard.sh
@@ -52,13 +52,16 @@ ACTION_ID="$(awk '
   END { if (found && !done) print id }
 ' "$WORKFLOW")"
 
+# Emptiness first: `grep -c .` counts non-empty lines, so an empty id would
+# report as "more than one line" and hide the very regression this file names as
+# its reason for existing.
+[ -n "$ACTION_ID" ] ||
+  fail "the anthropics/claude-code-action step has no id; its outputs are not addressable"
+
 # The id must be a single token: an extraction that returned two lines would
 # make every pattern built from it match nothing, which fails green.
 [ "$(grep -c . <<<"$ACTION_ID")" -eq 1 ] ||
   fail "the id extraction returned more than one line: [$ACTION_ID]"
-
-[ -n "$ACTION_ID" ] ||
-  fail "the anthropics/claude-code-action step has no id; its outputs are not addressable"
 
 # --- 2. the guard reads github_token under exactly that id -------------------
 

--- a/scripts/tests/test-claude-review-skip-guard.sh
+++ b/scripts/tests/test-claude-review-skip-guard.sh
@@ -36,28 +36,59 @@ fail() {
 # step with no id of its own would inherit the previous step's (`mode`), and the
 # assertion would pass on a file where the id had been dropped — the exact
 # regression this check exists for.
+#
+# Both key orderings are accepted. YAML mapping keys are unordered, so `uses:`
+# first and `id:` first are the same step; matching only the latter would report
+# "the step has no id" on a file that has one, which is a loud failure with a
+# misleading cause. The `uses:` line therefore only records that the step is the
+# one under test, and the id is printed at the following step boundary or at EOF.
+# `done` rather than a bare `exit`: awk still runs the END block after `exit`,
+# so without it the id is printed twice and every pattern built from it below
+# carries an embedded newline and matches nothing — a green run on any file.
 ACTION_ID="$(awk '
-  /^      - / { id = "" }
-  /^      - id: / { id = $3 }
-  /^ *uses: anthropics\/claude-code-action@/ { print id; exit }
+  /^      - / { if (found) { print id; done = 1; exit } id = "" }
+  /^ *(- )?id: / { id = $NF }
+  /^ *(- )?uses: anthropics\/claude-code-action@/ { found = 1 }
+  END { if (found && !done) print id }
 ' "$WORKFLOW")"
+
+# The id must be a single token: an extraction that returned two lines would
+# make every pattern built from it match nothing, which fails green.
+[ "$(grep -c . <<<"$ACTION_ID")" -eq 1 ] ||
+  fail "the id extraction returned more than one line: [$ACTION_ID]"
 
 [ -n "$ACTION_ID" ] ||
   fail "the anthropics/claude-code-action step has no id; its outputs are not addressable"
 
 # --- 2. the guard reads github_token under exactly that id -------------------
 
-grep -q "steps\.$ACTION_ID\.outputs\.github_token" "$WORKFLOW" ||
-  fail "no guard reference to steps.$ACTION_ID.outputs.github_token; a stale id resolves to empty, which means 'skip' and takes the check green on unreviewed diffs"
+# Anchored to the env entry, not matched anywhere in the file: the workflow's
+# own comments name this expression in prose, so an unanchored grep stays green
+# after the `SKIPPED:` entry is deleted — it would be matching the comment that
+# explains the wiring rather than the wiring.
+SKIPPED_EXPR="$(sed -n '/^ *SKIPPED: /,/^ *[A-Za-z_-]*:/p' "$WORKFLOW")"
+[ -n "$SKIPPED_EXPR" ] || fail "no SKIPPED env entry found in the assertion step"
+
+grep -q "steps\.$ACTION_ID\.outputs\.github_token" <<<"$SKIPPED_EXPR" ||
+  fail "the SKIPPED env entry does not read steps.$ACTION_ID.outputs.github_token; a stale id resolves to empty, which means 'skip' and takes the check green on unreviewed diffs"
+
+# The outcome test is what keeps the branch to the state it describes: an empty
+# token also describes a step that failed before its token exchange, and the
+# assertion step runs under `!cancelled()`, so those runs reach it too.
+grep -q "steps\.$ACTION_ID\.outcome == 'success'" <<<"$SKIPPED_EXPR" ||
+  fail "the SKIPPED env entry does not require steps.$ACTION_ID.outcome == 'success'; a failed action step would be reported as a validation skip"
 
 # --- locate the guard branches ------------------------------------------------
 
 # Each branch is located by its own condition rather than by a line offset, so
 # reordering the guard body cannot silently move an assertion onto the wrong
 # block.
-# shellcheck disable=SC2016 # the $SKIPPED_TOKEN text is matched literally in the YAML
-SKIP_LINE="$(grep -n '^ *if \[ -z "\$SKIPPED_TOKEN" \]; then$' "$WORKFLOW" | cut -d: -f1 || true)"
-[ -n "$SKIP_LINE" ] || fail "no skip branch guarded by an empty-token test found"
+# The skip branch is the one that acts on the channel *and* exits; the review
+# branch tests the same variable to warn, so the grep is anchored on the `if`
+# that opens a block rather than on any mention of the name.
+# shellcheck disable=SC2016 # the $SKIPPED text is matched literally in the YAML
+SKIP_LINE="$(grep -n '^          if \[ "\$SKIPPED" = "true" \]; then$' "$WORKFLOW" | cut -d: -f1 || true)"
+[ -n "$SKIP_LINE" ] || fail "no skip branch guarded by the skip channel found"
 [ "$(grep -c . <<<"$SKIP_LINE")" -eq 1 ] || fail "expected exactly one skip branch"
 
 # The red path is anchored on its error line, which only it carries.
@@ -76,6 +107,13 @@ REVIEW_LINE="$(grep -n '^ *if \[ "\$COUNT" -gt 0 \]; then$' "$WORKFLOW" | cut -d
 [ -n "$REVIEW_LINE" ] || fail "no head-SHA review check found"
 [ "$REVIEW_LINE" -lt "$SKIP_LINE" ] ||
   fail "review check is at line $REVIEW_LINE, below the skip branch at $SKIP_LINE"
+
+# The review branch carries the runtime detector for a broken channel: a review
+# on the head SHA proves the action ran, so a skip reported there can only mean
+# the wiring broke. It is the one place that is provable at runtime, which is
+# why its loss should not be silent.
+sed -n "${REVIEW_LINE},$((SKIP_LINE - 1))p" "$WORKFLOW" | grep -q '::warning::' ||
+  fail "the review branch no longer warns when the skip channel reports a skip on a reviewed head SHA"
 
 # --- 3. the skip branch exits green ------------------------------------------
 

--- a/scripts/tests/test-claude-review-skip-guard.sh
+++ b/scripts/tests/test-claude-review-skip-guard.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# The claude-code-action skips itself when the triggering workflow file differs
+# from the one on the default branch: it warns and returns without failing, so
+# the step ends green in seconds with no review posted. The assertion step in
+# ai-claude-review.yml tells that skip apart from a genuinely missing review by
+# reading the action's `github_token` output, which arrives empty on a skip.
+#
+# That channel is an undocumented implementation detail of the action, and its
+# failure direction is green: an unknown `steps.*` resolves to the empty string,
+# and empty means "skipped" here. A rename on this side would therefore make the
+# skip branch fire on *every* run and take the check green on unreviewed diffs,
+# silently. This file pins the wiring so that edit fails loudly instead.
+#
+# Everything is derived from the workflow rather than hard-coded, so the file
+# under test is the shipped one: the id is read out of the action step and the
+# guard's reference is then checked against whatever was read, which catches a
+# one-sided rename while leaving a consistent one free.
+#
+# Run: scripts/tests/test-claude-review-skip-guard.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+WORKFLOW="$REPO/.github/workflows/ai-claude-review.yml"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+[ -f "$WORKFLOW" ] || fail "ai-claude-review.yml not found at $WORKFLOW"
+
+# --- 1. the action step carries an id ----------------------------------------
+
+# The candidate is reset at every `      - ` step boundary. Without that reset a
+# step with no id of its own would inherit the previous step's (`mode`), and the
+# assertion would pass on a file where the id had been dropped — the exact
+# regression this check exists for.
+ACTION_ID="$(awk '
+  /^      - / { id = "" }
+  /^      - id: / { id = $3 }
+  /^ *uses: anthropics\/claude-code-action@/ { print id; exit }
+' "$WORKFLOW")"
+
+[ -n "$ACTION_ID" ] ||
+  fail "the anthropics/claude-code-action step has no id; its outputs are not addressable"
+
+# --- 2. the guard reads github_token under exactly that id -------------------
+
+grep -q "steps\.$ACTION_ID\.outputs\.github_token" "$WORKFLOW" ||
+  fail "no guard reference to steps.$ACTION_ID.outputs.github_token; a stale id resolves to empty, which means 'skip' and takes the check green on unreviewed diffs"
+
+# --- locate the guard branches ------------------------------------------------
+
+# Each branch is located by its own condition rather than by a line offset, so
+# reordering the guard body cannot silently move an assertion onto the wrong
+# block.
+# shellcheck disable=SC2016 # the $SKIPPED_TOKEN text is matched literally in the YAML
+SKIP_LINE="$(grep -n '^ *if \[ -z "\$SKIPPED_TOKEN" \]; then$' "$WORKFLOW" | cut -d: -f1 || true)"
+[ -n "$SKIP_LINE" ] || fail "no skip branch guarded by an empty-token test found"
+[ "$(grep -c . <<<"$SKIP_LINE")" -eq 1 ] || fail "expected exactly one skip branch"
+
+# The red path is anchored on its error line, which only it carries.
+RED_LINE="$(grep -n '^ *echo "::error::No review on ' "$WORKFLOW" | cut -d: -f1 || true)"
+[ -n "$RED_LINE" ] || fail "no red path found"
+[ "$(grep -c . <<<"$RED_LINE")" -eq 1 ] || fail "expected exactly one red path"
+
+[ "$SKIP_LINE" -lt "$RED_LINE" ] ||
+  fail "skip branch is at line $SKIP_LINE, below the red path at $RED_LINE — the red path would win"
+
+# The head-SHA review check must come first: it is what bounds the green failure
+# direction of the skip channel. Moved below the skip branch, a broken channel
+# would swallow real reviews instead of only the doubly-unlucky case.
+# shellcheck disable=SC2016 # the $COUNT text is matched literally in the YAML
+REVIEW_LINE="$(grep -n '^ *if \[ "\$COUNT" -gt 0 \]; then$' "$WORKFLOW" | cut -d: -f1 || true)"
+[ -n "$REVIEW_LINE" ] || fail "no head-SHA review check found"
+[ "$REVIEW_LINE" -lt "$SKIP_LINE" ] ||
+  fail "review check is at line $REVIEW_LINE, below the skip branch at $SKIP_LINE"
+
+# --- 3. the skip branch exits green ------------------------------------------
+
+# Scoped to the branch, not the file: an `exit 0` already exists on the
+# "review found" path, so a bare `grep -q 'exit 0'` was satisfied before this
+# change ever landed and would prove nothing.
+sed -n "${SKIP_LINE},$((RED_LINE - 1))p" "$WORKFLOW" | grep -q '^ *exit 0$' ||
+  fail "the skip branch does not exit 0"
+
+# --- 4. the regular branch still exits red -----------------------------------
+
+sed -n "${RED_LINE},\$p" "$WORKFLOW" | grep -q '^ *exit 1$' ||
+  fail "the red path no longer exits 1"
+
+# --- 5. two distinct markers, one occurrence each -----------------------------
+
+# One shared marker would let the upsert check of one state suppress the other
+# state's comment, so the two are asserted to be different as well as present.
+MISSING_MARKER="$(sed -n "s/^ *MARKER: '\(.*\)'$/\1/p" "$WORKFLOW")"
+SKIP_MARKER="$(sed -n "s/^ *SKIP_MARKER: '\(.*\)'$/\1/p" "$WORKFLOW")"
+
+[ -n "$MISSING_MARKER" ] || fail "no MARKER definition found"
+[ -n "$SKIP_MARKER" ] || fail "no SKIP_MARKER definition found"
+[ "$(grep -c . <<<"$MISSING_MARKER")" -eq 1 ] || fail "expected exactly one MARKER definition"
+[ "$(grep -c . <<<"$SKIP_MARKER")" -eq 1 ] || fail "expected exactly one SKIP_MARKER definition"
+
+[ "$MISSING_MARKER" != "$SKIP_MARKER" ] ||
+  fail "both states use the same marker; one upsert check would suppress the other comment"
+
+echo "PASS: ai-claude-review.yml workflow-validation skip guard"


### PR DESCRIPTION
## Summary

- The `anthropics/claude-code-action` skips itself when the triggering workflow file differs from the one on the default branch: it warns and returns without failing, so the step ends green in seconds with no review posted. The guard added on 2026-08-04 correctly noticed the diff was unreviewed but could not tell that skip apart from a real failure, so every affected pull request carried a permanent red check with a message pointing at the wrong cause.
- The guard now reads the action's `github_token` output, which arrives empty on such a skip — the action step gained the `id` this requires. After the existing head-SHA review check it reports the skip via `::notice::` plus a PR comment under its own `<!-- claude-review-skipped -->` marker and exits 0. The regular path is unchanged and still exits 1.
- `scripts/tests/test-claude-review-skip-guard.sh` pins the wiring. The detection channel is an undocumented implementation detail of the action and its failure direction is green — an unknown `steps.*` resolves to the empty string, and empty means "skipped" here — so a rename on this side would otherwise take the check green on unreviewed diffs in silence.
- Trade-off, deliberate: affected pull requests now merge without a Claude review rather than with a red check. The comment keeps that visible on the PR, where the job log is not — its API endpoints answer `Forbidden` for these runs.

## Test plan

- [x] `just test` green, including the new self-check
- [x] `just lint` green (actionlint ran via the container path, so shellcheck coverage was included)
- [x] Self-check verified by breaking each assertion in turn against a mutated copy: id removed, id renamed, the skip branch's `exit 0` changed, the red path's `exit 1` removed, both markers made identical, skip branch removed entirely — all six caught
- [ ] CI green