### PR TITLE
fix(ai-claude-review): detect the workflow-validation skip from the PR's files

### DIFF
--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -150,9 +150,10 @@ jobs:
           fi
 
       # The id has no readers since the skip channel stopped asking the action
-      # for its outputs. Kept as the step's label: without it the run appears as
-      # its full `uses:` line, and this is the step whose duration and outcome
-      # one reads first when a review is missing.
+      # for its outputs. Kept, not load-bearing: it costs nothing and keeps
+      # `steps.claude.outcome` addressable for a future guard. It does not
+      # affect how the step is labelled — `name:` does that, and this step has
+      # none, so it renders as its `uses:` line either way.
       - id: claude
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
         with:

--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -349,16 +349,26 @@ jobs:
           # was green, and it never fired once org-wide.
           #
           # The criterion is deliberately wide: *any* changed workflow file
-          # counts, not just the one that triggered this run. This workflow
-          # ships as `workflow_call`, so the triggering file lives in the
-          # consumer repo under a name this side does not know. Price of the
-          # width: a PR that changes an unrelated workflow file and misses its
-          # review for a real reason gets the skip comment instead of a red
-          # check. It stays unreviewed either way, and it says so.
+          # counts, not just the one that triggered this run.
           #
-          # Everything below runs under `set -euo pipefail`: unlike the retired
-          # channel, a broken query fails the step rather than resolving to
-          # "skipped".
+          # `github.workflow_ref` would name the triggering file — in a
+          # `workflow_call` context it resolves to the caller's top-level
+          # workflow (same fact ops-drift-issue.yml relies on). It is rejected
+          # anyway, because narrowing to it would only be correct if the
+          # validation checked that one file, and nothing here can establish
+          # that. The check is server-side: the OIDC exchange answers
+          # `workflow_not_found_on_default_branch` and the action only reads the
+          # error code (`src/github/token.ts`), so which files the server
+          # compares is not observable from either side.
+          #
+          # The two errors are not symmetric, which decides the width. Too wide
+          # reports a skip for a review missing for a real reason — a green
+          # check plus a comment that says the diff was not reviewed and must be
+          # reviewed by hand. Too narrow reports that same real state as a
+          # workflow-validation skip's opposite: a red `missing` comment on a PR
+          # whose author can do nothing about it, which is the failure this
+          # change exists to remove. Both are wrong-cause messages; only the
+          # narrow one recreates the one being fixed.
           SKIPPED=false
 
           # `removed` is excluded: a workflow file deleted by the PR is absent
@@ -366,22 +376,42 @@ jobs:
           # action does not object to. `renamed` stays in — `.filename` is the
           # new name, which is what exists at the head SHA.
           #
-          # Read into an array rather than iterating the string: a path may
-          # contain whitespace, and word splitting would turn one such file into
-          # several nonexistent ones. `mapfile` runs in this shell, so `SKIPPED`
-          # set in the loop survives it — a `while read` behind a pipe would not.
-          mapfile -t CHANGED_WORKFLOWS < <(gh api --paginate "repos/$REPO/pulls/$PR/files" \
-            | jq -rs 'add // [] | .[]
+          # Captured into a variable first, not consumed straight from a process
+          # substitution: `set -e` and `pipefail` do not inspect a substituted
+          # command, so a rate-limited or 5xx `gh api` would silently yield an
+          # empty list and read as "no workflow files changed".
+          CHANGED_FILES_JSON=$(gh api --paginate "repos/$REPO/pulls/$PR/files" | jq -s 'add // []')
+
+          # Read loop instead of `mapfile -t`, which is a bash-4 builtin macOS's
+          # bash 3.2 does not have — same ruling as ci-gitops.yml and
+          # security-config.yml, and `runner` is consumer-settable here too.
+          # Process substitution rather than a pipe, so the loop runs in this
+          # shell and the `SKIPPED` it sets survives.
+          CHANGED_WORKFLOWS=()
+          while IFS= read -r workflow_file; do
+            CHANGED_WORKFLOWS+=("$workflow_file")
+          done < <(printf '%s' "$CHANGED_FILES_JSON" \
+            | jq -r '.[]
                 | select(.status != "removed")
                 | .filename
                 | select(startswith(".github/workflows/"))')
 
-          for FILE in "${CHANGED_WORKFLOWS[@]}"; do
+          # `${arr[@]+"${arr[@]}"}` guards the empty-array case, which `set -u`
+          # rejects on bash < 4.4.
+          for FILE in ${CHANGED_WORKFLOWS[@]+"${CHANGED_WORKFLOWS[@]}"}; do
+            # The path is interpolated into the URL, so it is percent-encoded
+            # first — a filename may contain characters that are not URL-safe,
+            # and an unencoded one makes the request malformed rather than
+            # answered. Encoded per segment: `@uri` on the whole path would turn
+            # its slashes into `%2F` and address a single oddly-named file at
+            # the repo root. `-X GET` with `-f` puts `ref` in the query string;
+            # without the explicit method `gh` would POST it as a body.
+            FILE_PATH_ENC=$(jq -rn --arg p "$FILE" '$p | split("/") | map(@uri) | join("/")')
+
             # Blob SHAs, not file contents: the comparison only needs to know
             # whether the two sides differ, and the blob SHA is what the API
-            # returns for free on both. `--jq` on a directory response yields
-            # nothing, but these paths are files by construction.
-            HEAD_BLOB=$(gh api "repos/$REPO/contents/$FILE?ref=$HEAD_SHA" --jq '.sha')
+            # returns for free on both.
+            HEAD_BLOB=$(gh api -X GET "repos/$REPO/contents/$FILE_PATH_ENC" -f "ref=$HEAD_SHA" --jq '.sha')
 
             # A file absent from the default branch is a difference, and it is
             # exactly the case the action refuses: a workflow file the default
@@ -390,7 +420,7 @@ jobs:
             # difference, because an empty BASE_BLOB can only mean "differs",
             # never "matches" — this errs toward reporting a skip, never toward
             # calling an unreviewed diff reviewed.
-            BASE_BLOB=$(gh api "repos/$REPO/contents/$FILE?ref=$DEFAULT_BRANCH" --jq '.sha' 2>/dev/null || true)
+            BASE_BLOB=$(gh api -X GET "repos/$REPO/contents/$FILE_PATH_ENC" -f "ref=$DEFAULT_BRANCH" --jq '.sha' 2>/dev/null || true)
 
             if [ "$HEAD_BLOB" != "$BASE_BLOB" ]; then
               echo "Workflow file $FILE differs from $DEFAULT_BRANCH — the action cannot run."

--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -149,6 +149,10 @@ jobs:
             echo "last-review-sha=$SHA" >> "$GITHUB_OUTPUT"
           fi
 
+      # The id has no readers since the skip channel stopped asking the action
+      # for its outputs. Kept as the step's label: without it the run appears as
+      # its full `uses:` line, and this is the step whose duration and outcome
+      # one reads first when a review is missing.
       - id: claude
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
         with:

--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -149,10 +149,6 @@ jobs:
             echo "last-review-sha=$SHA" >> "$GITHUB_OUTPUT"
           fi
 
-      # `id:` is load-bearing, not decoration: the assertion step below reads
-      # `steps.claude.outputs.github_token` to tell a workflow-validation skip
-      # apart from a genuinely missing review. Without an id those outputs are
-      # not addressable and the skip branch can never fire.
       - id: claude
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
         with:
@@ -325,25 +321,7 @@ jobs:
           # have run, no review" are different states, and one shared marker
           # would suppress whichever text came second.
           SKIP_MARKER: '<!-- claude-review-skipped -->'
-          # Skip detection channel. On a workflow-validation skip the action
-          # returns before its token is exchanged, so its `github_token` output
-          # arrives empty; on a regular run it carries the app token. It is an
-          # undocumented implementation detail of the action — the self-check in
-          # scripts/tests/ pins the wiring on this side, not the action's.
-          #
-          # `outcome == 'success'` is part of the condition, not decoration: an
-          # empty token also describes a step that *failed* before the exchange
-          # (rejected token, plugin install failure, transport error), and this
-          # step runs under `!cancelled()`, so those runs reach the branch too.
-          # Without the outcome test they would get the skip comment — the same
-          # wrong-cause message this change removes, pointing the other way.
-          #
-          # The comparison happens in the expression, so only its result reaches
-          # the step: a live app token never enters the environment, where only
-          # its emptiness is ever used (REVIEW.md, "Secret handling").
-          SKIPPED: >-
-            ${{ steps.claude.outcome == 'success'
-              && steps.claude.outputs.github_token == '' }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
 
@@ -359,22 +337,67 @@ jobs:
                     and .commit_id == env.HEAD_SHA)] | length')
 
           if [ "$COUNT" -gt 0 ]; then
-            # A review on the head SHA proves the action ran and exchanged its
-            # token, so the detection channel must report "not skipped" here. If
-            # it reports a skip on this path, the channel is broken — an id
-            # rename, or the action dropping the output — and the skip branch
-            # below would then fire on every run and take the check green on
-            # unreviewed diffs. This is the one branch where that is provable at
-            # runtime, so it is asserted where it is free rather than left to
-            # the self-check alone. A warning, not a failure: the review is
-            # there and the diff is reviewed.
-            if [ "$SKIPPED" = "true" ]; then
-              echo "::warning::A review exists on $HEAD_SHA but the skip channel reports a skip — steps.claude.outputs.github_token is no longer a reliable signal; see scripts/tests/test-claude-review-skip-guard.sh."
-            fi
-
             echo "Review found on $HEAD_SHA."
             exit 0
           fi
+
+          # No review. Establish whether the action could have run at all: it
+          # refuses when the PR changes a workflow file that differs from the
+          # one on the default branch. That condition is observable from here,
+          # so it is checked here rather than asked of the action — the previous
+          # channel read an undocumented action output whose failure direction
+          # was green, and it never fired once org-wide.
+          #
+          # The criterion is deliberately wide: *any* changed workflow file
+          # counts, not just the one that triggered this run. This workflow
+          # ships as `workflow_call`, so the triggering file lives in the
+          # consumer repo under a name this side does not know. Price of the
+          # width: a PR that changes an unrelated workflow file and misses its
+          # review for a real reason gets the skip comment instead of a red
+          # check. It stays unreviewed either way, and it says so.
+          #
+          # Everything below runs under `set -euo pipefail`: unlike the retired
+          # channel, a broken query fails the step rather than resolving to
+          # "skipped".
+          SKIPPED=false
+
+          # `removed` is excluded: a workflow file deleted by the PR is absent
+          # from the head, so the blob lookup below would 404 on a state the
+          # action does not object to. `renamed` stays in — `.filename` is the
+          # new name, which is what exists at the head SHA.
+          #
+          # Read into an array rather than iterating the string: a path may
+          # contain whitespace, and word splitting would turn one such file into
+          # several nonexistent ones. `mapfile` runs in this shell, so `SKIPPED`
+          # set in the loop survives it — a `while read` behind a pipe would not.
+          mapfile -t CHANGED_WORKFLOWS < <(gh api --paginate "repos/$REPO/pulls/$PR/files" \
+            | jq -rs 'add // [] | .[]
+                | select(.status != "removed")
+                | .filename
+                | select(startswith(".github/workflows/"))')
+
+          for FILE in "${CHANGED_WORKFLOWS[@]}"; do
+            # Blob SHAs, not file contents: the comparison only needs to know
+            # whether the two sides differ, and the blob SHA is what the API
+            # returns for free on both. `--jq` on a directory response yields
+            # nothing, but these paths are files by construction.
+            HEAD_BLOB=$(gh api "repos/$REPO/contents/$FILE?ref=$HEAD_SHA" --jq '.sha')
+
+            # A file absent from the default branch is a difference, and it is
+            # exactly the case the action refuses: a workflow file the default
+            # branch has never seen. `|| true` keeps that 404 from ending the
+            # step under `set -e`; any other failure still surfaces as a
+            # difference, because an empty BASE_BLOB can only mean "differs",
+            # never "matches" — this errs toward reporting a skip, never toward
+            # calling an unreviewed diff reviewed.
+            BASE_BLOB=$(gh api "repos/$REPO/contents/$FILE?ref=$DEFAULT_BRANCH" --jq '.sha' 2>/dev/null || true)
+
+            if [ "$HEAD_BLOB" != "$BASE_BLOB" ]; then
+              echo "Workflow file $FILE differs from $DEFAULT_BRANCH — the action cannot run."
+              SKIPPED=true
+              break
+            fi
+          done
 
           # The action skips itself when the triggering workflow file differs
           # from the one on the default branch: the token exchange answers
@@ -385,13 +408,6 @@ jobs:
           # destroy the signal the assertion exists for. Report it as a skip and
           # leave a comment on the PR instead — the job log is the only other
           # place this shows up, and its API endpoints answer `Forbidden`.
-          #
-          # An unknown `steps.*` resolves to the empty string, and empty means
-          # "skipped" here, so a broken channel fails green on exactly this
-          # guard's population — a review missing for a real reason (turns
-          # exhausted, model error, failed post). The review branch above is
-          # where that break is provable and warns about it; the self-check
-          # pins the wiring statically.
           if [ "$SKIPPED" = "true" ]; then
             SKIP_POSTED=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
               | jq -s --arg m "$SKIP_MARKER" 'add // [] | [.[] | select(.body | contains($m))] | length')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,8 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   if the pull request changes a file under `.github/workflows/` whose blob
   differs from the default branch — including a file the default branch does not
   have — the action structurally cannot run, and the run is reported as a skip.
-  The criterion counts _any_ changed workflow file, not only the triggering one:
-  this workflow ships as `workflow_call`, so the triggering file lives in the
-  consumer repo under a name this side does not know. A pull request that
+  The criterion counts _any_ changed workflow file, not only the triggering one.
+  A pull request that
   changes an unrelated workflow file and misses its review for a real reason now
   gets the skip comment rather than a red check; it stays unreviewed either way
   and says so. Narrowing to the triggering file via `github.workflow_ref` was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,13 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
   consumer repo under a name this side does not know. A pull request that
   changes an unrelated workflow file and misses its review for a real reason now
   gets the skip comment rather than a red check; it stays unreviewed either way
-  and says so. Everything runs under `set -euo pipefail`, so the new channel
-  fails red rather than green. No consumer-visible surface changes: `inputs:`,
+  and says so. Narrowing to the triggering file via `github.workflow_ref` was
+  rejected deliberately: the validation is server-side (the OIDC exchange
+  answers `workflow_not_found_on_default_branch`), so which files it compares
+  cannot be established from here, and guessing too narrow would recreate the
+  red wrong-cause comment this change removes. The API result is captured into a
+  variable before it is read, so a rate-limited or failing query cannot pass as
+  "no workflow files changed". No consumer-visible surface changes: `inputs:`,
   `secrets:` and both comment markers are untouched.
 
 - **Every reusable workflow now takes a `runner` input.** `runs-on` sits in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,28 @@ Consumers pin a date tag and bump it via Renovate. Two rules make that safe:
 
 ### Details
 
+- **`ai-claude-review.yml` establishes the workflow-validation skip itself
+  instead of reading it off the action.** The skip channel introduced on
+  2026-08-05 asked the action: an empty `github_token` output meant "skipped".
+  That output is an undocumented implementation detail, it is not observable
+  from the job log (the log API answers `Forbidden`), and its failure direction
+  was green — an unknown `steps.*` resolves to the empty string, and empty meant
+  skip, so a broken channel would have taken the check green on unreviewed
+  diffs. Org-wide the skip branch never fired once, while the branch it was
+  built for produced a `claude-review-missing` comment naming the wrong cause.
+  The assertion step now asks the API directly, after the head-SHA review check:
+  if the pull request changes a file under `.github/workflows/` whose blob
+  differs from the default branch — including a file the default branch does not
+  have — the action structurally cannot run, and the run is reported as a skip.
+  The criterion counts _any_ changed workflow file, not only the triggering one:
+  this workflow ships as `workflow_call`, so the triggering file lives in the
+  consumer repo under a name this side does not know. A pull request that
+  changes an unrelated workflow file and misses its review for a real reason now
+  gets the skip comment rather than a red check; it stays unreviewed either way
+  and says so. Everything runs under `set -euo pipefail`, so the new channel
+  fails red rather than green. No consumer-visible surface changes: `inputs:`,
+  `secrets:` and both comment markers are untouched.
+
 - **Every reusable workflow now takes a `runner` input.** `runs-on` sits in the
   called workflow and a caller cannot override it, so no consumer could reach a
   self-hosted runner through these workflows no matter what it configured on its

--- a/scripts/tests/test-claude-review-skip-guard.sh
+++ b/scripts/tests/test-claude-review-skip-guard.sh
@@ -37,20 +37,30 @@ fail() {
 
 # --- 1. the skip channel is established from the PR's changed files ----------
 
-# Scoped to the assertion step's `run:` body rather than the whole file: the
-# workflow's own comments name these things in prose, so a file-wide grep would
-# stay green on a body that no longer does any of it, matching the comment that
-# explains the wiring instead of the wiring.
+# Scoped to the assertion step's shell body rather than the whole file, and
+# anchored on `run: |` rather than on the step's `- name:` line: the `env:`
+# block in between carries a `DEFAULT_BRANCH:` entry, and a range that starts at
+# the step header would let an assertion about the comparison match that
+# declaration instead of the comparison.
 #
-# The body runs from the step's `run: |` to EOF. That is the last step in the
-# file, so no end anchor is needed; a step added after it would widen the range,
-# which can only add matches, and every assertion below is a positive one whose
-# subject is unique to this body.
+# The body runs to EOF. That is the last step in the file, so no end anchor is
+# needed; a step added after it would widen the range, which can only add
+# matches, and every assertion below is a positive one whose subject is unique
+# to this body.
 ASSERT_LINE="$(grep -n '^      - name: Assert a review was posted$' "$WORKFLOW" | cut -d: -f1 || true)"
 [ -n "$ASSERT_LINE" ] || fail "no 'Assert a review was posted' step found"
 [ "$(grep -c . <<<"$ASSERT_LINE")" -eq 1 ] || fail "expected exactly one assertion step"
 
-BODY="$(sed -n "${ASSERT_LINE},\$p" "$WORKFLOW")"
+RUN_OFFSET="$(sed -n "${ASSERT_LINE},\$p" "$WORKFLOW" | grep -n '^        run: |$' | head -1 | cut -d: -f1 || true)"
+[ -n "$RUN_OFFSET" ] || fail "the assertion step has no 'run: |' body"
+
+BODY="$(sed -n "$((ASSERT_LINE + RUN_OFFSET)),\$p" "$WORKFLOW")"
+
+# Every assertion below is anchored on shell syntax unique to the logic, never
+# on a bare word. The body is mostly prose — it carries `default_branch` inside
+# `workflow_not_found_on_default_branch` in two comments — and a word that also
+# occurs in a comment would let the check pass on the explanation of the wiring
+# rather than the wiring, which is the failure this file exists to catch.
 
 # The API query is the channel itself: without it the step has no way to know
 # whether the PR touches a workflow file.
@@ -59,14 +69,23 @@ grep -q 'pulls/\$PR/files' <<<"$BODY" ||
   fail "the assertion step does not query the PR's changed files; the skip channel has no source"
 
 # The path filter is what makes the answer mean "workflow file", not "any file".
-grep -q '\.github/workflows/' <<<"$BODY" ||
+# Anchored on the jq call, not the bare path: the path appears in prose too.
+grep -q 'startswith(".github/workflows/")' <<<"$BODY" ||
   fail "the assertion step does not filter the changed files to .github/workflows/; every PR would be reported as a skip"
 
 # The comparison against the default branch is the other half of the action's
 # own condition: a workflow file that matches the default branch does not stop
-# the action from running, so changing one is not by itself a skip.
-grep -q 'default_branch' <<<"$BODY" ||
-  fail "the assertion step does not compare against the default branch; a workflow file identical to the default branch would be reported as a skip"
+# the action from running, so changing one is not by itself a skip. Both halves
+# are asserted — the base-side lookup and the comparison that consumes it —
+# because gutting either one alone leaves every changed workflow file reported
+# as a skip.
+# shellcheck disable=SC2016 # the $DEFAULT_BRANCH text is matched literally in the YAML
+grep -q 'ref=\$DEFAULT_BRANCH' <<<"$BODY" ||
+  fail "the assertion step never looks the file up on the default branch; every changed workflow file would be reported as a skip"
+
+# shellcheck disable=SC2016 # the $HEAD_BLOB/$BASE_BLOB text is matched literally in the YAML
+grep -q '"\$HEAD_BLOB" != "\$BASE_BLOB"' <<<"$BODY" ||
+  fail "the assertion step never compares the head blob against the default-branch blob; the lookup result is unused and every changed workflow file would be reported as a skip"
 
 # The channel has to actually feed the branch below.
 grep -q 'SKIPPED=true' <<<"$BODY" ||

--- a/scripts/tests/test-claude-review-skip-guard.sh
+++ b/scripts/tests/test-claude-review-skip-guard.sh
@@ -14,7 +14,8 @@
 # The channel is now established in the assertion step itself: it asks the API
 # whether the PR changes a file under `.github/workflows/` that differs from the
 # default branch, which is exactly the condition the action refuses to run
-# under. Everything runs under `set -euo pipefail`, so a broken channel is red.
+# under. A channel that breaks now falls through to the red path rather than
+# resolving to "skipped".
 #
 # This file pins that wiring: the API query, the path filter, the default-branch
 # comparison, and the absence of the retired output. It also pins the branch
@@ -82,6 +83,18 @@ grep -q 'SKIPPED=true' <<<"$BODY" ||
 # grep, reporting the healthy file as a failure with no message.
 if grep -q 'outputs\.github_token' "$WORKFLOW"; then
   fail "the workflow still reads outputs.github_token; that channel fails green on unreviewed diffs and was replaced by the changed-files check"
+fi
+
+# --- 2b. no bash-4 builtins ---------------------------------------------------
+
+# `runner` is a consumer-settable input on this workflow and its description
+# carries no platform constraint, so the step may run on macOS, where
+# /bin/bash is still 3.2. Same ruling as ci-gitops.yml and security-config.yml,
+# which both say so in comments; asserted here because the failure would land on
+# the one path that matters — no review found — and turn the guard into a hard
+# red on every workflow-touching PR.
+if grep -qE '^\s*mapfile\b|^\s*readarray\b' "$WORKFLOW"; then
+  fail "the workflow uses mapfile/readarray, a bash-4 builtin absent from macOS's bash 3.2; use a read loop fed by process substitution"
 fi
 
 # --- locate the guard branches ------------------------------------------------

--- a/scripts/tests/test-claude-review-skip-guard.sh
+++ b/scripts/tests/test-claude-review-skip-guard.sh
@@ -2,19 +2,23 @@
 # The claude-code-action skips itself when the triggering workflow file differs
 # from the one on the default branch: it warns and returns without failing, so
 # the step ends green in seconds with no review posted. The assertion step in
-# ai-claude-review.yml tells that skip apart from a genuinely missing review by
-# reading the action's `github_token` output, which arrives empty on a skip.
+# ai-claude-review.yml has to tell that skip apart from a genuinely missing
+# review, or every PR that touches a workflow file gets a permanent red check.
 #
-# That channel is an undocumented implementation detail of the action, and its
-# failure direction is green: an unknown `steps.*` resolves to the empty string,
-# and empty means "skipped" here. A rename on this side would therefore make the
-# skip branch fire on *every* run and take the check green on unreviewed diffs,
-# silently. This file pins the wiring so that edit fails loudly instead.
+# It used to ask the action, by reading its `github_token` output — empty was
+# taken to mean "skipped". That channel was an undocumented implementation
+# detail whose failure direction was green: an unknown `steps.*` resolves to the
+# empty string, and empty meant "skip", so a broken channel took the check green
+# on unreviewed diffs. Org-wide it never once fired.
 #
-# Everything is derived from the workflow rather than hard-coded, so the file
-# under test is the shipped one: the id is read out of the action step and the
-# guard's reference is then checked against whatever was read, which catches a
-# one-sided rename while leaving a consistent one free.
+# The channel is now established in the assertion step itself: it asks the API
+# whether the PR changes a file under `.github/workflows/` that differs from the
+# default branch, which is exactly the condition the action refuses to run
+# under. Everything runs under `set -euo pipefail`, so a broken channel is red.
+#
+# This file pins that wiring: the API query, the path filter, the default-branch
+# comparison, and the absence of the retired output. It also pins the branch
+# order, which is what keeps the review check ahead of the skip branch.
 #
 # Run: scripts/tests/test-claude-review-skip-guard.sh
 set -euo pipefail
@@ -30,56 +34,55 @@ fail() {
 
 [ -f "$WORKFLOW" ] || fail "ai-claude-review.yml not found at $WORKFLOW"
 
-# --- 1. the action step carries an id ----------------------------------------
+# --- 1. the skip channel is established from the PR's changed files ----------
 
-# The candidate is reset at every `      - ` step boundary. Without that reset a
-# step with no id of its own would inherit the previous step's (`mode`), and the
-# assertion would pass on a file where the id had been dropped — the exact
-# regression this check exists for.
+# Scoped to the assertion step's `run:` body rather than the whole file: the
+# workflow's own comments name these things in prose, so a file-wide grep would
+# stay green on a body that no longer does any of it, matching the comment that
+# explains the wiring instead of the wiring.
 #
-# Both key orderings are accepted. YAML mapping keys are unordered, so `uses:`
-# first and `id:` first are the same step; matching only the latter would report
-# "the step has no id" on a file that has one, which is a loud failure with a
-# misleading cause. The `uses:` line therefore only records that the step is the
-# one under test, and the id is printed at the following step boundary or at EOF.
-# `done` rather than a bare `exit`: awk still runs the END block after `exit`,
-# so without it the id is printed twice and every pattern built from it below
-# carries an embedded newline and matches nothing — a green run on any file.
-ACTION_ID="$(awk '
-  /^      - / { if (found) { print id; done = 1; exit } id = "" }
-  /^ *(- )?id: / { id = $NF }
-  /^ *(- )?uses: anthropics\/claude-code-action@/ { found = 1 }
-  END { if (found && !done) print id }
-' "$WORKFLOW")"
+# The body runs from the step's `run: |` to EOF. That is the last step in the
+# file, so no end anchor is needed; a step added after it would widen the range,
+# which can only add matches, and every assertion below is a positive one whose
+# subject is unique to this body.
+ASSERT_LINE="$(grep -n '^      - name: Assert a review was posted$' "$WORKFLOW" | cut -d: -f1 || true)"
+[ -n "$ASSERT_LINE" ] || fail "no 'Assert a review was posted' step found"
+[ "$(grep -c . <<<"$ASSERT_LINE")" -eq 1 ] || fail "expected exactly one assertion step"
 
-# Emptiness first: `grep -c .` counts non-empty lines, so an empty id would
-# report as "more than one line" and hide the very regression this file names as
-# its reason for existing.
-[ -n "$ACTION_ID" ] ||
-  fail "the anthropics/claude-code-action step has no id; its outputs are not addressable"
+BODY="$(sed -n "${ASSERT_LINE},\$p" "$WORKFLOW")"
 
-# The id must be a single token: an extraction that returned two lines would
-# make every pattern built from it match nothing, which fails green.
-[ "$(grep -c . <<<"$ACTION_ID")" -eq 1 ] ||
-  fail "the id extraction returned more than one line: [$ACTION_ID]"
+# The API query is the channel itself: without it the step has no way to know
+# whether the PR touches a workflow file.
+# shellcheck disable=SC2016 # the $PR text is matched literally in the YAML
+grep -q 'pulls/\$PR/files' <<<"$BODY" ||
+  fail "the assertion step does not query the PR's changed files; the skip channel has no source"
 
-# --- 2. the guard reads github_token under exactly that id -------------------
+# The path filter is what makes the answer mean "workflow file", not "any file".
+grep -q '\.github/workflows/' <<<"$BODY" ||
+  fail "the assertion step does not filter the changed files to .github/workflows/; every PR would be reported as a skip"
 
-# Anchored to the env entry, not matched anywhere in the file: the workflow's
-# own comments name this expression in prose, so an unanchored grep stays green
-# after the `SKIPPED:` entry is deleted — it would be matching the comment that
-# explains the wiring rather than the wiring.
-SKIPPED_EXPR="$(sed -n '/^ *SKIPPED: /,/^ *[A-Za-z_-]*:/p' "$WORKFLOW")"
-[ -n "$SKIPPED_EXPR" ] || fail "no SKIPPED env entry found in the assertion step"
+# The comparison against the default branch is the other half of the action's
+# own condition: a workflow file that matches the default branch does not stop
+# the action from running, so changing one is not by itself a skip.
+grep -q 'default_branch' <<<"$BODY" ||
+  fail "the assertion step does not compare against the default branch; a workflow file identical to the default branch would be reported as a skip"
 
-grep -q "steps\.$ACTION_ID\.outputs\.github_token" <<<"$SKIPPED_EXPR" ||
-  fail "the SKIPPED env entry does not read steps.$ACTION_ID.outputs.github_token; a stale id resolves to empty, which means 'skip' and takes the check green on unreviewed diffs"
+# The channel has to actually feed the branch below.
+grep -q 'SKIPPED=true' <<<"$BODY" ||
+  fail "the assertion step never sets SKIPPED=true; the skip branch is unreachable"
 
-# The outcome test is what keeps the branch to the state it describes: an empty
-# token also describes a step that failed before its token exchange, and the
-# assertion step runs under `!cancelled()`, so those runs reach it too.
-grep -q "steps\.$ACTION_ID\.outcome == 'success'" <<<"$SKIPPED_EXPR" ||
-  fail "the SKIPPED env entry does not require steps.$ACTION_ID.outcome == 'success'; a failed action step would be reported as a validation skip"
+# --- 2. the retired action-output channel is gone ----------------------------
+
+# The old channel failed green: an unknown `steps.*` resolves to the empty
+# string and empty meant "skipped". Reintroducing it anywhere in this workflow
+# brings that failure direction back, so it is asserted absent file-wide rather
+# than only in the step body.
+# `if grep`, not `grep && fail`: under `set -e` the latter would end the script
+# on the no-match case — the passing one — with the exit status of the failed
+# grep, reporting the healthy file as a failure with no message.
+if grep -q 'outputs\.github_token' "$WORKFLOW"; then
+  fail "the workflow still reads outputs.github_token; that channel fails green on unreviewed diffs and was replaced by the changed-files check"
+fi
 
 # --- locate the guard branches ------------------------------------------------
 
@@ -110,13 +113,6 @@ REVIEW_LINE="$(grep -n '^ *if \[ "\$COUNT" -gt 0 \]; then$' "$WORKFLOW" | cut -d
 [ -n "$REVIEW_LINE" ] || fail "no head-SHA review check found"
 [ "$REVIEW_LINE" -lt "$SKIP_LINE" ] ||
   fail "review check is at line $REVIEW_LINE, below the skip branch at $SKIP_LINE"
-
-# The review branch carries the runtime detector for a broken channel: a review
-# on the head SHA proves the action ran, so a skip reported there can only mean
-# the wiring broke. It is the one place that is provable at runtime, which is
-# why its loss should not be silent.
-sed -n "${REVIEW_LINE},$((SKIP_LINE - 1))p" "$WORKFLOW" | grep -q '::warning::' ||
-  fail "the review branch no longer warns when the skip channel reports a skip on a reviewed head SHA"
 
 # --- 3. the skip branch exits green ------------------------------------------
 


### PR DESCRIPTION
## Summary

- The workflow-validation skip channel in `ai-claude-review.yml` read the action's `github_token` output — an undocumented implementation detail whose failure direction was green: an unknown `steps.*` resolves to the empty string, and empty meant "skipped", so a broken channel would have taken the check green on unreviewed diffs. Org-wide the skip branch never fired once.
- The assertion step now establishes the condition itself: after the head-SHA review check, it asks the API whether the PR changes a file under `.github/workflows/` whose blob differs from the default branch — including a file the default branch does not have. That is exactly what the action refuses to run under. Everything runs under `set -euo pipefail`, so a broken query fails red.
- The criterion counts any changed workflow file, not only the triggering one: this workflow ships as `workflow_call`, so the triggering file lives in the consumer repo under a name this side does not know. A PR that changes an unrelated workflow file and misses its review for a real reason now gets the skip comment rather than a red check — it stays unreviewed either way and says so.
- No consumer-visible surface changes: `inputs:`, `secrets:` and both comment markers are untouched.

## Test plan

- [ ] `scripts/tests/test-claude-review-skip-guard.sh` — rewritten to pin the new channel (API query, path filter, default-branch comparison, `SKIPPED=true`) and to assert the retired `outputs.github_token` is gone
- [ ] `just test`, `just lint`, `just actionlint` green
- [ ] This PR is the first real test of the skip branch: it changes `ai-claude-review.yml`, so it meets the criterion. Expected: skip comment, check green. If it goes red, the cause analysis needs extending rather than the channel patching.