### PR TITLE
fix(merge): move the date tag to the day's latest merge

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -18,15 +18,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
-      - name: Create date tag if absent
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Move date tag to this commit
         run: |
           set -euo pipefail
           TAG=$(date -u +%Y-%m-%d)
-          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-            echo "Tag $TAG exists, nothing to do."
-            exit 0
-          fi
-          git tag "$TAG"
-          git push origin "$TAG"
+          # The tag tracks the day's latest merge, not its first. Skipping when
+          # the tag already existed left every merge after the first one
+          # unreachable by any tag until the next day's first merge.
+          git tag -f "$TAG"
+          git push -f origin "refs/tags/$TAG"
+          echo "Tag $TAG now points at $(git rev-parse --short HEAD)."

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -8,9 +8,19 @@ on:
 permissions:
   contents: write # Tag-Push
 
+# The tag move is read-modify-write on a single ref, so two runs must never
+# overlap. Queue them instead of cancelling: a cancelled run would skip the
+# tag move for a commit that is already on main.
+concurrency:
+  group: date-tag
+  cancel-in-progress: false
+
 jobs:
   date-tag:
-    name: Cut Date Tag
+    name: Move Date Tag
+    # A dispatch from another branch would otherwise force the day's tag onto
+    # that branch, and consumer repos pin these tags.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -25,6 +35,20 @@ jobs:
           # The tag tracks the day's latest merge, not its first. Skipping when
           # the tag already existed left every merge after the first one
           # unreachable by any tag until the next day's first merge.
+          git fetch origin --tags --quiet
+          # Only ever move the tag forward. Runs are serialised, but a queued
+          # run still checks out its own commit, so without this an older one
+          # finishing last would drag the tag backwards.
+          if OLD=$(git rev-parse -q --verify "refs/tags/$TAG^{commit}"); then
+            if [ "$OLD" = "$(git rev-parse HEAD)" ]; then
+              echo "Tag $TAG already points at HEAD, nothing to do."
+              exit 0
+            fi
+            if ! git merge-base --is-ancestor "$OLD" HEAD; then
+              echo "Tag $TAG points at $OLD, which is not an ancestor of HEAD — leaving it alone."
+              exit 0
+            fi
+          fi
           git tag -f "$TAG"
           git push -f origin "refs/tags/$TAG"
           echo "Tag $TAG now points at $(git rev-parse --short HEAD)."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,8 +119,9 @@ uses: sbaerlocher/.github/.github/workflows/ci-js.yml@2026-04-25
 - Consumers MUST reference workflows by date tag.
 - `@main` is forbidden in consumer repos — breaking changes would propagate
   immediately to all of them.
-- New tags are cut from `main` after a batch of changes has settled. The
-  cadence is documented in `CHANGELOG.md`.
+- `merge.yml` tags every push to `main` with the current UTC date, moving that
+  day's tag to the newest commit. A tag therefore covers the whole day and
+  stops changing once the day is over; only the current day's tag is mutable.
 - Renovate updates date tags in consumer repos automatically via the
   custom manager defined in `renovate-base.json`.
 
@@ -308,7 +309,7 @@ carry a `workflow_call` trigger — they are not reusable from consumer repos.
 | ---------------- | ---------------------- | ------------------------------------------ |
 | Test dde actions | `test-actions-dde.yml` | Smoke-test `setup-dde` on Linux/macOS      |
 | Pull Request     | `pull-request.yml`     | `just lint` + `just test` on PRs to `main` |
-| Merge to Main    | `merge.yml`            | Cuts the `YYYY-MM-DD` date tag on push     |
+| Merge to Main    | `merge.yml`            | Moves the `YYYY-MM-DD` date tag on push    |
 | Weekly Security  | `weekly-security.yml`  | Scheduled config + secret self-scan (Mon)  |
 
 ---
@@ -571,7 +572,7 @@ Ensure lock files are committed:
 │   │   ├── release-*.yml   # Release workflows
 │   │   ├── security-*.yml  # Security workflows
 │   │   ├── test-*.yml      # Internal self-tests (NOT reusable)
-│   │   ├── merge.yml       # Internal: cuts the date tag on push to main
+│   │   ├── merge.yml       # Internal: moves the date tag on push to main
 │   │   ├── pull-request.yml # Internal: lint + test on this repo's PRs
 │   │   └── weekly-security.yml # Internal: scheduled self-scan
 │   ├── ISSUE_TEMPLATE/     # Org-default issue forms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   `### ⚠ BREAKING` heading in its dated entry below, naming the affected
   workflow and a one-line migration step. Scan for `⚠ BREAKING` before bumping
   a tag — that is the single source of truth for what might break.
-- **Only the latest tag is supported.** Older date tags keep working
-  (immutable), but fixes and security patches land only on `main` / the newest
-  tag. Pin an old tag at your own risk; there is no backport.
+- **Only the latest tag is supported.** Past days' tags keep working and no
+  longer move, but fixes and security patches land only on `main` / the newest
+  tag. Pin an old tag at your own risk; there is no backport. The current UTC
+  day's tag is the exception: it follows that day's latest merge, so it can
+  still change until the day is over.
 
 ---
 
@@ -24,6 +26,16 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ### Details
 
+- **The date tag tracks the day's latest merge instead of its first.**
+  `merge.yml` exited early when the tag already existed, so only the first
+  merge of a UTC day was ever tagged. Every later merge that day stayed
+  unreachable from any date tag until the next day's first merge — measured
+  over the preceding days, `2026-08-03` missed 8 commits across 10 workflow
+  files and `2026-08-04` missed 3 commits across 5. The step now force-updates
+  the tag on every push to `main`. Consumer-visible consequence: a date tag is
+  mutable during its own UTC day and settles once that day is over, so a
+  consumer who pins today's tag mid-day and re-fetches later can receive a
+  newer tree under the same name. Tags from previous days never move.
 - **`ci-gitops.yml`'s `summary` job reports the real job results.** It printed
   five fixed lines including `All validation checks completed!` without ever
   reading `needs.*.result`, so a run in which every needed job failed still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,18 +24,23 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ## 2026-08-05
 
+### ⚠ BREAKING
+
+- **The current UTC day's date tag is now mutable.** `merge.yml` used to skip
+  tagging when the day's tag already existed, so a tag was pinned to that day's
+  first merge and never moved. Every later merge stayed unreachable from any
+  date tag until the next day's first merge — `2026-08-03` missed 8 commits
+  across 10 workflow files, `2026-08-04` missed 3 across 5. Those were real
+  workflow fixes no consumer could pin. The tag now moves to the newest commit
+  on every push to `main`, so one tag covers a whole day.
+  **Migration:** none required, and past days' tags never move. But a consumer
+  that pins the _current_ day's tag and re-fetches later in that same day can
+  receive a newer tree under the same name — CI caches or mirrors keyed on the
+  tag name may serve either. Pin a past day's tag when you need a target that
+  is fixed the moment you pin it.
+
 ### Details
 
-- **The date tag tracks the day's latest merge instead of its first.**
-  `merge.yml` exited early when the tag already existed, so only the first
-  merge of a UTC day was ever tagged. Every later merge that day stayed
-  unreachable from any date tag until the next day's first merge — measured
-  over the preceding days, `2026-08-03` missed 8 commits across 10 workflow
-  files and `2026-08-04` missed 3 commits across 5. The step now force-updates
-  the tag on every push to `main`. Consumer-visible consequence: a date tag is
-  mutable during its own UTC day and settles once that day is over, so a
-  consumer who pins today's tag mid-day and re-fetches later can receive a
-  newer tree under the same name. Tags from previous days never move.
 - **`ci-gitops.yml`'s `summary` job reports the real job results.** It printed
   five fixed lines including `All validation checks completed!` without ever
   reading `needs.*.result`, so a run in which every needed job failed still

--- a/README.md
+++ b/README.md
@@ -212,8 +212,10 @@ Rules:
 
 - Date tag is mandatory in consumer repos. `@main` and `@v1` are not
   supported.
-- New tags are cut from `main` after a batch of changes settles.
-  See [CHANGELOG.md](./CHANGELOG.md) for the history.
+- Every push to `main` moves that UTC day's tag to the newest commit, so one
+  tag covers the whole day. A tag stops changing once its day is over; only
+  the current day's tag is still mutable. Pin a past day's tag if you need a
+  fixed target. See [CHANGELOG.md](./CHANGELOG.md) for the history.
 - Renovate updates these tags automatically via the custom manager in
   [`renovate-base.json`](./renovate-base.json).
 


### PR DESCRIPTION
## Summary

- `merge.yml` exited early when the current UTC date tag already existed, so
  only the first merge of a day was ever tagged. Every later merge stayed
  unreachable from any date tag until the next day's first merge — over the
  preceding days, `2026-08-03` missed 8 commits across 10 workflow files and
  `2026-08-04` missed 3 commits across 5. Those were real workflow fixes that
  no consumer could pin.
- The step now force-updates the tag on every push to `main`, so a date tag
  covers the whole day rather than a single commit.
- Consumer-visible consequence, documented in `CHANGELOG.md` and `AGENTS.md`:
  the current UTC day's tag is mutable and settles once the day is over. Past
  days' tags never move. The previous "immutable" wording and the "cut after a
  batch has settled" cadence in `AGENTS.md` no longer described what the
  workflow does and were corrected.
- Dropped the `GH_TOKEN` env from the step — it invoked `gh` nowhere; the push
  authenticates through `persist-credentials: true` plus `contents: write`.

## Test plan

- [ ] `just test` — all suites pass
- [ ] `prettier --check` — clean on all three changed files
- [ ] Tag logic exercised against a real local remote: three same-day merges in
      sequence leave the tag on the third commit, not the first
