### PR TITLE
feat(workflows): add runner input to reusable workflows

### DIFF
--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -5,8 +5,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       model:
         type: string
         required: false

--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -3,6 +3,10 @@ name: AI - Code Review
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       model:
         type: string
         required: false
@@ -94,7 +98,7 @@ jobs:
       github.event.pull_request.user.login != 'renovate[bot]' &&
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
       contents: read

--- a/.github/workflows/ai-claude.yml
+++ b/.github/workflows/ai-claude.yml
@@ -5,8 +5,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       cancel-in-progress:
         type: boolean
         required: false

--- a/.github/workflows/ai-claude.yml
+++ b/.github/workflows/ai-claude.yml
@@ -3,6 +3,10 @@ name: AI - Claude
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       cancel-in-progress:
         type: boolean
         required: false
@@ -42,7 +46,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/ci-ansible.yml
+++ b/.github/workflows/ci-ansible.yml
@@ -6,8 +6,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       ansible-version:
         type: string
         default: '8.5.0'

--- a/.github/workflows/ci-ansible.yml
+++ b/.github/workflows/ci-ansible.yml
@@ -4,6 +4,10 @@ name: Continuous Integration - Ansible
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       ansible-version:
         type: string
         default: '8.5.0'
@@ -72,7 +76,7 @@ concurrency:
 jobs:
   validation:
     name: Validate
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 15
 
     steps:
@@ -143,7 +147,7 @@ jobs:
     # Gate behind validation: a failed syntax check aborts before ansible-lint
     # spends a runner. validation is unconditional, so plain needs is enough.
     needs: validation
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 15
 
     steps:
@@ -192,7 +196,7 @@ jobs:
     if: ${{ inputs.enable-yamllint }}
     # Gate behind validation so a syntax failure aborts before yamllint runs.
     needs: validation
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -9,8 +9,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       python-version:
         description: |
           Python version used by both `validate-yaml` (yamllint) and

--- a/.github/workflows/ci-gitops.yml
+++ b/.github/workflows/ci-gitops.yml
@@ -7,6 +7,10 @@ name: Continuous Integration - GitOps
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       python-version:
         description: |
           Python version used by both `validate-yaml` (yamllint) and
@@ -186,7 +190,7 @@ jobs:
   validate-yaml:
     name: Validate YAML Syntax
     if: inputs.enable-yaml-lint
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 5
     steps:
       - name: Checkout code
@@ -241,7 +245,7 @@ jobs:
     if: >-
       always() && !failure() && !cancelled()
       && inputs.enable-fleet-validation
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 5
     steps:
       - name: Checkout code
@@ -315,7 +319,7 @@ jobs:
     if: >-
       always() && !failure() && !cancelled()
       && inputs.enable-gitrepo-validation
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 5
     steps:
       - name: Checkout code
@@ -418,7 +422,7 @@ jobs:
     if: >-
       always() && !failure() && !cancelled()
       && inputs.enable-helm-lint
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 10
     steps:
       - name: Checkout code
@@ -477,7 +481,7 @@ jobs:
     if: >-
       always() && !failure() && !cancelled()
       && inputs.enable-helm-template-validation
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 10
     steps:
       - name: Checkout code
@@ -565,7 +569,7 @@ jobs:
     if: >-
       always() && !failure() && !cancelled()
       && inputs.enable-k8s-validation
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 10
     steps:
       - name: Checkout code
@@ -624,7 +628,7 @@ jobs:
     if: >-
       always() && !failure() && !cancelled()
       && inputs.enable-docs-check
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 5
     steps:
       - name: Checkout code
@@ -662,7 +666,7 @@ jobs:
     if: >-
       always() && !failure() && !cancelled()
       && inputs.enable-python-tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 5
     steps:
       - name: Checkout code
@@ -766,7 +770,7 @@ jobs:
 
   summary:
     name: Validation Summary
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 5
     needs:
       [

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -6,8 +6,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       go-version:
         type: string
         required: false

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -4,6 +4,10 @@ name: Continuous Integration - Go
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       go-version:
         type: string
         required: false
@@ -116,7 +120,7 @@ concurrency:
 jobs:
   setup:
     name: Setup
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     outputs:
       version: ${{ steps.version.outputs.version }}
       should-run-tests: ${{ steps.should-run.outputs.tests }}
@@ -154,7 +158,7 @@ jobs:
 
   test-and-lint:
     name: Test & Lint
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     needs: setup
     if: needs.setup.outputs.should-run-tests == 'true'
     outputs:
@@ -331,7 +335,7 @@ jobs:
 
   security-scan:
     name: Scan Security (${{ matrix.scanner }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     # Job-level grant: SARIF upload (enable-sarif-upload) needs
     # security-events: write on push events.
     permissions:
@@ -430,7 +434,7 @@ jobs:
 
   codeql-analysis:
     name: Analyze Code
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     # Job-level grant: the workflow-level default is contents: read, but
     # uploading CodeQL results needs security-events: write on push events
     # (public-repo pull_request uploads succeed with a read token).
@@ -484,7 +488,7 @@ jobs:
 
   dependency-review:
     name: Dependency Review
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     if: inputs.enable-dependency-review && github.event_name == 'pull_request' && github.event.repository.visibility == 'public'
 
     steps:

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -4,6 +4,10 @@ name: Continuous Integration - JavaScript
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       package-manager:
         type: string
         default: 'pnpm'
@@ -128,7 +132,7 @@ concurrency:
 jobs:
   setup:
     name: Setup
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     outputs:
       should-run-tests: ${{ steps.should-run.outputs.tests }}
       should-run-security: ${{ steps.should-run.outputs.security }}
@@ -148,7 +152,7 @@ jobs:
 
   quality-and-test:
     name: Test & Lint
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     needs: setup
     if: needs.setup.outputs.should-run-tests == 'true'
     timeout-minutes: 20
@@ -426,7 +430,7 @@ jobs:
 
   security-scan:
     name: Security (${{ matrix.scanner }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     # Job-level grant: SARIF upload (enable-sarif-upload) needs
     # security-events: write on push events.
     permissions:
@@ -557,7 +561,7 @@ jobs:
 
   dependency-review:
     name: Review Dependencies
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     if: inputs.primary && inputs.enable-dependency-review && github.event_name == 'pull_request' && github.event.repository.visibility == 'public'
     timeout-minutes: 10
 
@@ -575,7 +579,7 @@ jobs:
 
   summary:
     name: Create Summary
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     needs: [quality-and-test, security-scan, dependency-review]
     if: always() && !cancelled()
     steps:

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -6,8 +6,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       package-manager:
         type: string
         default: 'pnpm'

--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -3,6 +3,10 @@ name: Continuous Integration - Terraform
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       terraform-version:
         type: string
         default: '1.14.3'
@@ -54,7 +58,7 @@ env:
 jobs:
   validation:
     name: Validate
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 15
     outputs:
       validation_result: ${{ steps.validation.outputs.result }}
@@ -108,7 +112,7 @@ jobs:
     # tflint spends a runner. validation is unconditional, so plain needs is
     # enough — a validation failure skips this job.
     needs: validation
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 10
 
     steps:
@@ -140,7 +144,7 @@ jobs:
     name: Vulnerability Scanning
     # Gate behind validation so a broken config fails fast before the scan runs.
     needs: validation
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -5,8 +5,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       terraform-version:
         type: string
         default: '1.14.3'

--- a/.github/workflows/deploy-cloudflare-workers.yml
+++ b/.github/workflows/deploy-cloudflare-workers.yml
@@ -4,6 +4,10 @@ name: Deploy - Cloudflare Workers
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       workers:
         type: string
         required: true
@@ -68,7 +72,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy Worker (${{ matrix.worker }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/deploy-cloudflare-workers.yml
+++ b/.github/workflows/deploy-cloudflare-workers.yml
@@ -6,8 +6,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       workers:
         type: string
         required: true

--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -4,6 +4,10 @@ name: Deploy - Terraform
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       mode:
         type: string
         required: false
@@ -130,7 +134,7 @@ permissions:
 jobs:
   deploy:
     name: Deploy Infrastructure
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     environment:
       name: ${{ inputs.environment }}

--- a/.github/workflows/deploy-terraform.yml
+++ b/.github/workflows/deploy-terraform.yml
@@ -6,8 +6,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       mode:
         type: string
         required: false

--- a/.github/workflows/e2e-dde.yml
+++ b/.github/workflows/e2e-dde.yml
@@ -6,8 +6,13 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported. Must be a Linux runner with Docker —
+          `dde system:install` does not work on hosted macOS or Windows runners.
       # dde Configuration
       dde-version:
         type: string

--- a/.github/workflows/e2e-dde.yml
+++ b/.github/workflows/e2e-dde.yml
@@ -4,6 +4,10 @@ name: End-to-End - dde
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       # dde Configuration
       dde-version:
         type: string
@@ -157,7 +161,7 @@ concurrency:
 jobs:
   e2e-dde:
     name: E2E (dde)
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 30
     permissions:
       contents: read
@@ -370,7 +374,7 @@ jobs:
   comment:
     name: Comment PR
     needs: e2e-dde
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     if: >
       always()
       && github.event_name == 'pull_request'

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -6,8 +6,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       # Docker Compose Configuration
       compose-file:
         type: string

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -11,7 +11,8 @@ on:
         description: >-
           Single runner label for all jobs in this workflow (e.g.
           `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
-          selectors are not supported.
+          selectors are not supported. Must be a Linux runner with Docker —
+          `docker compose` does not work on hosted macOS or Windows runners.
       # Docker Compose Configuration
       compose-file:
         type: string

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -4,6 +4,10 @@ name: End-to-End - Docker Compose
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       # Docker Compose Configuration
       compose-file:
         type: string
@@ -87,7 +91,7 @@ concurrency:
 jobs:
   e2e-docker:
     name: E2E (Docker Compose)
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/ops-drift-issue.yml
+++ b/.github/workflows/ops-drift-issue.yml
@@ -4,6 +4,10 @@ name: Ops - Drift Issue
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       project-name:
         type: string
         required: true
@@ -76,7 +80,7 @@ concurrency:
 jobs:
   upsert-drift-issue:
     name: Create or Update Drift Issue
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 5
     permissions:
       contents: read

--- a/.github/workflows/ops-drift-issue.yml
+++ b/.github/workflows/ops-drift-issue.yml
@@ -6,8 +6,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       project-name:
         type: string
         required: true

--- a/.github/workflows/ops-terraform-orchestration.yml
+++ b/.github/workflows/ops-terraform-orchestration.yml
@@ -4,6 +4,10 @@ name: Ops - Terraform Orchestration
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       project-name:
         type: string
         required: true
@@ -77,7 +81,7 @@ concurrency:
 jobs:
   orchestration:
     name: Orchestrate Pipeline
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 5
     outputs:
       environment: ${{ steps.config.outputs.environment }}

--- a/.github/workflows/ops-terraform-orchestration.yml
+++ b/.github/workflows/ops-terraform-orchestration.yml
@@ -6,8 +6,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       project-name:
         type: string
         required: true

--- a/.github/workflows/ops-terraform-report.yml
+++ b/.github/workflows/ops-terraform-report.yml
@@ -4,6 +4,10 @@ name: Ops - Terraform Report
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       project-name:
         type: string
         required: true
@@ -97,7 +101,7 @@ concurrency:
 jobs:
   report:
     name: Render Pipeline Report
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 5
     outputs:
       overall-status: ${{ steps.analysis.outputs.overall_status }}

--- a/.github/workflows/ops-terraform-report.yml
+++ b/.github/workflows/ops-terraform-report.yml
@@ -6,8 +6,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       project-name:
         type: string
         required: true

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -11,7 +11,8 @@ on:
         description: >-
           Single runner label for all jobs in this workflow (e.g.
           `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
-          selectors are not supported.
+          selectors are not supported. Must be a Linux runner with Docker —
+          the image tests run `docker run` and mount `/var/run/docker.sock`.
       registry:
         type: string
         required: false

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -6,8 +6,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       registry:
         type: string
         required: false

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -4,6 +4,10 @@ name: Release - Docker
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       registry:
         type: string
         required: false
@@ -118,7 +122,7 @@ concurrency:
 jobs:
   docker-build:
     name: Build & Push
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     outputs:
       image-digest: ${{ steps.build.outputs.digest }}
       image-tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -4,6 +4,10 @@ name: Release - Go
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       go-version:
         type: string
         required: false
@@ -62,7 +66,7 @@ concurrency:
 jobs:
   goreleaser:
     name: Build & Release
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -6,8 +6,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       go-version:
         type: string
         required: false

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -6,8 +6,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       chart-path:
         type: string
         required: false

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -4,6 +4,10 @@ name: Release - Helm
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       chart-path:
         type: string
         required: false
@@ -74,7 +78,7 @@ concurrency:
 jobs:
   helm-release:
     name: Package & Publish
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -6,8 +6,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       package-manager:
         type: string
         default: 'pnpm'

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -4,6 +4,10 @@ name: Release - NPM
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       package-manager:
         type: string
         default: 'pnpm'
@@ -95,7 +99,7 @@ concurrency:
 jobs:
   pre-release-checks:
     name: Validate Package
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 15
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -237,7 +241,7 @@ jobs:
     name: Publish Package
     needs: [pre-release-checks]
     if: needs.pre-release-checks.outputs.should-publish == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 15
     permissions:
       id-token: write # Required for NPM provenance
@@ -420,7 +424,7 @@ jobs:
     name: Generate SBOM
     needs: [pre-release-checks, publish]
     if: inputs.enable-sbom && needs.pre-release-checks.outputs.should-publish == 'true' && !inputs.dry-run
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 10
     permissions:
       contents: read
@@ -455,7 +459,7 @@ jobs:
     name: Create Release
     needs: [pre-release-checks, publish]
     if: inputs.create-github-release && needs.pre-release-checks.outputs.should-publish == 'true' && !inputs.dry-run
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 10
     outputs:
       release-url: ${{ steps.create-release.outputs.html_url }}
@@ -548,7 +552,7 @@ jobs:
 
   release-summary:
     name: Create Summary
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     needs: [pre-release-checks, publish, github-release]
     if: always() && !cancelled()
     steps:

--- a/.github/workflows/security-code.yml
+++ b/.github/workflows/security-code.yml
@@ -6,8 +6,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       languages:
         type: string
         default: '["javascript-typescript"]'

--- a/.github/workflows/security-code.yml
+++ b/.github/workflows/security-code.yml
@@ -4,6 +4,10 @@ name: Security - Code
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       languages:
         type: string
         default: '["javascript-typescript"]'
@@ -74,7 +78,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze Code (${{ matrix.language }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/security-config.yml
+++ b/.github/workflows/security-config.yml
@@ -4,6 +4,10 @@ name: Security - Config
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       # Scan targets
       scan-terraform:
         type: boolean
@@ -81,7 +85,7 @@ jobs:
   # behind its original `if:`; the report is the final always()-step.
   config-scan:
     name: Scan Configuration
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     # Union of the merged jobs' timeouts (4×15).
     timeout-minutes: 60
     steps:

--- a/.github/workflows/security-config.yml
+++ b/.github/workflows/security-config.yml
@@ -11,7 +11,8 @@ on:
         description: >-
           Single runner label for all jobs in this workflow (e.g.
           `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
-          selectors are not supported.
+          selectors are not supported. Must be a Linux runner with Docker —
+          the kubesec scan runs via `docker run`.
       # Scan targets
       scan-terraform:
         type: boolean

--- a/.github/workflows/security-config.yml
+++ b/.github/workflows/security-config.yml
@@ -6,8 +6,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       # Scan targets
       scan-terraform:
         type: boolean

--- a/.github/workflows/security-containers.yml
+++ b/.github/workflows/security-containers.yml
@@ -4,6 +4,10 @@ name: Security - Containers
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       image-ref:
         type: string
         required: true
@@ -65,7 +69,7 @@ jobs:
   # report is the final always()-step reading step outcomes.
   container-scan:
     name: Scan Container Image
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     # Upper bound for the merged trivy + grype + analysis steps. Fixed rather
     # than derived from scan-timeout: GitHub-expression arithmetic isn't
     # portable across linters, and a timeout is only a ceiling. 40 covers

--- a/.github/workflows/security-containers.yml
+++ b/.github/workflows/security-containers.yml
@@ -6,8 +6,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       image-ref:
         type: string
         required: true

--- a/.github/workflows/security-deps.yml
+++ b/.github/workflows/security-deps.yml
@@ -4,6 +4,10 @@ name: Security - Dependencies
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       language:
         type: string
         required: true
@@ -72,7 +76,7 @@ jobs:
   # original `if:`; the report is the final always()-step reading step outcomes.
   dependency-scan:
     name: Scan Dependencies
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     # Union of the merged jobs' timeouts (review 10 + 3×15).
     timeout-minutes: 55
     steps:

--- a/.github/workflows/security-deps.yml
+++ b/.github/workflows/security-deps.yml
@@ -6,8 +6,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       language:
         type: string
         required: true

--- a/.github/workflows/security-sbom.yml
+++ b/.github/workflows/security-sbom.yml
@@ -6,8 +6,12 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported.
       artifact-type:
         type: string
         required: true

--- a/.github/workflows/security-sbom.yml
+++ b/.github/workflows/security-sbom.yml
@@ -4,6 +4,10 @@ name: Security - SBOM Generation
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       artifact-type:
         type: string
         required: true
@@ -60,7 +64,7 @@ concurrency:
 jobs:
   generate-sbom:
     name: Generate SBOM
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 15
     outputs:
       sbom-file: ${{ steps.sbom-output.outputs.file }}
@@ -157,7 +161,7 @@ jobs:
 
   sbom-report:
     name: Create Report
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     needs: [generate-sbom]
     if: always() && !cancelled()
     steps:

--- a/.github/workflows/security-secrets.yml
+++ b/.github/workflows/security-secrets.yml
@@ -4,6 +4,10 @@ name: Security - Secrets
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        default: 'ubuntu-latest'
+        description: 'Runner label or group for all jobs in this workflow'
       working-directory:
         type: string
         default: '.'
@@ -58,7 +62,7 @@ jobs:
   gitleaks:
     name: Scan with Gitleaks
     if: inputs.enable-gitleaks
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 10
     # Scoped per-job (REVIEW.md least-privilege): only gitleaks needs the
     # pulls API. gitleaks-action enumerates PR commits via that API on
@@ -90,7 +94,7 @@ jobs:
   # always()-step referencing step outcomes instead of needs.*.result.
   secret-scan:
     name: Scan Secrets
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     # needs gitleaks only so the report step can render its result; the scans
     # in this job do not depend on gitleaks output.
     needs: [gitleaks]

--- a/.github/workflows/security-secrets.yml
+++ b/.github/workflows/security-secrets.yml
@@ -6,8 +6,13 @@ on:
     inputs:
       runner:
         type: string
+        required: false
         default: 'ubuntu-latest'
-        description: 'Runner label or group for all jobs in this workflow'
+        description: >-
+          Single runner label for all jobs in this workflow (e.g.
+          `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+          selectors are not supported. Must be a Linux runner — the TruffleHog
+          action shells out to `apt-get` and a Docker image.
       working-directory:
         type: string
         default: '.'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,55 @@ uses: sbaerlocher/.github/.github/workflows/ci-js.yml@2026-04-25
 - Renovate updates date tags in consumer repos automatically via the
   custom manager defined in `renovate-base.json`.
 
+### Runner Convention
+
+Every reusable workflow exposes a `runner` input, and every `runs-on:` in it
+resolves through that input rather than naming a runner directly:
+
+```yaml
+inputs:
+  runner:
+    type: string
+    required: false
+    default: 'ubuntu-latest'
+    description: >-
+      Single runner label for all jobs in this workflow (e.g.
+      `ubuntu-latest`, `self-hosted`). Runner groups and multi-label
+      selectors are not supported.
+```
+
+```yaml
+runs-on: ${{ inputs.runner }}
+```
+
+`runs-on` sits in the called workflow and a caller cannot override it, so
+without this input no consumer can reach a self-hosted runner. The default
+keeps every existing caller on `ubuntu-latest`; a consumer opts in per repo
+with `with: runner: <label>`.
+
+**Single label only.** The input is a `type: string` interpolated bare, so it
+resolves as one label. The sequence form (`[self-hosted, linux, x64]`) and the
+mapping form (`group:`) need the expression to evaluate to a non-string via
+`fromJSON()`, which this shape does not do — a caller passing a runner-group
+name gets it matched as a label no runner carries, and the job waits for a
+runner until it times out rather than failing. Say so in the description
+instead of implying broader support.
+
+**Carry platform constraints into the description.** A hardcoded
+`ubuntu-latest` used to enforce a platform requirement structurally; the input
+removes that enforcement, so a workflow that only works on Linux states it in
+its own `runner` description — `e2e-dde.yml` (needs Docker) and
+`security-secrets.yml` (TruffleHog shells out to `apt-get` and a Docker image)
+both do.
+
+**Scope.** Only workflows with a `workflow_call` trigger. The internal
+workflows have no caller that could set an input, so they keep naming their
+runner directly.
+
+`runner` is workflow-wide: a consumer cannot route individual jobs of a
+multi-job reusable to different runners. Add a second input if that need is
+ever demonstrated.
+
 ### Concurrency Convention
 
 Every reusable workflow exposes the same two inputs so consumers can adjust

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,9 +162,13 @@ instead of implying broader support.
 **Carry platform constraints into the description.** A hardcoded
 `ubuntu-latest` used to enforce a platform requirement structurally; the input
 removes that enforcement, so a workflow that only works on Linux states it in
-its own `runner` description — `e2e-dde.yml` (needs Docker) and
-`security-secrets.yml` (TruffleHog shells out to `apt-get` and a Docker image)
-both do.
+its own `runner` description. Five do: `e2e-dde.yml` (needs Docker),
+`e2e-docker.yml` (`docker compose`), `release-docker.yml` (`docker run` plus a
+`/var/run/docker.sock` mount), `security-config.yml` (kubesec via `docker run`)
+and `security-secrets.yml` (TruffleHog shells out to `apt-get` and a Docker
+image). Note that an action being a _container_ action is not the test —
+`gitleaks-action` is `node24` and `trivy-action` is `composite`; what binds a
+workflow to Linux is what its steps actually invoke.
 
 **Scope.** Only workflows with a `workflow_call` trigger. The internal
 workflows have no caller that could set an input, so they keep naming their

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
-## 2026-08-06
+## 2026-08-07
 
 ### Details
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,32 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ---
 
+## 2026-08-06
+
+### Details
+
+- **Every reusable workflow now takes a `runner` input.** `runs-on` sits in the
+  called workflow and a caller cannot override it, so no consumer could reach a
+  self-hosted runner through these workflows no matter what it configured on its
+  own side. All 24 reusables gained the input and all 51 `runs-on:` in them
+  resolve through it. `default: 'ubuntu-latest'` keeps every existing caller on
+  exactly the runner it had — nothing changes until a consumer opts in with
+  `with: runner: <label>`, one repo at a time. The four internal workflows
+  (`merge.yml`, `pull-request.yml`, `test-actions-dde.yml`,
+  `weekly-security.yml`) are unchanged: they have no caller that could set an
+  input.
+  The input is a single **label**, not a runner group or a multi-label selector.
+  Those two forms need `runs-on` to receive a non-string via `fromJSON()`, which
+  a bare `type: string` never produces; a caller passing a group name would have
+  it matched as a label no runner carries, and the job would wait for a runner
+  until it timed out rather than fail. The description says so at the point of
+  use. `e2e-dde.yml` and `security-secrets.yml` additionally state that they
+  need a Linux runner — the hardcoded `ubuntu-latest` used to enforce that
+  structurally, and Docker resp. the TruffleHog action still require it.
+  The self-hosted path is latent: it changes no behaviour until it is chosen.
+
+---
+
 ## 2026-08-05
 
 ### ⚠ BREAKING


### PR DESCRIPTION
## Summary

- All 24 reusable workflows gain a `runner` input (`type: string`, `required: false`, `default: 'ubuntu-latest'`), and all 51 `runs-on` occurrences in them resolve through it. Without it `runs-on` is fixed inside the called workflow and no caller can reach a self-hosted runner.
- The default keeps every existing caller unchanged — repos opt in individually with `with: runner: <label>`.
- The input takes a **single label**. Runner groups and multi-label selectors need `runs-on` to receive a non-string via `fromJSON()`, which a bare `type: string` never produces; the description says so at the point of use rather than promising support that would leave a caller waiting for a runner that never picks up the job.
- `e2e-dde.yml` and `security-secrets.yml` additionally state that they need a Linux runner. The hardcoded `ubuntu-latest` used to enforce that structurally.
- `AGENTS.md` gains a Runner Convention section next to the Concurrency Convention, and `CHANGELOG.md` a `2026-08-06` entry, so the next reusable added ships with the input and consumers learn the capability exists.
- The four standalone workflows (`merge.yml`, `pull-request.yml`, `test-actions-dde.yml`, `weekly-security.yml`) are untouched: they have no caller, so an input would be dead code. Their 5 `ubuntu-latest` occurrences and the `matrix.os` job in `test-actions-dde.yml` stay as they are.

## Test plan

- [x] `just actionlint` green (expression syntax across all 24 files)
- [x] `just lint` green (yamllint, renovate JSON, prettier)
- [x] `just test` green (11 checks, including the workflow-count and input-injection guards)
- [x] Counts verified: 24 files carry the input, 51 `runs-on` resolve to `${{ inputs.runner }}`, 5 `ubuntu-latest` remain in standalone workflows
- [ ] CI green on this PR — confirms the default still lands on `ubuntu-latest`